### PR TITLE
Avoid extension UX breakage if timestamp mistyped

### DIFF
--- a/extension/src/ChatMessage.tsx
+++ b/extension/src/ChatMessage.tsx
@@ -96,7 +96,7 @@ export function ChatMessage({
           </div>
         )}
 
-        {timestamp && (
+        {timestamp && (timestamp instanceof Date) && (
           <div className={`text-xs ${t.text.muted} mt-1`}>{timestamp.toLocaleTimeString()}</div>
         )}
       </div>

--- a/extension/test/ChatMessage.test.tsx
+++ b/extension/test/ChatMessage.test.tsx
@@ -52,4 +52,21 @@ describe("ChatMessage", () => {
 
     expect(screen.getByText("Working on your request...")).toBeInTheDocument();
   });
+
+  it("does not render timestamp when timestamp is not a Date object", () => {
+    // @ts-expect-error - intentionally passing invalid timestamp to test runtime safety
+    render(<ChatMessage {...defaultProps} timestamp={{}} />);
+
+    // Should not attempt to render timestamp or throw error
+    expect(screen.queryByText(/:/)).not.toBeInTheDocument();
+  });
+
+  it("does not render timestamp when timestamp is a plain object", () => {
+    // @ts-expect-error - intentionally passing invalid timestamp to test runtime safety
+    render(<ChatMessage {...defaultProps} timestamp={{ notADate: true }} />);
+
+    // Should not crash or render invalid timestamp
+    const messageContainer = screen.getByText("Hello world").parentElement;
+    expect(messageContainer).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
This is a bandaid (it's not clear why a timestamp would exist but not be a date object), but it totally breaks the UX, so let's avoid that.