### PR TITLE
Open extension devtools automatically to see logs

### DIFF
--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -68,4 +68,9 @@ export default defineConfig({
     // Fallback for other browsers
     return baseManifest;
   },
+  webExt: {
+    // Open developer tools on startup (mostly to see the logs) during development
+    // (requires Firefox 106+). Only seems to work in Firefox.
+    openDevtools: true,
+  },
 });


### PR DESCRIPTION
Automatically open Extension dev tools when running pnpm targets like `pnpm dev:firefox`.  Improoves dev velocity a lot by always having logs visible when things go wrong.

Doesn't appear to be supported for Chrome.