### PR TITLE
Fix webext dev:firefox:persist to create dir

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev:chrome": "wxt -b chrome",
     "dev:firefox": "wxt -b firefox",
-    "dev:firefox:persist": "WEB_EXT_FIREFOX_PROFILE=.wxt/firefox-data WEB_EXT_KEEP_PROFILE_CHANGES=true wxt -b firefox",
+    "dev:firefox:persist": "node scripts/mkdirp.js .wxt/firefox-data && WEB_EXT_FIREFOX_PROFILE=.wxt/firefox-data WEB_EXT_KEEP_PROFILE_CHANGES=true wxt -b firefox",
     "prebuild:chrome": "cd .. && pnpm build",
     "build:chrome": "wxt build -b chrome",
     "prebuild:firefox": "cd .. && pnpm build",

--- a/extension/scripts/mkdirp.js
+++ b/extension/scripts/mkdirp.js
@@ -1,0 +1,16 @@
+import { mkdirSync } from "node:fs";
+
+// Create directory (and any parent directories) if it doesn't exist
+const dir = process.argv[2];
+
+if (!dir) {
+  console.error("Usage: node mkdirp.js <directory-path>");
+  process.exit(1);
+}
+
+try {
+  mkdirSync(dir, { recursive: true });
+} catch (err) {
+  console.error(`Failed to create directory "${dir}": ${err?.message || String(err)}`);
+  process.exit(1);
+}


### PR DESCRIPTION
In the cases where a firefox profile directory doesn't exist, we create one.