### PR TITLE
Improve CI reliability with --frozen-lockfile and pnpm 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Check formatting
         run: pnpm run format:check

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -52,7 +52,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install all dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build core package
         run: pnpm run build

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -8,6 +8,7 @@ on:
       - "src/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/extension_ci.yml"
   pull_request:
     branches: [main, develop]
     paths:
@@ -15,6 +16,7 @@ on:
       - "src/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/extension_ci.yml"
 
 jobs:
   extension-ci:

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -60,21 +60,16 @@ jobs:
         run: pnpm run build
 
       - name: Check extension formatting
-        working-directory: ./extension
-        run: pnpm run format:check
+        run: pnpm --filter spark-extension run format:check
 
       - name: Run extension type check
-        working-directory: ./extension
-        run: pnpm run typecheck
+        run: pnpm --filter spark-extension run typecheck
 
       - name: Run extension tests
-        working-directory: ./extension
-        run: pnpm test
+        run: pnpm --filter spark-extension test
 
       - name: Build extension for Firefox
-        working-directory: ./extension
-        run: pnpm run build:firefox
+        run: pnpm --filter spark-extension run build:firefox
 
       - name: Build extension for Chrome
-        working-directory: ./extension
-        run: pnpm run build:chrome
+        run: pnpm --filter spark-extension run build:chrome

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 8
+          version: 9
 
       - name: Get pnpm store directory
         shell: bash

--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -8,6 +8,7 @@ on:
       - "src/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/server_ci.yml"
   pull_request:
     branches: [main, develop]
     paths:
@@ -15,6 +16,7 @@ on:
       - "src/**"
       - "package.json"
       - "pnpm-lock.yaml"
+      - ".github/workflows/server_ci.yml"
 
 jobs:
   server-ci:

--- a/.github/workflows/server_ci.yml
+++ b/.github/workflows/server_ci.yml
@@ -49,12 +49,12 @@ jobs:
 
       - name: Install root dependencies and build main package
         run: |
-          pnpm install --no-frozen-lockfile
+          pnpm install --frozen-lockfile
           pnpm run build
 
       - name: Install server dependencies
         working-directory: ./server
-        run: pnpm install --no-frozen-lockfile
+        run: pnpm install --frozen-lockfile
 
       - name: Check server formatting
         working-directory: ./server


### PR DESCRIPTION
I'm having various issues trying to fix different things, and some of them are related to version skew. This tries to make things more reliable across development and shipping environments by using `--frozen-lockfile`.  In order to do this, I ended up also

* switching CI to `pnpm` 9 so that CI can use the lockfiles that we're checking in
* switching `extension_ci.yml`  to use `--filter` instead of `working-directory` to unconfuse `pnpm`
* make each CI workflow file depend on itself, so that any changes to the workflows themselves get checked by CI

According to the docs, in `pnpm` 9 and 10, `--frozen-lockfile` should actually be correct on CI by default (and thus unnecessary) because the default reads various environment variables to infer the correct environment and setting. I figured I'd avoid a heuristic in favor of determinism and have one less variable in play by being explicit here.

I'd love comments from both @nchapman and @lmorchard on this PR, since it touches everything.

Question: I don't imagine the release changes can be tested as easily as just comparing them, as they're likely to generate different bits before and after this change. I'm inclined to just do some simple smoke-testing of the cli and the extension from the generated tarballs by hand. Thoughts?