### PR TITLE
Add JSON logger and AI generation events for machine-readable output

### DIFF
--- a/src/browser/ariaBrowser.ts
+++ b/src/browser/ariaBrowser.ts
@@ -33,6 +33,9 @@ export enum LoadState {
 }
 
 export interface AriaBrowser {
+  /** The name of the browser being used */
+  browserName: string;
+
   /** Starts the browser instance */
   start(): Promise<void>;
 

--- a/src/browser/playwrightBrowser.ts
+++ b/src/browser/playwrightBrowser.ts
@@ -52,6 +52,7 @@ export interface ExtendedPlaywrightBrowserOptions extends PlaywrightBrowserOptio
  * PlaywrightBrowser - Browser implementation using Playwright's accessibility features
  */
 export class PlaywrightBrowser implements AriaBrowser {
+  public browserName: string;
   private browser: PlaywrightOriginalBrowser | null = null;
   private context: BrowserContext | null = null;
   private page: Page | null = null;
@@ -59,7 +60,17 @@ export class PlaywrightBrowser implements AriaBrowser {
   // Default timeouts
   private readonly ACTION_TIMEOUT_MS = 5000; // 5 seconds timeout for interactive actions
 
-  constructor(private options: ExtendedPlaywrightBrowserOptions = {}) {}
+  constructor(private options: ExtendedPlaywrightBrowserOptions = {}) {
+    this.browserName = `playwright:${this.options.browser ?? "firefox"}`;
+  }
+
+  get pwEndpoint(): string | undefined {
+    return this.options.pwEndpoint;
+  }
+
+  get proxyServer(): string | undefined {
+    return this.options.proxyServer;
+  }
 
   /**
    * Maps Spark's top-level options into the appropriate Playwright options

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -5,6 +5,7 @@ import { PlaywrightBrowser } from "../../browser/playwrightBrowser.js";
 import { config } from "../config.js";
 import { validateBrowser, getValidBrowsers, parseJsonData, parseResourcesList } from "../utils.js";
 import { createAIProvider } from "../provider.js";
+import { ConsoleLogger, JSONConsoleLogger } from "../../loggers.js";
 
 /**
  * Creates the 'run' command for executing web automation tasks
@@ -47,6 +48,7 @@ export function createRunCommand(): Command {
       "Proxy authentication password",
       config.get("proxy_password"),
     )
+    .option("--logger <logger>", "Logger to use (console, json)", config.get("logger") || "console")
     .action(executeRunCommand);
 }
 
@@ -82,6 +84,9 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       process.exit(1);
     }
 
+    // Create logger
+    const logger = options.logger === "json" ? new JSONConsoleLogger() : new ConsoleLogger();
+
     // Create browser instance
     const browser = new PlaywrightBrowser({
       browser: options.browser,
@@ -103,25 +108,14 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       vision: options.vision,
       guardrails: options.guardrails,
       provider: aiProvider,
+      logger,
     });
-
-    console.log(chalk.blue.bold("🚀 Spark Automation Starting"));
-    console.log(chalk.gray(`Task: ${task}`));
-    console.log(chalk.gray(`Browser: ${options.browser}`));
-    if (options.pwEndpoint) console.log(chalk.gray(`Remote endpoint: ${options.pwEndpoint}`));
-    if (options.proxy) console.log(chalk.gray(`Proxy: ${options.proxy}`));
-    if (options.url) console.log(chalk.gray(`Starting URL: ${options.url}`));
-    if (data) console.log(chalk.gray(`Data: ${JSON.stringify(data)}`));
-    if (options.guardrails) console.log(chalk.gray(`Guardrails: ${options.guardrails}`));
-    if (options.vision) console.log(chalk.gray(`Vision: enabled`));
-    console.log("");
 
     // Execute the task
     await webAgent.execute(task, options.url, data);
 
     // Close the browser
     await webAgent.close();
-    console.log(chalk.green.bold("\n✅ Task completed successfully!"));
   } catch (error) {
     console.error(chalk.red.bold("\n❌ Error:"), chalk.whiteBright(error));
     process.exit(1);

--- a/src/cli/config.ts
+++ b/src/cli/config.ts
@@ -20,6 +20,9 @@ export interface SparkConfig {
   proxy?: string;
   proxy_username?: string;
   proxy_password?: string;
+
+  // Logging Configuration
+  logger?: "console" | "json";
 }
 
 export class ConfigManager {
@@ -98,6 +101,11 @@ export class ConfigManager {
       }),
       ...(process.env.SPARK_PROXY_PASSWORD && {
         proxy_password: process.env.SPARK_PROXY_PASSWORD,
+      }),
+
+      // Logging Configuration
+      ...(process.env.SPARK_LOGGER && {
+        logger: process.env.SPARK_LOGGER as SparkConfig["logger"],
       }),
     };
 
@@ -216,6 +224,9 @@ export class ConfigManager {
     if (process.env.SPARK_PROXY) env.proxy = process.env.SPARK_PROXY;
     if (process.env.SPARK_PROXY_USERNAME) env.proxy_username = process.env.SPARK_PROXY_USERNAME;
     if (process.env.SPARK_PROXY_PASSWORD) env.proxy_password = process.env.SPARK_PROXY_PASSWORD;
+
+    // Logging Configuration
+    if (process.env.SPARK_LOGGER) env.logger = process.env.SPARK_LOGGER as SparkConfig["logger"];
 
     const merged = this.getConfig();
 

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,11 +4,16 @@ import { EventEmitter } from "eventemitter3";
  * Enum of all possible event types in the web agent
  */
 export enum WebAgentEventType {
-  // Task lifecycle
+  // Task events
+  TASK_SETUP = "task:setup",
   TASK_STARTED = "task:started",
   TASK_COMPLETED = "task:completed",
   TASK_VALIDATED = "task:validated",
   TASK_VALIDATION_ERROR = "task:validation_error",
+
+  // AI events
+  AI_GENERATION = "ai:generation",
+  AI_GENERATION_ERROR = "ai:generation:error",
 
   // Agent reasoning and status
   AGENT_STEP = "agent:step",
@@ -40,6 +45,19 @@ export interface WebAgentEventData {
 }
 
 /**
+ * Event data when a task is setup
+ */
+export interface TaskSetupEventData extends WebAgentEventData {
+  task: string;
+  browserName: string;
+  guardrails: string | null;
+  data: any;
+  pwEndpoint: string | null;
+  proxy: string | null;
+  vision: boolean | null;
+}
+
+/**
  * Event data when a task is started
  */
 export interface TaskStartEventData extends WebAgentEventData {
@@ -54,6 +72,35 @@ export interface TaskStartEventData extends WebAgentEventData {
  */
 export interface TaskCompleteEventData extends WebAgentEventData {
   finalAnswer: string | null;
+}
+
+/**
+ * Event data when AI generation occurs
+ */
+export interface AIGenerationEventData extends WebAgentEventData {
+  prompt: string;
+  schema: any;
+  messages?: any[];
+  object?: any;
+  finishReason?: string;
+  usage?: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+  };
+  providerMetadata?: any;
+  warnings?: string[];
+  temperature?: number;
+}
+
+/**
+ * Event data when AI generation error occurs
+ */
+export interface AIGenerationErrorEventData extends WebAgentEventData {
+  prompt: string;
+  error: string;
+  schema: any;
+  messages?: any[];
 }
 
 /**
@@ -193,10 +240,13 @@ export interface StatusMessageEventData extends WebAgentEventData {
  * Union type of all event data types
  */
 export type WebAgentEvent =
+  | { type: WebAgentEventType.TASK_SETUP; data: TaskSetupEventData }
   | { type: WebAgentEventType.TASK_STARTED; data: TaskStartEventData }
   | { type: WebAgentEventType.TASK_COMPLETED; data: TaskCompleteEventData }
   | { type: WebAgentEventType.TASK_VALIDATED; data: TaskValidationEventData }
   | { type: WebAgentEventType.TASK_VALIDATION_ERROR; data: ValidationErrorEventData }
+  | { type: WebAgentEventType.AI_GENERATION; data: AIGenerationEventData }
+  | { type: WebAgentEventType.AI_GENERATION_ERROR; data: AIGenerationErrorEventData }
   | { type: WebAgentEventType.AGENT_STEP; data: CurrentStepEventData }
   | { type: WebAgentEventType.AGENT_OBSERVED; data: ObservationEventData }
   | { type: WebAgentEventType.AGENT_REASONED; data: ThoughtEventData }

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -1,6 +1,7 @@
 import chalk from "chalk";
 import { WebAgentEventType, WebAgentEventEmitter } from "./events.js";
 import type {
+  WebAgentEvent,
   ActionExecutionEventData,
   ActionResultEventData,
   CompressionDebugEventData,
@@ -13,6 +14,7 @@ import type {
   PageNavigationEventData,
   StatusMessageEventData,
   TaskCompleteEventData,
+  TaskSetupEventData,
   TaskStartEventData,
   ThoughtEventData,
   WaitingEventData,
@@ -20,6 +22,7 @@ import type {
   ProcessingEventData,
   ScreenshotCapturedEventData,
   ValidationErrorEventData,
+  AIGenerationErrorEventData,
 } from "./events.js";
 
 /**
@@ -85,6 +88,7 @@ export class ConsoleLogger implements Logger {
     this.emitter = emitter;
 
     // Task events
+    emitter.onEvent(WebAgentEventType.TASK_SETUP, this.handleTaskSetup);
     emitter.onEvent(WebAgentEventType.TASK_STARTED, this.handleTaskStart);
     emitter.onEvent(WebAgentEventType.TASK_COMPLETED, this.handleTaskComplete);
     emitter.onEvent(WebAgentEventType.TASK_VALIDATED, this.handleTaskValidation);
@@ -110,12 +114,16 @@ export class ConsoleLogger implements Logger {
     // Debug events
     emitter.onEvent(WebAgentEventType.SYSTEM_DEBUG_COMPRESSION, this.handleCompressionDebug);
     emitter.onEvent(WebAgentEventType.SYSTEM_DEBUG_MESSAGE, this.handleMessagesDebug);
+
+    // AI events
+    emitter.onEvent(WebAgentEventType.AI_GENERATION_ERROR, this.handleAIGenerationError);
   }
 
   dispose(): void {
     // Clean up event listeners to prevent memory leaks
     if (this.emitter) {
       // Task events
+      this.emitter.offEvent(WebAgentEventType.TASK_SETUP, this.handleTaskSetup);
       this.emitter.offEvent(WebAgentEventType.TASK_STARTED, this.handleTaskStart);
       this.emitter.offEvent(WebAgentEventType.TASK_COMPLETED, this.handleTaskComplete);
       this.emitter.offEvent(WebAgentEventType.TASK_VALIDATED, this.handleTaskValidation);
@@ -148,10 +156,24 @@ export class ConsoleLogger implements Logger {
       );
       this.emitter.offEvent(WebAgentEventType.SYSTEM_DEBUG_MESSAGE, this.handleMessagesDebug);
 
+      // AI events
+      this.emitter.offEvent(WebAgentEventType.AI_GENERATION_ERROR, this.handleAIGenerationError);
+
       // Reset emitter reference
       this.emitter = null;
     }
   }
+
+  private handleTaskSetup = (data: TaskSetupEventData): void => {
+    console.log(chalk.blue.bold("🚀 Spark Automation Starting"));
+    console.log(chalk.cyan.bold("\n🎯 Task: "), chalk.whiteBright(data.task));
+    console.log(chalk.gray(`Browser: ${data.browserName}`));
+    if (data.pwEndpoint) console.log(chalk.gray(`Remote endpoint: ${data.pwEndpoint}`));
+    if (data.proxy) console.log(chalk.gray(`Proxy: ${data.proxy}`));
+    if (data.data) console.log(chalk.gray(`Data: ${JSON.stringify(data.data)}`));
+    if (data.guardrails) console.log(chalk.gray(`Guardrails: ${data.guardrails}`));
+    if (data.vision) console.log(chalk.gray(`Vision: enabled`));
+  };
 
   private handleTaskStart = (data: TaskStartEventData): void => {
     console.log(chalk.cyan.bold("\n🎯 Task: "), chalk.whiteBright(data.task));
@@ -304,4 +326,43 @@ export class ConsoleLogger implements Logger {
   private handleStatusMessage = (data: StatusMessageEventData): void => {
     console.log(chalk.green.bold("💬 Agent Status:"), chalk.whiteBright(data.message));
   };
+
+  private handleAIGenerationError = (data: AIGenerationErrorEventData): void => {
+    console.error(chalk.red.bold("❌ AI generation error:"), chalk.whiteBright(data.error));
+  };
+}
+
+export class JSONConsoleLogger implements Logger {
+  private emitter: WebAgentEventEmitter | null = null;
+  private handlers: [WebAgentEventType, (data: any) => void][] = [];
+
+  initialize(emitter: WebAgentEventEmitter): void {
+    if (this.emitter) {
+      this.dispose();
+    }
+    this.emitter = emitter;
+    this.handlers = [];
+
+    for (const event of Object.values(WebAgentEventType)) {
+      const handler = this.buildEventHandler(event);
+      this.handlers.push([event, handler]);
+      emitter.onEvent(event, handler);
+    }
+  }
+
+  dispose(): void {
+    if (this.emitter) {
+      for (const [event, handler] of this.handlers) {
+        this.emitter.offEvent(event, handler);
+      }
+      this.emitter = null;
+    }
+  }
+
+  private buildEventHandler(type: WebAgentEventType) {
+    return (data: WebAgentEvent["data"]): void => {
+      const json = JSON.stringify({ event: type, data }, null, 0);
+      console.log(json);
+    };
+  }
 }

--- a/test/events.test.ts
+++ b/test/events.test.ts
@@ -19,6 +19,7 @@ import {
   NetworkTimeoutEventData,
   TaskValidationEventData,
   StatusMessageEventData,
+  WEB_AGENT_EVENT_TYPES,
 } from "../src/events.js";
 
 describe("WebAgentEventEmitter", () => {
@@ -114,10 +115,13 @@ describe("WebAgentEventEmitter", () => {
     it("should handle all WebAgentEventType values", () => {
       // Verify all event types are defined
       const expectedEventTypes = [
+        "task:setup",
         "task:started",
         "task:completed",
         "task:validated",
         "task:validation_error",
+        "ai:generation",
+        "ai:generation:error",
         "agent:step",
         "agent:observed",
         "agent:reasoned",

--- a/test/loggers.test.ts
+++ b/test/loggers.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ConsoleLogger, Logger } from "../src/loggers.js";
+import { ConsoleLogger, JSONConsoleLogger, Logger } from "../src/loggers.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../src/events.js";
 import type {
   TaskStartEventData,
+  TaskSetupEventData,
   TaskCompleteEventData,
   TaskValidationEventData,
+  AIGenerationEventData,
+  AIGenerationErrorEventData,
   PageNavigationEventData,
   CurrentStepEventData,
   ObservationEventData,
@@ -95,7 +98,7 @@ describe("ConsoleLogger", () => {
   });
 
   describe("Task events", () => {
-    it("should handle TASK_START events", () => {
+    it("should handle TASK_STARTED events", () => {
       const eventData: TaskStartEventData = {
         timestamp: Date.now(),
         task: "Complete a web form",
@@ -120,7 +123,7 @@ describe("ConsoleLogger", () => {
       expect(allOutput).toContain("https://example.com/contact");
     });
 
-    it("should handle TASK_COMPLETE events", () => {
+    it("should handle TASK_COMPLETED events", () => {
       const eventData: TaskCompleteEventData = {
         timestamp: Date.now(),
         finalAnswer: "Form submitted successfully with confirmation ID: 12345",
@@ -637,6 +640,303 @@ describe("ConsoleLogger", () => {
       expect(mockConsole.log).toHaveBeenCalled();
 
       logger2.dispose();
+    });
+  });
+
+  describe("New event types", () => {
+    it("should handle TASK_SETUP events", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        task: "Complete a web form",
+        browserName: "playwright:firefox",
+        guardrails: null,
+        data: { key: "value" },
+        pwEndpoint: null,
+        proxy: "http://proxy.example.com:8080",
+        vision: true,
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(mockConsole.log).toHaveBeenCalled();
+      const calls = mockConsole.log.mock.calls;
+      const allOutput = calls.flat().join(" ");
+
+      expect(allOutput).toContain("🚀 Spark Automation Starting");
+      expect(allOutput).toContain("Complete a web form");
+      expect(allOutput).toContain("playwright:firefox");
+      expect(allOutput).toContain("proxy.example.com");
+      expect(allOutput).toContain("Vision: enabled");
+    });
+
+    it("should handle AI_GENERATION_ERROR events", () => {
+      const eventData: AIGenerationErrorEventData = {
+        timestamp: Date.now(),
+        prompt: "Generate a response",
+        error: "API rate limit exceeded",
+        schema: { type: "object" },
+        messages: [{ role: "user", content: "test" }],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.AI_GENERATION_ERROR,
+        data: eventData,
+      });
+
+      expect(mockConsole.error).toHaveBeenCalled();
+      const allOutput = mockConsole.error.mock.calls.flat().join(" ");
+      expect(allOutput).toContain("❌ AI generation error:");
+      expect(allOutput).toContain("API rate limit exceeded");
+    });
+  });
+});
+
+describe("JSONConsoleLogger", () => {
+  let logger: JSONConsoleLogger;
+  let emitter: WebAgentEventEmitter;
+  let originalConsoleLog: typeof console.log;
+
+  beforeEach(() => {
+    // Capture console.log output
+    originalConsoleLog = console.log;
+    console.log = mockConsole.log;
+    mockConsole.log.mockClear();
+
+    logger = new JSONConsoleLogger();
+    emitter = new WebAgentEventEmitter();
+    logger.initialize(emitter);
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    logger.dispose();
+  });
+
+  describe("Logger interface", () => {
+    it("should implement Logger interface", () => {
+      expect(logger).toBeInstanceOf(JSONConsoleLogger);
+      expect(typeof logger.initialize).toBe("function");
+      expect(typeof logger.dispose).toBe("function");
+    });
+
+    it("should initialize with event emitter", () => {
+      const newLogger = new JSONConsoleLogger();
+      const newEmitter = new WebAgentEventEmitter();
+
+      expect(() => {
+        newLogger.initialize(newEmitter);
+      }).not.toThrow();
+
+      newLogger.dispose();
+    });
+
+    it("should dispose properly", () => {
+      const newLogger = new JSONConsoleLogger();
+      const newEmitter = new WebAgentEventEmitter();
+      newLogger.initialize(newEmitter);
+
+      expect(() => {
+        newLogger.dispose();
+      }).not.toThrow();
+
+      // Should be safe to call dispose multiple times
+      expect(() => {
+        newLogger.dispose();
+      }).not.toThrow();
+    });
+  });
+
+  describe("JSON output", () => {
+    it("should output valid JSON for all events", () => {
+      const eventData: TaskStartEventData = {
+        timestamp: Date.now(),
+        task: "Test task",
+        explanation: "Test explanation",
+        plan: "Test plan",
+        url: "https://example.com",
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.TASK_STARTED,
+        data: eventData,
+      });
+
+      expect(mockConsole.log).toHaveBeenCalledTimes(1);
+      const output = mockConsole.log.mock.calls[0][0];
+
+      // Should be valid JSON
+      expect(() => JSON.parse(output)).not.toThrow();
+
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe(WebAgentEventType.TASK_STARTED);
+      expect(parsed.data.task).toBe("Test task");
+      expect(parsed.data.explanation).toBe("Test explanation");
+      expect(parsed.data.plan).toBe("Test plan");
+      expect(parsed.data.url).toBe("https://example.com");
+    });
+
+    it("should output JSON for TASK_SETUP events", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        task: "Complete a web form",
+        browserName: "playwright:firefox",
+        guardrails: "test-guardrails",
+        data: { key: "value" },
+        pwEndpoint: "ws://localhost:9222",
+        proxy: "http://proxy.example.com:8080",
+        vision: true,
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(mockConsole.log).toHaveBeenCalledTimes(1);
+      const output = mockConsole.log.mock.calls[0][0];
+
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe(WebAgentEventType.TASK_SETUP);
+      expect(parsed.data.task).toBe("Complete a web form");
+      expect(parsed.data.browserName).toBe("playwright:firefox");
+      expect(parsed.data.guardrails).toBe("test-guardrails");
+      expect(parsed.data.data).toEqual({ key: "value" });
+      expect(parsed.data.pwEndpoint).toBe("ws://localhost:9222");
+      expect(parsed.data.proxy).toBe("http://proxy.example.com:8080");
+      expect(parsed.data.vision).toBe(true);
+    });
+
+    it("should output JSON for AI_GENERATION events", () => {
+      const eventData: AIGenerationEventData = {
+        timestamp: Date.now(),
+        prompt: "Generate a response",
+        schema: { type: "object", properties: { action: { type: "string" } } },
+        messages: [{ role: "user", content: "test message" }],
+        object: { action: "click", ref: "button1" },
+        finishReason: "stop",
+        usage: {
+          promptTokens: 100,
+          completionTokens: 50,
+          totalTokens: 150,
+        },
+        temperature: 0.7,
+        warnings: [],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.AI_GENERATION,
+        data: eventData,
+      });
+
+      expect(mockConsole.log).toHaveBeenCalledTimes(1);
+      const output = mockConsole.log.mock.calls[0][0];
+
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe(WebAgentEventType.AI_GENERATION);
+      expect(parsed.data.prompt).toBe("Generate a response");
+      expect(parsed.data.object).toEqual({ action: "click", ref: "button1" });
+      expect(parsed.data.usage.promptTokens).toBe(100);
+      expect(parsed.data.usage.completionTokens).toBe(50);
+      expect(parsed.data.temperature).toBe(0.7);
+    });
+
+    it("should output JSON for AI_GENERATION_ERROR events", () => {
+      const eventData: AIGenerationErrorEventData = {
+        timestamp: Date.now(),
+        prompt: "Generate a response",
+        error: "API rate limit exceeded",
+        schema: { type: "object" },
+        messages: [{ role: "user", content: "test" }],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.AI_GENERATION_ERROR,
+        data: eventData,
+      });
+
+      expect(mockConsole.log).toHaveBeenCalledTimes(1);
+      const output = mockConsole.log.mock.calls[0][0];
+
+      const parsed = JSON.parse(output);
+      expect(parsed.event).toBe(WebAgentEventType.AI_GENERATION_ERROR);
+      expect(parsed.data.prompt).toBe("Generate a response");
+      expect(parsed.data.error).toBe("API rate limit exceeded");
+      expect(parsed.data.schema).toEqual({ type: "object" });
+    });
+
+    it("should handle all event types without errors", () => {
+      // Test a few different event types to ensure universal handling
+      const events = [
+        {
+          type: WebAgentEventType.BROWSER_NAVIGATED,
+          data: { timestamp: Date.now(), title: "Test Page", url: "https://example.com" },
+        },
+        {
+          type: WebAgentEventType.AGENT_OBSERVED,
+          data: { timestamp: Date.now(), observation: "Found form element" },
+        },
+        {
+          type: WebAgentEventType.BROWSER_ACTION_STARTED,
+          data: { timestamp: Date.now(), action: "click", ref: "button1" },
+        },
+      ];
+
+      events.forEach((event) => {
+        emitter.emitEvent(event);
+      });
+
+      expect(mockConsole.log).toHaveBeenCalledTimes(3);
+
+      // All outputs should be valid JSON
+      mockConsole.log.mock.calls.forEach((call) => {
+        const output = call[0];
+        expect(() => JSON.parse(output)).not.toThrow();
+        const parsed = JSON.parse(output);
+        expect(parsed).toHaveProperty("event");
+        expect(parsed).toHaveProperty("data");
+      });
+    });
+  });
+
+  describe("Event listener management", () => {
+    it("should register listeners for all event types", () => {
+      // Check that listeners are registered for various event types
+      const eventTypes = [
+        WebAgentEventType.TASK_SETUP,
+        WebAgentEventType.TASK_STARTED,
+        WebAgentEventType.AI_GENERATION,
+        WebAgentEventType.AI_GENERATION_ERROR,
+        WebAgentEventType.BROWSER_NAVIGATED,
+        WebAgentEventType.AGENT_OBSERVED,
+      ];
+
+      eventTypes.forEach((eventType) => {
+        expect(emitter.listenerCount(eventType)).toBeGreaterThan(0);
+      });
+    });
+
+    it("should remove all listeners on dispose", () => {
+      const eventTypes = [
+        WebAgentEventType.TASK_SETUP,
+        WebAgentEventType.TASK_STARTED,
+        WebAgentEventType.AI_GENERATION,
+        WebAgentEventType.AI_GENERATION_ERROR,
+      ];
+
+      // Verify listeners are present
+      eventTypes.forEach((eventType) => {
+        expect(emitter.listenerCount(eventType)).toBeGreaterThan(0);
+      });
+
+      logger.dispose();
+
+      // Verify all listeners are removed
+      eventTypes.forEach((eventType) => {
+        expect(emitter.listenerCount(eventType)).toBe(0);
+      });
     });
   });
 });

--- a/test/webAgent.test.ts
+++ b/test/webAgent.test.ts
@@ -39,6 +39,7 @@ function createMockActionResponse(overrides: any = {}) {
 
 // Mock browser implementation for testing
 class MockAriaBrowser implements AriaBrowser {
+  public browserName = "mockariabrowser";
   private currentUrl = "https://example.com";
   private currentTitle = "Example Page";
   private currentText = "Example page content";


### PR DESCRIPTION
Mostly shuffling as much output as I can into events that can be spat out as JSON, which the eval harness parses to monitor spark agent runs.

- Add JSONConsoleLogger for structured JSON event logging
- Add --logger CLI option and SPARK_LOGGER env var to choose between console and JSON output
- Add AI generation events (AI_GENERATION, AI_GENERATION_ERROR) with usage tracking
- Add TASK_SETUP event to capture initial task configuration
- Move task setup logging from CLI to event system for consistency
- Add AI generation error handling in ConsoleLogger
- Update event type definitions and interfaces for new events

This enables machine-readable logging for evaluation and monitoring workflows while maintaining backward compatibility with console output.