### PR TITLE
Add Google Generative AI provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "ollama-ai-provider-v2": "^1.1.1",
     "playwright": "1.53.0",
     "turndown": "^7.2.1",
-    "zod": "^4.0.17"
+    "zod": "^4.1.8"
   },
   "packageManager": "pnpm@9.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "vitest": "^1.6.1"
   },
   "dependencies": {
+    "@ai-sdk/google": "^2.0.17",
     "@ai-sdk/google-vertex": "^3.0.9",
     "@ai-sdk/openai": "^2.0.15",
     "@ai-sdk/openai-compatible": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,28 +10,28 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^2.0.17
-        version: 2.0.17(zod@4.1.5)
+        version: 2.0.17(zod@4.1.11)
       '@ai-sdk/google-vertex':
         specifier: ^3.0.9
-        version: 3.0.24(zod@4.1.5)
+        version: 3.0.24(zod@4.1.11)
       '@ai-sdk/openai':
         specifier: ^2.0.15
-        version: 2.0.27(zod@4.1.5)
+        version: 2.0.27(zod@4.1.11)
       '@ai-sdk/openai-compatible':
         specifier: ^1.0.7
-        version: 1.0.15(zod@4.1.5)
+        version: 1.0.15(zod@4.1.11)
       '@ghostery/adblocker-playwright':
         specifier: ^2.11.3
         version: 2.11.6(playwright@1.53.0)
       '@openrouter/ai-sdk-provider':
         specifier: ^1.1.2
-        version: 1.2.0(ai@5.0.37(zod@4.1.5))(zod@4.1.5)
+        version: 1.2.0(ai@5.0.37(zod@4.1.11))(zod@4.1.11)
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.5
       ai:
         specifier: ^5.0.15
-        version: 5.0.37(zod@4.1.5)
+        version: 5.0.37(zod@4.1.11)
       chalk:
         specifier: ^5.5.0
         version: 5.6.2
@@ -55,7 +55,7 @@ importers:
         version: 5.1.5
       ollama-ai-provider-v2:
         specifier: ^1.1.1
-        version: 1.3.1(zod@4.1.5)
+        version: 1.3.1(zod@4.1.11)
       playwright:
         specifier: 1.53.0
         version: 1.53.0
@@ -63,8 +63,8 @@ importers:
         specifier: ^7.2.1
         version: 7.2.1
       zod:
-        specifier: ^4.0.17
-        version: 4.1.5
+        specifier: ^4.1.8
+        version: 4.1.11
     devDependencies:
       '@types/jsdom':
         specifier: ^21.1.7
@@ -3530,8 +3530,8 @@ packages:
   zod@3.25.75:
     resolution: {integrity: sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==}
 
-  zod@4.1.5:
-    resolution: {integrity: sha512-rcUUZqlLJgBC33IT3PNMgsCq6TzLQEG/Ei/KTCU0PedSWRMAXoOUN+4t/0H+Q8bdnLPdqUYnvboJT0bn/229qg==}
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
   zustand@5.0.6:
     resolution: {integrity: sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==}
@@ -3560,67 +3560,67 @@ snapshots:
 
   '@adobe/css-tools@4.4.3': {}
 
-  '@ai-sdk/anthropic@2.0.14(zod@4.1.5)':
+  '@ai-sdk/anthropic@2.0.14(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/gateway@1.0.19(zod@4.1.5)':
+  '@ai-sdk/gateway@1.0.19(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/google-vertex@3.0.24(zod@4.1.5)':
+  '@ai-sdk/google-vertex@3.0.24(zod@4.1.11)':
     dependencies:
-      '@ai-sdk/anthropic': 2.0.14(zod@4.1.5)
-      '@ai-sdk/google': 2.0.13(zod@4.1.5)
+      '@ai-sdk/anthropic': 2.0.14(zod@4.1.11)
+      '@ai-sdk/google': 2.0.13(zod@4.1.11)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
       google-auth-library: 9.15.1
-      zod: 4.1.5
+      zod: 4.1.11
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  '@ai-sdk/google@2.0.13(zod@4.1.5)':
+  '@ai-sdk/google@2.0.13(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/google@2.0.17(zod@4.1.5)':
+  '@ai-sdk/google@2.0.17(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.10(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.10(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/openai-compatible@1.0.15(zod@4.1.5)':
+  '@ai-sdk/openai-compatible@1.0.15(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/openai@2.0.27(zod@4.1.5)':
+  '@ai-sdk/openai@2.0.27(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
-  '@ai-sdk/provider-utils@3.0.10(zod@4.1.5)':
+  '@ai-sdk/provider-utils@3.0.10(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 4.1.5
+      zod: 4.1.11
 
-  '@ai-sdk/provider-utils@3.0.8(zod@4.1.5)':
+  '@ai-sdk/provider-utils@3.0.8(zod@4.1.11)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.0.0
       eventsource-parser: 3.0.6
-      zod: 4.1.5
+      zod: 4.1.11
 
   '@ai-sdk/provider@2.0.0':
     dependencies:
@@ -4029,10 +4029,10 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@openrouter/ai-sdk-provider@1.2.0(ai@5.0.37(zod@4.1.5))(zod@4.1.5)':
+  '@openrouter/ai-sdk-provider@1.2.0(ai@5.0.37(zod@4.1.11))(zod@4.1.11)':
     dependencies:
-      ai: 5.0.37(zod@4.1.5)
-      zod: 4.1.5
+      ai: 5.0.37(zod@4.1.11)
+      zod: 4.1.11
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -4454,13 +4454,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@5.0.37(zod@4.1.5):
+  ai@5.0.37(zod@4.1.11):
     dependencies:
-      '@ai-sdk/gateway': 1.0.19(zod@4.1.5)
+      '@ai-sdk/gateway': 1.0.19(zod@4.1.11)
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
       '@opentelemetry/api': 1.9.0
-      zod: 4.1.5
+      zod: 4.1.11
 
   ansi-align@3.0.1:
     dependencies:
@@ -5788,11 +5788,11 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider-v2@1.3.1(zod@4.1.5):
+  ollama-ai-provider-v2@1.3.1(zod@4.1.11):
     dependencies:
       '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
-      zod: 4.1.5
+      '@ai-sdk/provider-utils': 3.0.8(zod@4.1.11)
+      zod: 4.1.11
 
   on-exit-leak-free@2.1.2: {}
 
@@ -6235,14 +6235,14 @@ snapshots:
 
   'spark@file:':
     dependencies:
-      '@ai-sdk/google': 2.0.17(zod@4.1.5)
-      '@ai-sdk/google-vertex': 3.0.24(zod@4.1.5)
-      '@ai-sdk/openai': 2.0.27(zod@4.1.5)
-      '@ai-sdk/openai-compatible': 1.0.15(zod@4.1.5)
+      '@ai-sdk/google': 2.0.17(zod@4.1.11)
+      '@ai-sdk/google-vertex': 3.0.24(zod@4.1.11)
+      '@ai-sdk/openai': 2.0.27(zod@4.1.11)
+      '@ai-sdk/openai-compatible': 1.0.15(zod@4.1.11)
       '@ghostery/adblocker-playwright': 2.11.6(playwright@1.53.0)
-      '@openrouter/ai-sdk-provider': 1.2.0(ai@5.0.37(zod@4.1.5))(zod@4.1.5)
+      '@openrouter/ai-sdk-provider': 1.2.0(ai@5.0.37(zod@4.1.11))(zod@4.1.11)
       '@types/turndown': 5.0.5
-      ai: 5.0.37(zod@4.1.5)
+      ai: 5.0.37(zod@4.1.11)
       chalk: 5.6.2
       commander: 14.0.0
       cross-fetch: 4.1.0
@@ -6250,10 +6250,10 @@ snapshots:
       eventemitter3: 5.0.1
       liquidjs: 10.21.1
       nanoid: 5.1.5
-      ollama-ai-provider-v2: 1.3.1(zod@4.1.5)
+      ollama-ai-provider-v2: 1.3.1(zod@4.1.11)
       playwright: 1.53.0
       turndown: 7.2.1
-      zod: 4.1.5
+      zod: 4.1.11
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -6879,7 +6879,7 @@ snapshots:
 
   zod@3.25.75: {}
 
-  zod@4.1.5: {}
+  zod@4.1.11: {}
 
   zustand@5.0.6(@types/react@19.1.8)(react@19.1.1)(use-sync-external-store@1.5.0(react@19.1.1)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@ai-sdk/google':
+        specifier: ^2.0.17
+        version: 2.0.17(zod@4.1.5)
       '@ai-sdk/google-vertex':
         specifier: ^3.0.9
         version: 3.0.24(zod@4.1.5)
@@ -165,16 +168,16 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.16.0
-        version: 1.17.1(hono@4.9.6)
+        version: 1.17.1(hono@4.9.9)
       '@hono/sentry':
         specifier: ^1.2.2
-        version: 1.2.2(hono@4.9.6)
+        version: 1.2.2(hono@4.9.9)
       dotenv:
         specifier: ^16.6.1
         version: 16.6.1
       hono:
-        specifier: ^4.9.6
-        version: 4.9.6
+        specifier: ^4.9.7
+        version: 4.9.9
       spark:
         specifier: file:..
         version: 'file:'
@@ -227,6 +230,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/google@2.0.17':
+    resolution: {integrity: sha512-6LyuUrCZuiULg0rUV+kT4T2jG19oUntudorI4ttv1ARkSbwl8A39ue3rA487aDDy6fUScdbGFiV5Yv/o4gidVA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai-compatible@1.0.15':
     resolution: {integrity: sha512-i4TzohCxuFzBSdRNPa9eNFW6AYDZ5itbxz+rJa2kpNTMYqHgqKPGzet3X6eLIUVntA10icrqhWT+hUhxXZIS9Q==}
     engines: {node: '>=18'}
@@ -238,6 +247,12 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4
+
+  '@ai-sdk/provider-utils@3.0.10':
+    resolution: {integrity: sha512-T1gZ76gEIwffep6MWI0QNy9jgoybUHE7TRaHB5k54K8mF91ciGFlbtCGxDYhMH3nCRergKwYFIDeFF0hJSIQHQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/provider-utils@3.0.8':
     resolution: {integrity: sha512-cDj1iigu7MW2tgAQeBzOiLhjHOUM9vENsgh4oAVitek0d//WdgfPCsKO3euP7m7LyO/j9a1vr/So+BGNdpFXYw==}
@@ -1977,8 +1992,8 @@ packages:
   highlight.js@10.7.3:
     resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
 
-  hono@4.9.6:
-    resolution: {integrity: sha512-doVjXhSFvYZ7y0dNokjwwSahcrAfdz+/BCLvAMa/vHLzjj8+CFyV5xteThGUsKdkaasgN+gF2mUxao+SGLpUeA==}
+  hono@4.9.9:
+    resolution: {integrity: sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -3575,6 +3590,12 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
       zod: 4.1.5
 
+  '@ai-sdk/google@2.0.17(zod@4.1.5)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.10(zod@4.1.5)
+      zod: 4.1.5
+
   '@ai-sdk/openai-compatible@1.0.15(zod@4.1.5)':
     dependencies:
       '@ai-sdk/provider': 2.0.0
@@ -3585,6 +3606,13 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@ai-sdk/provider-utils': 3.0.8(zod@4.1.5)
+      zod: 4.1.5
+
+  '@ai-sdk/provider-utils@3.0.10(zod@4.1.5)':
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
       zod: 4.1.5
 
   '@ai-sdk/provider-utils@3.0.8(zod@4.1.5)':
@@ -3950,13 +3978,13 @@ snapshots:
     dependencies:
       tldts-experimental: 7.0.13
 
-  '@hono/node-server@1.17.1(hono@4.9.6)':
+  '@hono/node-server@1.17.1(hono@4.9.9)':
     dependencies:
-      hono: 4.9.6
+      hono: 4.9.9
 
-  '@hono/sentry@1.2.2(hono@4.9.6)':
+  '@hono/sentry@1.2.2(hono@4.9.9)':
     dependencies:
-      hono: 4.9.6
+      hono: 4.9.9
       toucan-js: 4.1.1
 
   '@isaacs/balanced-match@4.0.1': {}
@@ -5255,7 +5283,7 @@ snapshots:
 
   highlight.js@10.7.3: {}
 
-  hono@4.9.6: {}
+  hono@4.9.9: {}
 
   hookable@5.5.3: {}
 
@@ -6207,6 +6235,7 @@ snapshots:
 
   'spark@file:':
     dependencies:
+      '@ai-sdk/google': 2.0.17(zod@4.1.5)
       '@ai-sdk/google-vertex': 3.0.24(zod@4.1.5)
       '@ai-sdk/openai': 2.0.27(zod@4.1.5)
       '@ai-sdk/openai-compatible': 1.0.15(zod@4.1.5)

--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -33,10 +33,11 @@ interface SparkTaskRequest {
   guardrails?: string;
 
   // AI configuration overrides
-  provider?: "openai" | "openrouter" | "vertex" | "ollama" | "openai-compatible" | "lmstudio";
+  provider?: "openai" | "openrouter" | "vertex" | "ollama" | "openai-compatible" | "lmstudio" | "google";
   model?: string;
   openaiApiKey?: string;
   openrouterApiKey?: string;
+  googleApiKey?: string;
   ollamaBaseUrl?: string;
   openaiCompatibleBaseUrl?: string;
   openaiCompatibleName?: string;
@@ -160,6 +161,7 @@ spark.post("/run", async (c) => {
           model: body.model,
           openai_api_key: body.openaiApiKey,
           openrouter_api_key: body.openrouterApiKey,
+          google_generative_ai_api_key: body.googleApiKey,
           ollama_base_url: body.ollamaBaseUrl,
           openai_compatible_base_url: body.openaiCompatibleBaseUrl,
           openai_compatible_name: body.openaiCompatibleName,

--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -33,7 +33,14 @@ interface SparkTaskRequest {
   guardrails?: string;
 
   // AI configuration overrides
-  provider?: "openai" | "openrouter" | "vertex" | "ollama" | "openai-compatible" | "lmstudio" | "google";
+  provider?:
+    | "openai"
+    | "openrouter"
+    | "vertex"
+    | "ollama"
+    | "openai-compatible"
+    | "lmstudio"
+    | "google";
   model?: string;
   openaiApiKey?: string;
   openrouterApiKey?: string;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,10 +5,18 @@ import { config as loadDotenv } from "dotenv";
 
 export interface SparkConfig {
   // AI Configuration
-  provider?: "openai" | "openrouter" | "vertex" | "ollama" | "openai-compatible" | "lmstudio";
+  provider?:
+    | "openai"
+    | "openrouter"
+    | "vertex"
+    | "ollama"
+    | "openai-compatible"
+    | "lmstudio"
+    | "google";
   model?: string;
   openai_api_key?: string;
   openrouter_api_key?: string;
+  google_generative_ai_api_key?: string;
   vertex_project?: string;
   vertex_location?: string;
 
@@ -100,6 +108,9 @@ export class ConfigManager {
       ...(process.env.SPARK_MODEL && { model: process.env.SPARK_MODEL }),
       ...(process.env.OPENAI_API_KEY && { openai_api_key: process.env.OPENAI_API_KEY }),
       ...(process.env.OPENROUTER_API_KEY && { openrouter_api_key: process.env.OPENROUTER_API_KEY }),
+      ...(process.env.GOOGLE_GENERATIVE_AI_API_KEY && {
+        google_generative_ai_api_key: process.env.GOOGLE_GENERATIVE_AI_API_KEY,
+      }),
       ...((process.env.GOOGLE_VERTEX_PROJECT ||
         process.env.GOOGLE_CLOUD_PROJECT ||
         process.env.GCP_PROJECT) && {
@@ -297,6 +308,8 @@ export class ConfigManager {
     if (process.env.SPARK_MODEL) env.model = process.env.SPARK_MODEL;
     if (process.env.OPENAI_API_KEY) env.openai_api_key = process.env.OPENAI_API_KEY;
     if (process.env.OPENROUTER_API_KEY) env.openrouter_api_key = process.env.OPENROUTER_API_KEY;
+    if (process.env.GOOGLE_GENERATIVE_AI_API_KEY)
+      env.google_generative_ai_api_key = process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (
       process.env.GOOGLE_VERTEX_PROJECT ||
       process.env.GOOGLE_CLOUD_PROJECT ||


### PR DESCRIPTION
This PR adds support for Google Generative AI as a new AI provider option, enabling users to use Google's Gemini models through the @ai-sdk/google package.

- Adds Google Generative AI provider support with API key configuration
- Includes comprehensive test coverage for the new provider
- Updates configuration management to handle Google API keys from environment variables and global config