### PR TITLE
Remove fill_and_enter action

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,16 +165,16 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.16.0
-        version: 1.17.1(hono@4.8.9)
+        version: 1.17.1(hono@4.9.6)
       '@hono/sentry':
         specifier: ^1.2.2
-        version: 1.2.2(hono@4.8.9)
+        version: 1.2.2(hono@4.9.6)
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
       hono:
-        specifier: ^4.8.5
-        version: 4.8.9
+        specifier: ^4.9.6
+        version: 4.9.6
       spark:
         specifier: file:..
         version: 'file:'
@@ -1973,8 +1973,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.8.9:
-    resolution: {integrity: sha512-ERIxkXMRhUxGV7nS/Af52+j2KL60B1eg+k6cPtgzrGughS+espS9KQ7QO0SMnevtmRlBfAcN0mf1jKtO6j/doA==}
+  hono@4.9.6:
+    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -2952,6 +2952,7 @@ packages:
 
   'spark@file:':
     resolution: {directory: '', type: directory}
+    engines: {node: ^22.0.0}
     hasBin: true
 
   spawn-sync@1.0.15:
@@ -3943,13 +3944,13 @@ snapshots:
     dependencies:
       tldts-experimental: 7.0.13
 
-  '@hono/node-server@1.17.1(hono@4.8.9)':
+  '@hono/node-server@1.17.1(hono@4.9.6)':
     dependencies:
-      hono: 4.8.9
+      hono: 4.9.6
 
-  '@hono/sentry@1.2.2(hono@4.8.9)':
+  '@hono/sentry@1.2.2(hono@4.9.6)':
     dependencies:
-      hono: 4.8.9
+      hono: 4.9.6
       toucan-js: 4.1.1
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -5248,7 +5249,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.8.9: {}
+  hono@4.9.6: {}
 
   hookable@5.5.3: {}
 

