### PR TITLE
Bugfix to ensure CLI uses env var for pw_endpoint as default

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -41,7 +41,11 @@ export function createRunCommand(): Command {
       "Comma-separated list of resources to block",
       config.get("block_resources") || "media,manifest",
     )
-    .option("--pw-endpoint <endpoint>", "Playwright endpoint URL to connect to remote browser")
+    .option(
+      "--pw-endpoint <endpoint>",
+      "Playwright endpoint URL to connect to remote browser",
+      config.get("pw_endpoint"),
+    )
     .option(
       "--pw-cdp-endpoint <endpoint>",
       "Chrome DevTools Protocol endpoint URL (chromium browsers only)",


### PR DESCRIPTION
Noticed that, when I used a spark server docker image, but overrode the entrypoint command to run the spark CLI for an eval, it ignored the SPARK_PW_ENDPOINT env var. This seems to fix it 