### PR TITLE
Timestamp reviver

### DIFF
--- a/extension/src/ChatMessage.tsx
+++ b/extension/src/ChatMessage.tsx
@@ -96,7 +96,7 @@ export function ChatMessage({
           </div>
         )}
 
-        {timestamp && (timestamp instanceof Date) && (
+        {timestamp && (
           <div className={`text-xs ${t.text.muted} mt-1`}>{timestamp.toLocaleTimeString()}</div>
         )}
       </div>

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -1,0 +1,13 @@
+/**
+ * JSON.parse reviver function that converts ISO date strings to Date objects for 'timestamp' keys.
+ *
+ * @param key - The key being parsed
+ * @param value - The value associated with the key
+ * @returns A Date object if the key is 'timestamp' and value is not null/undefined, otherwise the original value
+ */
+export function reviver(key: string, value: any): any {
+  if (key === 'timestamp' && value != null) {
+    return new Date(value);
+  }
+  return value;
+}

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -7,7 +7,12 @@
  */
 export function reviver(key: string, value: any): any {
   if (key === 'timestamp' && value != null) {
-    return new Date(value);
+    const date = new Date(value);
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+    // If invalid, return the original value
+    return value;
   }
   return value;
 }

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -5,7 +5,7 @@
  * @param value - The value associated with the key
  * @returns A Date object if the key is 'timestamp' and value is not null/undefined, otherwise the original value
  */
-export function reviver(key: string, value: any): any {
+export function reviver(key: string, value: unknown): unknown {
   if (key === 'timestamp' && value != null) {
     const date = new Date(value);
     if (!isNaN(date.getTime())) {

--- a/extension/test/ChatMessage.test.tsx
+++ b/extension/test/ChatMessage.test.tsx
@@ -52,21 +52,4 @@ describe("ChatMessage", () => {
 
     expect(screen.getByText("Working on your request...")).toBeInTheDocument();
   });
-
-  it("does not render timestamp when timestamp is not a Date object", () => {
-    // @ts-expect-error - intentionally passing invalid timestamp to test runtime safety
-    render(<ChatMessage {...defaultProps} timestamp={{}} />);
-
-    // Should not attempt to render timestamp or throw error
-    expect(screen.queryByText(/:/)).not.toBeInTheDocument();
-  });
-
-  it("does not render timestamp when timestamp is a plain object", () => {
-    // @ts-expect-error - intentionally passing invalid timestamp to test runtime safety
-    render(<ChatMessage {...defaultProps} timestamp={{ notADate: true }} />);
-
-    // Should not crash or render invalid timestamp
-    const messageContainer = screen.getByText("Hello world").parentElement;
-    expect(messageContainer).toBeInTheDocument();
-  });
 });

--- a/extension/test/utils/storage.test.ts
+++ b/extension/test/utils/storage.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { reviver } from '../../src/utils/storage';
+
+describe('reviver', () => {
+  it('should convert ISO date string to Date object when key is timestamp', () => {
+    const json = '{"timestamp":"2025-10-02T12:00:00.000Z"}';
+    const result = JSON.parse(json, reviver);
+
+    expect(result.timestamp).toBeInstanceOf(Date);
+    expect(result.timestamp.toISOString()).toBe('2025-10-02T12:00:00.000Z');
+  });
+
+  it('should pass through non-timestamp keys unchanged', () => {
+    const json = '{"name":"test","count":42,"active":true}';
+    const result = JSON.parse(json, reviver);
+
+    expect(result.name).toBe('test');
+    expect(result.count).toBe(42);
+    expect(result.active).toBe(true);
+  });
+
+  it('should handle null/undefined timestamp values', () => {
+    const json = '{"timestamp":null}';
+    const result = JSON.parse(json, reviver);
+
+    expect(result.timestamp).toBeNull();
+  });
+});


### PR DESCRIPTION
Trying to fix another instance of the timestamp problem with a Band-Aid caused the TypeScript type system to get mad. 
I also realized that every date that was rehydrated from a store came back as an ISO date string rather than a date object, causing various things to fail. 

In this patch, I add a reviver function and cause the stores to use it to fix this problem for every top-level key named 'timestamp'. 

I also realized that the previous band-aid fix I had was incorrect, so I've backed that out.

Keying off a name of timestamp is not awesome; Zustand docs suggest that one should have values be objects with an explicit type field. But that's not a rabbit hole worth falling down right now, I don't think. 

@lmorchard and/or @nchapman, can one of y'all make a call on whether this is good enough?
