### PR TITLE
Improve CI reliability by switching --frozen-lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Check formatting
         run: pnpm run format:check

--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -49,12 +49,12 @@ jobs:
 
       - name: Install root dependencies and build main package
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install
           pnpm run build
 
       - name: Install server dependencies
         working-directory: ./server
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install
 
       - name: Check server formatting
         working-directory: ./server


### PR DESCRIPTION
I'm fighting through various CI and other problems across the sub-repos, and I'd like to remove one source of randomness and version mismatches by getting rid of --no-frozen-lockfile so that all builders use the same dependency tree.