### PR TITLE
Fix extension regression and workflow

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -57,6 +57,12 @@ jobs:
       - name: Build core package
         run: pnpm run build
 
+      # Re-run install to resolve package exports now that dist/ exists.
+      # pnpm resolves exports during install, but dist/ is only created
+      # (and not resolved) by the build step above.
+      - name: Re-link workspace dependencies
+        run: pnpm install
+
       - name: Check extension formatting
         working-directory: ./extension
         run: pnpm run format:check

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,36 +1,11 @@
 import { defineConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
-import { fileURLToPath } from "url";
-import { dirname, resolve } from "path";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ["@wxt-dev/module-react", "@wxt-dev/webextension-polyfill"],
   vite: () => ({
     plugins: [tailwindcss()],
-    resolve: {
-      alias: {
-        // Point to the compiled JS file, not source TS
-        // This avoids Vite trying to bundle source dependencies
-        "spark/core": resolve(__dirname, "../dist/core.js"),
-      },
-    },
-    build: {
-      rollupOptions: {
-        // Treat certain imports as external to avoid bundling issues
-        external: (id) => {
-          // Don't try to bundle webextension-polyfill from parent package
-          const moduleName = "@wxt-dev/webextension-polyfill";
-          return (
-            (id === moduleName || id.startsWith(moduleName + "/")) &&
-            !id.includes("node_modules/@wxt-dev")
-          );
-        },
-      },
-    },
   }),
   manifest: ({ browser }) => {
     // Common configuration for all browsers

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.18.1)(happy-dom@20.0.0)(jsdom@24.1.3)(lightningcss@1.30.1)
+        version: 1.6.1(@types/node@22.18.1)(happy-dom@20.0.2)(jsdom@24.1.3)(lightningcss@1.30.1)
 
   extension:
     dependencies:
@@ -150,7 +150,7 @@ importers:
         version: 1.1.3(vite@5.4.19(@types/node@22.18.1)(lightningcss@1.30.1))(wxt@0.20.11(@types/node@22.18.1)(lightningcss@1.30.1)(rollup@4.44.2))
       happy-dom:
         specifier: ^20.0.0
-        version: 20.0.0
+        version: 20.0.2
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -159,7 +159,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@22.18.1)(happy-dom@20.0.0)(jsdom@24.1.3)(lightningcss@1.30.1)
+        version: 3.2.4(@types/node@22.18.1)(happy-dom@20.0.2)(jsdom@24.1.3)(lightningcss@1.30.1)
       wxt:
         specifier: 0.20.11
         version: 0.20.11(@types/node@22.18.1)(lightningcss@1.30.1)(rollup@4.44.2)
@@ -196,7 +196,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^1.6.1
-        version: 1.6.1(@types/node@22.18.1)(happy-dom@20.0.0)(jsdom@24.1.3)(lightningcss@1.30.1)
+        version: 1.6.1(@types/node@22.18.1)(happy-dom@20.0.2)(jsdom@24.1.3)(lightningcss@1.30.1)
 
 packages:
 
@@ -1103,8 +1103,8 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/node@20.19.20':
-    resolution: {integrity: sha512-2Q7WS25j4pS1cS8yw3d6buNCVJukOTeQ39bAnwR6sOJbaxvyCGebzTMypDFN82CxBLnl+lSWVdCCWbRY6y9yZQ==}
+  '@types/node@20.19.9':
+    resolution: {integrity: sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==}
 
   '@types/node@22.18.1':
     resolution: {integrity: sha512-rzSDyhn4cYznVG+PCzGe1lwuMYJrcBS1fc3JqSa2PvtABwWo+dZ1ij5OVok3tqfpEBCBoaR4d7upFJk73HRJDw==}
@@ -1933,8 +1933,8 @@ packages:
     resolution: {integrity: sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==}
     engines: {node: '>=14.0.0'}
 
-  happy-dom@20.0.0:
-    resolution: {integrity: sha512-GkWnwIFxVGCf2raNrxImLo397RdGhLapj5cT3R2PT7FwL62Ze1DROhzmYW7+J3p9105DYMVenEejEbnq5wA37w==}
+  happy-dom@20.0.2:
+    resolution: {integrity: sha512-pYOyu624+6HDbY+qkjILpQGnpvZOusItCk+rvF5/V+6NkcgTKnbOldpIy22tBnxoaLtlM9nXgoqAcW29/B7CIw==}
     engines: {node: '>=20.0.0'}
 
   has-flag@3.0.0:
@@ -4228,7 +4228,7 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
-  '@types/node@20.19.20':
+  '@types/node@20.19.9':
     dependencies:
       undici-types: 6.21.0
 
@@ -5144,9 +5144,9 @@ snapshots:
       - encoding
       - supports-color
 
-  happy-dom@20.0.0:
+  happy-dom@20.0.2:
     dependencies:
-      '@types/node': 20.19.20
+      '@types/node': 20.19.9
       '@types/whatwg-mimetype': 3.0.2
       whatwg-mimetype: 3.0.0
 
@@ -6434,7 +6434,7 @@ snapshots:
       fsevents: 2.3.3
       lightningcss: 1.30.1
 
-  vitest@1.6.1(@types/node@22.18.1)(happy-dom@20.0.0)(jsdom@24.1.3)(lightningcss@1.30.1):
+  vitest@1.6.1(@types/node@22.18.1)(happy-dom@20.0.2)(jsdom@24.1.3)(lightningcss@1.30.1):
     dependencies:
       '@vitest/expect': 1.6.1
       '@vitest/runner': 1.6.1
@@ -6458,7 +6458,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.1
-      happy-dom: 20.0.0
+      happy-dom: 20.0.2
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less
@@ -6470,7 +6470,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@3.2.4(@types/node@22.18.1)(happy-dom@20.0.0)(jsdom@24.1.3)(lightningcss@1.30.1):
+  vitest@3.2.4(@types/node@22.18.1)(happy-dom@20.0.2)(jsdom@24.1.3)(lightningcss@1.30.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
@@ -6497,7 +6497,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.18.1
-      happy-dom: 20.0.0
+      happy-dom: 20.0.2
       jsdom: 24.1.3
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
This fixes the extension regression by:

* adding a second install step of the top-level dist to the CI workflow so that the extension can link in things generated during the build step after the first install
* regenerates pnpm-lock.yaml from scratch to get rid of a CI build error due to a now-incorrect dependency

It requires the `freeze-lockfiles` patch to merge first so that CI switches to `pnpm 9` and actually uses pnpm-lock.yaml instead of discarding it.

The builds on this branch will remain broken until freeze-lockfiles merges, and we retrigger the builds here.