### PR TITLE
Add dev:firefox:persist and stable ext id for saving Spark info across restarts

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev:chrome": "wxt -b chrome",
     "dev:firefox": "wxt -b firefox",
+    "dev:firefox:persist": "WEB_EXT_FIREFOX_PROFILE=.wxt/firefox-data WEB_EXT_KEEP_PROFILE_CHANGES=true wxt -b firefox",
     "build:chrome": "wxt build -b chrome",
     "build:firefox": "wxt build -b firefox",
     "zip:chrome": "wxt zip -b chrome",

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -54,6 +54,14 @@ export default defineConfig({
             128: "icon/128.png",
           },
         },
+        browser_specific_settings: {
+          // XXX need to do the equivalent thing for Chrome
+          gecko: {
+            // Need a stable identifier so wxt doesn't use a random one each
+            // time and break persistence.
+            id: "spark@mozilla.org",
+          },
+        },
       };
     }
 


### PR DESCRIPTION
This could still use some cleanup (see the XXX), but it makes development much less painful.