### PR TITLE
Add pnpm dev:chrome for ext that persists profile

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -8,6 +8,7 @@
     "node": "^22.0.0"
   },
   "scripts": {
+    "dev:chrome": "node scripts/mkdirp.js .wxt/chrome-data && WEB_EXT_CHROMIUM_PROFILE=.wxt/chrome-data WEB_EXT_KEEP_PROFILE_CHANGES=true wxt -b chrome",
     "dev:chrome:tmp-profile": "wxt -b chrome",
     "dev:firefox": "node scripts/mkdirp.js .wxt/firefox-data && WEB_EXT_FIREFOX_PROFILE=.wxt/firefox-data WEB_EXT_KEEP_PROFILE_CHANGES=true wxt -b firefox",
     "dev:firefox:tmp-profile": "wxt -b firefox",

--- a/extension/wxt.config.ts
+++ b/extension/wxt.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, type WebExtConfig } from "wxt";
 import tailwindcss from "@tailwindcss/vite";
+import { resolve } from "node:path";
 
 function generateWebExtJSON(): WebExtConfig {
   const config: WebExtConfig = {
@@ -14,6 +15,14 @@ function generateWebExtJSON(): WebExtConfig {
   const firefoxProfile = process.env.WEB_EXT_FIREFOX_PROFILE;
   if (firefoxProfile) {
     config.firefoxProfile = firefoxProfile;
+  }
+
+  // Chrome/Chromium profile persistence - controlled by environment variables
+  // Set by dev:chrome script to maintain logins, settings, etc.
+  const chromiumProfile = process.env.WEB_EXT_CHROMIUM_PROFILE;
+  if (chromiumProfile) {
+    // Use absolute path for Windows compatibility
+    config.chromiumProfile = resolve(chromiumProfile);
   }
 
   if (process.env.WEB_EXT_KEEP_PROFILE_CHANGES === "true") {


### PR DESCRIPTION
Adds a `dev:chrome` pnpm script for Chrome extension development with persistent profile data, mirroring the existing Firefox workflow to retain logins, settings, and other profile data across sessions.