--- a/src/browser/ariaBrowser.ts
+++ b/src/browser/ariaBrowser.ts
@@ -15,7 +15,6 @@ export enum PageAction {
   Uncheck = "uncheck",
   Select = "select",
   Enter = "enter",
-  FillAndEnter = "fill_and_enter",
 
   // Navigation and workflow
   Wait = "wait",

--- a/src/browser/playwrightBrowser.ts
+++ b/src/browser/playwrightBrowser.ts
@@ -463,18 +463,6 @@ export class PlaywrightBrowser implements AriaBrowser {
           await this.ensureOptimizedPageLoad();
           break;
 
-        case PageAction.FillAndEnter:
-          if (!value)
-            throw new BrowserActionException(
-              "fill_and_enter",
-              "Value required for fill_and_enter action",
-            );
-          await locator!.fill(value, { timeout: this.ACTION_TIMEOUT_MS });
-          await locator!.press("Enter", { timeout: this.ACTION_TIMEOUT_MS });
-          // Forms might trigger page reloads on enter
-          await this.ensureOptimizedPageLoad();
-          break;
-
         // Navigation and workflow (these don't need element refs)
         case PageAction.Wait:
           if (!value) throw new BrowserActionException("wait", "Value required for wait action");
@@ -551,7 +539,6 @@ export class PlaywrightBrowser implements AriaBrowser {
       PageAction.Uncheck,
       PageAction.Select,
       PageAction.Enter,
-      PageAction.FillAndEnter,
     ];
 
     return elementActions.includes(action);

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -41,9 +41,6 @@ export const TOOL_STRINGS = {
     enter: {
       description: "Press Enter key on an element (useful for form submission)",
     },
-    fill_and_enter: {
-      description: "Fill text into an input field and press Enter (useful for search boxes)",
-    },
     wait: {
       description: "Wait for a specified number of seconds",
       seconds: "Number of seconds to wait (0-30)",
@@ -127,7 +124,6 @@ IMPORTANT:
 const toolExamples = `
 - click({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.click.description}
 - fill({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "text"}) - ${TOOL_STRINGS.webActions.fill.description}
-- fill_and_enter({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "text"}) - ${TOOL_STRINGS.webActions.fill_and_enter.description}
 - select({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "option"}) - ${TOOL_STRINGS.webActions.select.description}
 - hover({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.hover.description}
 - check({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.check.description}

--- a/src/tools/webActionTools.ts
+++ b/src/tools/webActionTools.ts
@@ -185,17 +185,6 @@ export function createWebActionTools(context: WebActionContext) {
       },
     }),
 
-    fill_and_enter: tool({
-      description: TOOL_STRINGS.webActions.fill_and_enter.description,
-      inputSchema: z.object({
-        ref: z.string().describe(TOOL_STRINGS.webActions.common.elementRef),
-        value: z.string().describe(TOOL_STRINGS.webActions.common.textValue),
-      }),
-      execute: async ({ ref, value }) => {
-        return await performActionWithValidation(PageAction.FillAndEnter, context, ref, value);
-      },
-    }),
-
     wait: tool({
       description: TOOL_STRINGS.webActions.wait.description,
       inputSchema: z.object({

--- a/test/ariaBrowser.test.ts
+++ b/test/ariaBrowser.test.ts
@@ -13,7 +13,6 @@ describe("AriaBrowser interface", () => {
         "uncheck",
         "select",
         "enter",
-        "fill_and_enter",
         "wait",
         "goto",
         "back",
@@ -41,7 +40,6 @@ describe("AriaBrowser interface", () => {
       expect(PageAction.Uncheck).toBe("uncheck");
       expect(PageAction.Select).toBe("select");
       expect(PageAction.Enter).toBe("enter");
-      expect(PageAction.FillAndEnter).toBe("fill_and_enter");
       expect(PageAction.Wait).toBe("wait");
       expect(PageAction.Goto).toBe("goto");
       expect(PageAction.Back).toBe("back");
@@ -62,7 +60,6 @@ describe("AriaBrowser interface", () => {
         PageAction.Uncheck,
         PageAction.Select,
         PageAction.Enter,
-        PageAction.FillAndEnter,
       ];
 
       // Navigation actions
@@ -204,7 +201,6 @@ describe("AriaBrowser interface", () => {
         expect(action).toBe(action.toLowerCase());
         expect(action).not.toContain(" ");
         expect(action).not.toContain("-");
-        // Underscores are allowed for compound actions like fill_and_enter
       });
 
       // LoadState values should be lowercase

--- a/test/playwrightBrowser.test.ts
+++ b/test/playwrightBrowser.test.ts
@@ -405,7 +405,6 @@ describe("PlaywrightBrowser", () => {
           PageAction.Uncheck,
           PageAction.Select,
           PageAction.Enter,
-          PageAction.FillAndEnter,
         ];
 
         elementActions.forEach((action) => {
@@ -477,13 +476,6 @@ describe("PlaywrightBrowser", () => {
           waitForLoadState: vi.fn(),
         };
         (browser as any).page = mockPage;
-
-        await expect(browser.performAction("ref1", PageAction.FillAndEnter)).rejects.toThrow(
-          BrowserActionException,
-        );
-        await expect(browser.performAction("ref1", PageAction.FillAndEnter)).rejects.toThrow(
-          "Value required for fill_and_enter action",
-        );
       });
 
       it("should throw BrowserActionException for invalid wait time", async () => {
@@ -555,25 +547,6 @@ describe("PlaywrightBrowser", () => {
         const error = await browser.performAction("missing", PageAction.Click).catch((e) => e);
         expect(error).toBeInstanceOf(InvalidRefException);
         expect(error.ref).toBe("missing");
-      });
-
-      it("should handle FillAndEnter action correctly", async () => {
-        const mockLocator = {
-          count: vi.fn().mockResolvedValue(1),
-          fill: vi.fn().mockResolvedValue(undefined),
-          press: vi.fn().mockResolvedValue(undefined),
-        };
-        const mockPage = {
-          locator: vi.fn().mockReturnValue(mockLocator),
-          waitForTimeout: vi.fn().mockResolvedValue(undefined),
-          waitForLoadState: vi.fn().mockResolvedValue(undefined),
-        };
-        (browser as any).page = mockPage;
-
-        await browser.performAction("search", PageAction.FillAndEnter, "query text");
-
-        expect(mockLocator.fill).toHaveBeenCalledWith("query text", { timeout: 20000 });
-        expect(mockLocator.press).toHaveBeenCalledWith("Enter", { timeout: 20000 });
       });
     });
   });

--- a/test/tools/webActionTools.test.ts
+++ b/test/tools/webActionTools.test.ts
@@ -116,7 +116,6 @@ describe("Web Action Tools", () => {
       expect(tools.uncheck).toBeDefined();
       expect(tools.focus).toBeDefined();
       expect(tools.enter).toBeDefined();
-      expect(tools.fill_and_enter).toBeDefined();
       expect(tools.wait).toBeDefined();
       expect(tools.goto).toBeDefined();
       expect(tools.back).toBeDefined();
@@ -136,9 +135,6 @@ describe("Web Action Tools", () => {
       expect(tools.focus.description).toBe("Focus on an element");
       expect(tools.enter.description).toBe(
         "Press Enter key on an element (useful for form submission)",
-      );
-      expect(tools.fill_and_enter.description).toBe(
-        "Fill text into an input field and press Enter (useful for search boxes)",
       );
       expect(tools.wait.description).toBe("Wait for a specified number of seconds");
       expect(tools.goto.description).toBe(
@@ -364,44 +360,6 @@ describe("Web Action Tools", () => {
         success: true,
         action: "enter",
         ref: "form1",
-      });
-    });
-  });
-
-  describe("Fill and Enter Action", () => {
-    it("should execute fill and enter action successfully", async () => {
-      const performActionSpy = vi.spyOn(mockBrowser, "performAction");
-
-      const result = await tools.fill_and_enter.execute({ ref: "search1", value: "query" });
-
-      expect(performActionSpy).toHaveBeenCalledTimes(1);
-      expect(performActionSpy).toHaveBeenCalledWith("search1", PageAction.FillAndEnter, "query");
-      expect(result).toEqual({
-        success: true,
-        action: "fill_and_enter",
-        ref: "search1",
-        value: "query",
-      });
-    });
-
-    it("should emit browser action events", async () => {
-      const emitSpy = vi.spyOn(eventEmitter, "emit");
-
-      await tools.fill_and_enter.execute({ ref: "search1", value: "query" });
-
-      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.AGENT_ACTION, {
-        action: "fill_and_enter",
-        ref: "search1",
-        value: "query",
-      });
-      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_STARTED, {
-        action: "fill_and_enter",
-        ref: "search1",
-        value: "query",
-      });
-      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-        success: true,
-        action: "fill_and_enter",
       });
     });
   });


### PR DESCRIPTION
We added `fill_and_enter` as an optimization for search style form fields. This ends up causing a problem with complex form fields (think autocomplete). Removing this for now. We keep learning the lesson that trying to take more than one action at a time is often a mistake.