### PR TITLE
Support multiple providers/OpenRouter

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -14,6 +14,7 @@ interface StorageSettings {
   apiKey?: string;
   apiEndpoint?: string;
   model?: string;
+  provider?: "openai" | "openrouter";
 }
 
 export default defineBackground(() => {
@@ -88,6 +89,7 @@ export default defineBackground(() => {
               "apiKey",
               "apiEndpoint",
               "model",
+              "provider",
             ])) as StorageSettings;
 
             if (!settings.apiKey) {
@@ -130,7 +132,8 @@ export default defineBackground(() => {
               const result = await AgentManager.runTask(executeMessage.task, {
                 apiKey: settings.apiKey,
                 apiEndpoint: settings.apiEndpoint,
-                model: settings.model || "gpt-4.1",
+                model: settings.model || "gpt-4.1-mini",
+                provider: settings.provider,
                 logger,
                 tabId: executeMessage.tabId,
                 data: executeMessage.data,

--- a/extension/src/components/sidepanel/SettingsView.tsx
+++ b/extension/src/components/sidepanel/SettingsView.tsx
@@ -37,12 +37,26 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
       <div className="flex-1 p-6 overflow-y-auto">
         <div className="space-y-6">
           <div className="space-y-2">
-            <label className={`block text-sm font-medium ${t.text.secondary}`}>API Key</label>
+            <label className={`block text-sm font-medium ${t.text.secondary}`}>Provider</label>
+            <select
+              value={settings.provider}
+              onChange={(e) =>
+                updateSettings({ provider: e.target.value as "openai" | "openrouter" })
+              }
+              className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} focus:outline-none ${focusRing}`}
+            >
+              <option value="openai">OpenAI</option>
+              <option value="openrouter">OpenRouter</option>
+            </select>
+          </div>
+
+          <div className="space-y-2">
+            <label className={`block text-sm font-medium ${t.text.secondary}`}>Model</label>
             <input
-              type="password"
-              value={settings.apiKey}
-              onChange={(e) => updateSettings({ apiKey: e.target.value })}
-              placeholder="sk-..."
+              type="text"
+              value={settings.model}
+              onChange={(e) => updateSettings({ model: e.target.value })}
+              placeholder="gpt-4.1-mini"
               className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} placeholder-gray-400 focus:outline-none ${focusRing}`}
             />
           </div>
@@ -59,12 +73,12 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
           </div>
 
           <div className="space-y-2">
-            <label className={`block text-sm font-medium ${t.text.secondary}`}>Model</label>
+            <label className={`block text-sm font-medium ${t.text.secondary}`}>API Key</label>
             <input
-              type="text"
-              value={settings.model}
-              onChange={(e) => updateSettings({ model: e.target.value })}
-              placeholder="gpt-4.1-mini"
+              type="password"
+              value={settings.apiKey}
+              onChange={(e) => updateSettings({ apiKey: e.target.value })}
+              placeholder="sk-..."
               className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} placeholder-gray-400 focus:outline-none ${focusRing}`}
             />
           </div>

--- a/extension/src/stores/settingsStore.ts
+++ b/extension/src/stores/settingsStore.ts
@@ -7,6 +7,7 @@ export interface Settings {
   apiKey: string;
   apiEndpoint: string;
   model: string;
+  provider: "openai" | "openrouter";
 }
 
 export interface SettingsStore {
@@ -23,7 +24,8 @@ export interface SettingsStore {
 const defaultSettings: Settings = {
   apiKey: "",
   apiEndpoint: "https://api.openai.com/v1",
-  model: "gpt-4.1",
+  model: "gpt-4.1-mini",
+  provider: "openai",
 };
 
 // Create browser storage adapter for settings
@@ -68,6 +70,7 @@ export const useSettingsStore = create<SettingsStore>()(
             apiKey: settings.apiKey,
             apiEndpoint: settings.apiEndpoint,
             model: settings.model,
+            provider: settings.provider,
           });
 
           set({ saveStatus: "Settings saved successfully!" });
@@ -85,12 +88,24 @@ export const useSettingsStore = create<SettingsStore>()(
 
       loadSettings: async () => {
         try {
-          const stored = await browser.storage.local.get(["apiKey", "apiEndpoint", "model"]);
+          const stored = await browser.storage.local.get([
+            "apiKey",
+            "apiEndpoint",
+            "model",
+            "provider",
+          ]);
+
+          // Validate provider value
+          const isValidProvider = stored.provider === "openai" || stored.provider === "openrouter";
+          const provider = isValidProvider
+            ? (stored.provider as "openai" | "openrouter")
+            : defaultSettings.provider;
 
           const newSettings: Settings = {
             apiKey: (stored.apiKey as string) || defaultSettings.apiKey,
             apiEndpoint: (stored.apiEndpoint as string) || defaultSettings.apiEndpoint,
             model: (stored.model as string) || defaultSettings.model,
+            provider,
           };
 
           set({ settings: newSettings });

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -21,7 +21,7 @@ export function reviver(key: string, value: unknown): unknown {
     // timestamps. We should either refactor all code to use ISO date
     // strings for timestamps (more readable), or standardize on using
     // numbers everywhere (more performant).
-    const date = new Date(value as string | number);
+    const date = new Date(value);
     if (!isNaN(date.getTime())) {
       return date;
     }

--- a/extension/src/utils/storage.ts
+++ b/extension/src/utils/storage.ts
@@ -1,8 +1,12 @@
 /**
  * JSON.parse reviver function that converts ISO date strings to Date objects for 'timestamp' keys.
  *
+ * This function is designed to work with JSON.parse and Zustand's createJSONStorage.
+ * While it accepts `unknown`, it will only receive valid JSON values at runtime:
+ * string, number, boolean, null, objects, or arrays.
+ *
  * @param key - The key being parsed
- * @param value - The value associated with the key
+ * @param value - The value associated with the key (will be a valid JSON value at runtime)
  * @returns A Date object if the key is 'timestamp' and value is not null/undefined, otherwise the original value
  */
 export function reviver(key: string, value: unknown): unknown {
@@ -11,7 +15,13 @@ export function reviver(key: string, value: unknown): unknown {
     value != null &&
     (typeof value === "string" || typeof value === "number")
   ) {
-    const date = new Date(value);
+    // At runtime, value will be string or number from JSON
+    //
+    // XXX There is still code in the codebase that uses numbers for
+    // timestamps. We should either refactor all code to use ISO date
+    // strings for timestamps (more readable), or standardize on using
+    // numbers everywhere (more performant).
+    const date = new Date(value as string | number);
     if (!isNaN(date.getTime())) {
       return date;
     }

--- a/extension/test/AgentManager.test.ts
+++ b/extension/test/AgentManager.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { AgentManager } from "../src/AgentManager";
+
+vi.mock("@ai-sdk/openai");
+vi.mock("@openrouter/ai-sdk-provider");
+vi.mock("spark/core");
+vi.mock("../src/ExtensionBrowser");
+
+import { createOpenAI } from "@ai-sdk/openai";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { WebAgent } from "spark/core";
+import { ExtensionBrowser } from "../src/ExtensionBrowser";
+
+describe("AgentManager", () => {
+  let mockOpenAI: any;
+  let mockOpenRouter: any;
+  let mockModel: any;
+  let mockWebAgent: any;
+
+  beforeEach(() => {
+    mockModel = vi.fn();
+
+    mockOpenAI = vi.fn(() => mockModel);
+    vi.mocked(createOpenAI).mockReturnValue(mockOpenAI);
+
+    mockOpenRouter = vi.fn(() => mockModel);
+    vi.mocked(createOpenRouter).mockReturnValue(mockOpenRouter);
+
+    mockWebAgent = {
+      execute: vi.fn().mockResolvedValue({ finalAnswer: "test result" }),
+      close: vi.fn().mockResolvedValue(undefined),
+    };
+    vi.mocked(WebAgent).mockImplementation(() => mockWebAgent);
+
+    vi.mocked(ExtensionBrowser).mockImplementation(() => ({}) as any);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Default Provider Behavior", () => {
+    it("should use OpenAI provider by default", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-key",
+      });
+
+      expect(createOpenAI).toHaveBeenCalled();
+      expect(createOpenRouter).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Accept Provider Parameter", () => {
+    it("should accept provider option in runTask", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-key",
+        provider: "openai",
+      });
+
+      expect(createOpenAI).toHaveBeenCalled();
+    });
+  });
+
+  describe("Create OpenRouter Provider", () => {
+    it("should create OpenRouter provider when specified", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openrouter-key",
+        provider: "openrouter",
+      });
+
+      expect(createOpenRouter).toHaveBeenCalled();
+      expect(createOpenAI).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("OpenRouter Headers", () => {
+    it("should include required headers for OpenRouter", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openrouter-key",
+        provider: "openrouter",
+      });
+
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: "test-openrouter-key",
+        headers: {
+          "HTTP-Referer": "https://github.com/Mozilla-Ocho/spark",
+          "X-Title": "Spark Web Automation Tool",
+        },
+      });
+    });
+  });
+
+  describe("OpenRouter Default Model", () => {
+    it("should use openai/gpt-4.1-mini as default for OpenRouter", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openrouter-key",
+        provider: "openrouter",
+      });
+
+      expect(mockOpenRouter).toHaveBeenCalledWith("openai/gpt-4.1-mini");
+    });
+
+    it("should use gpt-4.1-mini as default for OpenAI", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openai-key",
+        provider: "openai",
+      });
+
+      expect(mockOpenAI).toHaveBeenCalledWith("gpt-4.1-mini");
+    });
+  });
+
+  describe("OpenRouter Ignores apiEndpoint", () => {
+    it("should ignore apiEndpoint for OpenRouter", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openrouter-key",
+        provider: "openrouter",
+        apiEndpoint: "https://custom-endpoint.com/v1",
+      });
+
+      expect(createOpenRouter).toHaveBeenCalledWith({
+        apiKey: "test-openrouter-key",
+        headers: {
+          "HTTP-Referer": "https://github.com/Mozilla-Ocho/spark",
+          "X-Title": "Spark Web Automation Tool",
+        },
+      });
+    });
+
+    it("should respect apiEndpoint for OpenAI", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-openai-key",
+        provider: "openai",
+        apiEndpoint: "https://custom-endpoint.com/v1",
+      });
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        apiKey: "test-openai-key",
+        baseURL: "https://custom-endpoint.com/v1",
+      });
+    });
+  });
+
+  describe("Backward Compatibility", () => {
+    it("should maintain backward compatibility with no provider param", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-key",
+        apiEndpoint: "https://custom.com/v1",
+        model: "gpt-4o",
+      });
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        apiKey: "test-key",
+        baseURL: "https://custom.com/v1",
+      });
+      expect(mockOpenAI).toHaveBeenCalledWith("gpt-4o");
+    });
+
+    it("should use default OpenAI endpoint when none specified", async () => {
+      await AgentManager.runTask("test task", {
+        apiKey: "test-key",
+      });
+
+      expect(createOpenAI).toHaveBeenCalledWith({
+        apiKey: "test-key",
+        baseURL: "https://api.openai.com/v1",
+      });
+    });
+  });
+});

--- a/extension/test/background.test.ts
+++ b/extension/test/background.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// This test validates the TypeScript interface and the integration
+// with AgentManager. We cannot easily test the WXT defineBackground
+// callback directly, so we test the types and AgentManager integration.
+
+describe("Background Script - Provider Support", () => {
+  describe("StorageSettings Interface", () => {
+    it("should define provider field with correct type", () => {
+      // TypeScript compilation validates this at build time
+      const validSettings: {
+        apiKey?: string;
+        apiEndpoint?: string;
+        model?: string;
+        provider?: "openai" | "openrouter";
+      } = {
+        apiKey: "test-key",
+        provider: "openrouter",
+      };
+
+      expect(validSettings.provider).toBe("openrouter");
+    });
+
+    it("should allow openai provider value", () => {
+      const settings: {
+        provider?: "openai" | "openrouter";
+      } = {
+        provider: "openai",
+      };
+
+      expect(settings.provider).toBe("openai");
+    });
+
+    it("should allow openrouter provider value", () => {
+      const settings: {
+        provider?: "openai" | "openrouter";
+      } = {
+        provider: "openrouter",
+      };
+
+      expect(settings.provider).toBe("openrouter");
+    });
+
+    it("should allow undefined provider value", () => {
+      const settings: {
+        provider?: "openai" | "openrouter";
+      } = {};
+
+      expect(settings.provider).toBeUndefined();
+    });
+  });
+
+  describe("Provider Integration with AgentManager", () => {
+    beforeEach(() => {
+      vi.clearAllMocks();
+    });
+
+    it("should pass provider to AgentManager.runTask", async () => {
+      // Simulate what background script does
+      const settings = {
+        apiKey: "test-key",
+        apiEndpoint: "https://api.openai.com/v1",
+        model: "gpt-4.1",
+        provider: "openrouter",
+      };
+
+      const taskOptions = {
+        apiKey: settings.apiKey,
+        apiEndpoint: settings.apiEndpoint,
+        model: settings.model || "gpt-4.1",
+        provider: settings.provider,
+        tabId: 1,
+      };
+
+      // Verify type compatibility
+      expect(taskOptions.provider).toBe("openrouter");
+      expect(typeof taskOptions.provider).toBe("string");
+    });
+
+    it("should handle missing provider correctly", () => {
+      const settings = {
+        apiKey: "test-key",
+        model: "gpt-4.1",
+      };
+
+      const taskOptions = {
+        apiKey: settings.apiKey,
+        model: settings.model || "gpt-4.1",
+        provider: (settings as any).provider,
+      };
+
+      expect(taskOptions.provider).toBeUndefined();
+    });
+
+    it("should construct task options with all provider types", () => {
+      const testCases: Array<"openai" | "openrouter" | undefined> = [
+        "openai",
+        "openrouter",
+        undefined,
+      ];
+
+      testCases.forEach((provider) => {
+        const settings = {
+          apiKey: "test-key",
+          provider,
+        };
+
+        const taskOptions = {
+          apiKey: settings.apiKey,
+          provider: settings.provider,
+        };
+
+        expect(taskOptions.provider).toBe(provider);
+      });
+    });
+  });
+
+  describe("Storage Key Validation", () => {
+    it("should include provider in storage keys", () => {
+      // This validates that the background script reads the correct keys
+      const storageKeys = ["apiKey", "apiEndpoint", "model", "provider"];
+
+      expect(storageKeys).toContain("provider");
+      expect(storageKeys).toHaveLength(4);
+    });
+  });
+
+  describe("Type Safety Enforcement", () => {
+    it("should only accept valid provider values", () => {
+      type Provider = "openai" | "openrouter";
+
+      const validProviders: Provider[] = ["openai", "openrouter"];
+
+      validProviders.forEach((provider) => {
+        const settings = {
+          provider,
+        };
+
+        expect(["openai", "openrouter"]).toContain(settings.provider);
+      });
+    });
+
+    it("should type check provider in StorageSettings", () => {
+      interface StorageSettings {
+        apiKey?: string;
+        apiEndpoint?: string;
+        model?: string;
+        provider?: "openai" | "openrouter";
+      }
+
+      const settings1: StorageSettings = {
+        provider: "openai",
+      };
+
+      const settings2: StorageSettings = {
+        provider: "openrouter",
+      };
+
+      const settings3: StorageSettings = {};
+
+      expect(settings1.provider).toBe("openai");
+      expect(settings2.provider).toBe("openrouter");
+      expect(settings3.provider).toBeUndefined();
+    });
+  });
+
+  describe("Default Values", () => {
+    it("should use default model when not provided", () => {
+      const settings: {
+        apiKey: string;
+        model?: string;
+        provider: "openrouter";
+      } = {
+        apiKey: "test-key",
+        provider: "openrouter" as const,
+      };
+
+      const model = settings.model || "gpt-4.1";
+
+      expect(model).toBe("gpt-4.1");
+    });
+
+    it("should preserve custom model when provided", () => {
+      const settings = {
+        apiKey: "test-key",
+        model: "gpt-4o",
+        provider: "openai" as const,
+      };
+
+      const model = settings.model || "gpt-4.1";
+
+      expect(model).toBe("gpt-4o");
+    });
+  });
+});

--- a/extension/test/components/SettingsView.test.tsx
+++ b/extension/test/components/SettingsView.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SettingsView from "../../src/components/sidepanel/SettingsView";
+
+// Mock the hooks
+const mockUpdateSettings = vi.fn();
+const mockSaveSettings = vi.fn();
+
+vi.mock("src/stores/settingsStore", () => ({
+  useSettings: vi.fn(() => ({
+    settings: {
+      apiKey: "test-key",
+      apiEndpoint: "https://api.openai.com/v1",
+      model: "gpt-4.1-mini",
+      provider: "openai",
+    },
+    saveStatus: null,
+    updateSettings: mockUpdateSettings,
+    saveSettings: mockSaveSettings,
+  })),
+}));
+
+const mockTheme = {
+  bg: {
+    primary: "bg-white",
+    secondary: "bg-gray-50",
+    input: "bg-white",
+    error: "bg-red-50",
+    success: "bg-green-50",
+  },
+  text: {
+    primary: "text-gray-900",
+    secondary: "text-gray-700",
+    muted: "text-gray-500",
+    error: "text-red-700",
+    success: "text-green-700",
+  },
+  border: {
+    primary: "border-gray-200",
+    input: "border-gray-300",
+    error: "border-red-200",
+    success: "border-green-200",
+  },
+};
+
+vi.mock("src/useSystemTheme", () => ({
+  useSystemTheme: vi.fn(() => ({
+    isDark: false,
+    theme: mockTheme,
+  })),
+}));
+
+describe("SettingsView - Provider Dropdown", () => {
+  const mockOnBack = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Rendering", () => {
+    it("should render provider dropdown", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerLabel = screen.getByText("Provider");
+      expect(providerLabel).toBeInTheDocument();
+
+      // Find the select element (there's only one combobox)
+      const selects = screen.getAllByRole("combobox");
+      expect(selects).toHaveLength(1);
+      expect(selects[0]).toBeInTheDocument();
+    });
+
+    it("should display current provider value", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
+      expect(providerSelect.value).toBe("openai");
+    });
+
+    it("should show OpenAI and OpenRouter options", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const openaiOption = screen.getByRole("option", { name: "OpenAI" }) as HTMLOptionElement;
+      const openrouterOption = screen.getByRole("option", {
+        name: "OpenRouter",
+      }) as HTMLOptionElement;
+
+      expect(openaiOption).toBeInTheDocument();
+      expect(openrouterOption).toBeInTheDocument();
+    });
+  });
+
+  describe("User Interaction", () => {
+    it("should have onChange handler attached", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
+
+      // Verify the select element is interactive
+      expect(providerSelect).not.toBeDisabled();
+      expect(providerSelect.tagName).toBe("SELECT");
+    });
+
+    it("should render with default provider value", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
+
+      // Check that provider value is set
+      expect(providerSelect.value).toBe("openai");
+    });
+  });
+
+  describe("Form Integration", () => {
+    it("should preserve provider value across re-renders", () => {
+      const { rerender } = render(<SettingsView onBack={mockOnBack} />);
+
+      let providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
+      expect(providerSelect.value).toBe("openai");
+
+      rerender(<SettingsView onBack={mockOnBack} />);
+
+      providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
+      expect(providerSelect.value).toBe("openai");
+    });
+
+    it("should have save button", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const saveButton = screen.getByRole("button", { name: /save settings/i });
+      expect(saveButton).toBeInTheDocument();
+    });
+
+    it("should have back button", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const backButton = screen.getByRole("button", { name: /back to chat/i });
+      expect(backButton).toBeInTheDocument();
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("should have proper label for provider dropdown", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const label = screen.getByText("Provider");
+      const providerSelect = screen.getByRole("combobox");
+
+      expect(label).toBeInTheDocument();
+      expect(providerSelect).toBeInTheDocument();
+    });
+
+    it("should be keyboard navigable", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerSelect = screen.getByRole("combobox");
+
+      // Provider select should be focusable
+      providerSelect.focus();
+      expect(providerSelect).toHaveFocus();
+    });
+  });
+
+  describe("Provider-specific behavior", () => {
+    it("should display OpenAI as default provider", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const providerSelect = screen.getByRole("combobox");
+
+      // Should start as OpenAI
+      expect((providerSelect as HTMLSelectElement).value).toBe("openai");
+    });
+
+    it("should have both OpenAI and OpenRouter as selectable options", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      const openaiOption = screen.getByRole("option", { name: "OpenAI" }) as HTMLOptionElement;
+      const openrouterOption = screen.getByRole("option", {
+        name: "OpenRouter",
+      }) as HTMLOptionElement;
+
+      // Both options should be present and selectable
+      expect(openaiOption.value).toBe("openai");
+      expect(openrouterOption.value).toBe("openrouter");
+    });
+  });
+
+  describe("Other form fields", () => {
+    it("should render all required fields including provider", () => {
+      render(<SettingsView onBack={mockOnBack} />);
+
+      expect(screen.getByText("API Key")).toBeInTheDocument();
+      expect(screen.getByText("Provider")).toBeInTheDocument();
+      expect(screen.getByText("API Endpoint")).toBeInTheDocument();
+      expect(screen.getByText("Model")).toBeInTheDocument();
+    });
+  });
+});

--- a/extension/test/stores/settingsStore.test.ts
+++ b/extension/test/stores/settingsStore.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Settings } from "../../src/stores/settingsStore";
+import { useSettingsStore } from "../../src/stores/settingsStore";
+import browser from "webextension-polyfill";
+
+// Mock webextension-polyfill
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    storage: {
+      local: {
+        set: vi.fn(),
+        get: vi.fn(),
+        remove: vi.fn(),
+      },
+    },
+  },
+}));
+
+describe("Settings Interface", () => {
+  it("should include provider property", () => {
+    const settings: Settings = {
+      apiKey: "test-key",
+      apiEndpoint: "https://api.openai.com/v1",
+      model: "gpt-4",
+      provider: "openai",
+    };
+
+    expect(settings.provider).toBe("openai");
+  });
+
+  it("should allow openrouter as provider", () => {
+    const settings: Settings = {
+      apiKey: "test-key",
+      apiEndpoint: "https://openrouter.ai/api/v1",
+      model: "gpt-4",
+      provider: "openrouter",
+    };
+
+    expect(settings.provider).toBe("openrouter");
+  });
+});
+
+describe("Storage Persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should persist provider to storage when saving", async () => {
+    const store = useSettingsStore.getState();
+
+    // Update settings with provider
+    store.updateSettings({
+      apiKey: "test-key",
+      apiEndpoint: "https://openrouter.ai/api/v1",
+      model: "gpt-4",
+      provider: "openrouter",
+    });
+
+    // Mock storage.local.set to resolve
+    vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
+
+    // Save settings
+    await store.saveSettings();
+
+    // Verify provider was included in the storage call
+    expect(browser.storage.local.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "openrouter",
+      }),
+    );
+  });
+});
+
+describe("Storage Loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset store state before each test
+    useSettingsStore.setState({
+      settings: {
+        apiKey: "",
+        apiEndpoint: "https://api.openai.com/v1",
+        model: "gpt-4.1-mini",
+        provider: "openai",
+      },
+      saveStatus: null,
+    });
+  });
+
+  it("should load provider from storage", async () => {
+    // Mock storage with provider value
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      apiKey: "stored-key",
+      apiEndpoint: "https://openrouter.ai/api/v1",
+      model: "gpt-4",
+      provider: "openrouter",
+    });
+
+    // Load settings
+    await useSettingsStore.getState().loadSettings();
+
+    // Verify provider was loaded
+    expect(useSettingsStore.getState().settings.provider).toBe("openrouter");
+  });
+
+  it("should fallback to default provider when not in storage", async () => {
+    // Mock storage without provider value
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      apiKey: "stored-key",
+      apiEndpoint: "https://api.openai.com/v1",
+      model: "gpt-4",
+    });
+
+    // Load settings
+    await useSettingsStore.getState().loadSettings();
+
+    // Verify provider falls back to openai
+    expect(useSettingsStore.getState().settings.provider).toBe("openai");
+  });
+
+  it("should fallback to default provider for invalid values", async () => {
+    // Mock storage with invalid provider value
+    vi.mocked(browser.storage.local.get).mockResolvedValue({
+      apiKey: "stored-key",
+      apiEndpoint: "https://api.openai.com/v1",
+      model: "gpt-4",
+      provider: "invalid-provider",
+    });
+
+    // Load settings
+    await useSettingsStore.getState().loadSettings();
+
+    // Verify provider falls back to openai
+    expect(useSettingsStore.getState().settings.provider).toBe("openai");
+  });
+});

--- a/extension/vitest.config.ts
+++ b/extension/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
 import { WxtVitest } from "wxt/testing";
+import path from "path";
 
 export default defineConfig({
   plugins: [WxtVitest()],
+  resolve: {
+    alias: {
+      "spark/core": path.resolve(__dirname, "../src/core.ts"),
+    },
+  },
   test: {
     globals: true,
     environment: "happy-dom",


### PR DESCRIPTION
This has the basics of supporting multiple providers, the first of which is OpenRouter.

It adds: 
* a provider property to the single Settings object, and teaches the system that certain defaults go with OpenAI and certain defaults go with OpenRouter.
* a provider dropdown to the settings UI and re-orders the settings UI to be clearer.
* a bunch of mostly unit tests. They're more brittle than I might like, but I see how to clean this up as things progress.

Sorry that this PR is as big as it is; I'll try to keep the future ones smaller.  It may be easier to understand the pieces by looking at the individual commits.

I think that this will be the beginning of a gradual shift to a settingsStore that can handle multiple Settings objects so that one can switch back and forth without having to re-enter API keys and models, as well as to less duplication of code by (often) passing around Settings objects rather than all the individual parameters.

@nchapman @lmorchard I don't think this needs super-detailed review, but I'd love at least a high-level look from one of you before I merge it.