### PR TITLE
Make WebExt log plan when available, fixes #110

### DIFF
--- a/extension/test/EventStoreLogger.test.ts
+++ b/extension/test/EventStoreLogger.test.ts
@@ -88,3 +88,147 @@ describe("EventStoreLogger error logging", () => {
     });
   });
 });
+
+describe("Task Plan Logging", () => {
+  let loggerInfoSpy: any;
+  let logger: EventStoreLogger;
+
+  beforeEach(() => {
+    logger = new EventStoreLogger();
+    // Spy on the internal logger's info method
+    loggerInfoSpy = vi.spyOn(logger["logger"], "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    loggerInfoSpy.mockRestore();
+  });
+
+  it("should log task plans using logger.info when task:started event contains a plan", () => {
+    const planData = {
+      plan: "1. Analyze the code\n2. Write tests\n3. Implement feature",
+      taskId: "task-123",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", planData);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      "Task Plan Details",
+      expect.objectContaining({
+        taskId: "task-123",
+      }),
+      expect.objectContaining({
+        taskId: "task-123",
+        plan: planData.plan,
+        planLength: planData.plan.length,
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+
+  it("should not log when task:started event has no plan", () => {
+    const dataWithoutPlan = {
+      taskId: "task-456",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", dataWithoutPlan);
+
+    expect(loggerInfoSpy).not.toHaveBeenCalled();
+  });
+
+  it("should not log when plan is null or undefined", () => {
+    const dataWithNullPlan = {
+      plan: null,
+      taskId: "task-null",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", dataWithNullPlan);
+    expect(loggerInfoSpy).not.toHaveBeenCalled();
+
+    const dataWithUndefinedPlan = {
+      plan: undefined,
+      taskId: "task-undefined",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", dataWithUndefinedPlan);
+    expect(loggerInfoSpy).not.toHaveBeenCalled();
+  });
+
+  it("should log complete plan structure including all event data", () => {
+    const complexPlanData = {
+      plan: "Complex multi-step plan:\n- Step 1\n- Step 2\n- Step 3",
+      taskId: "task-789",
+      metadata: {
+        source: "ai_agent",
+        version: "1.0",
+      },
+      additionalInfo: "extra context",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", complexPlanData);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      "Task Plan Details",
+      expect.objectContaining({
+        taskId: "task-789",
+      }),
+      expect.objectContaining({
+        taskId: "task-789",
+        plan: complexPlanData.plan,
+        planLength: complexPlanData.plan.length,
+        timestamp: expect.any(Number),
+        fullEventData: complexPlanData,
+      }),
+    );
+  });
+
+  it("should handle missing taskId gracefully", () => {
+    const planDataNoTaskId = {
+      plan: "Plan without task ID",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", planDataNoTaskId);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      "Task Plan Details",
+      expect.objectContaining({
+        taskId: "unknown",
+      }),
+      expect.objectContaining({
+        taskId: "unknown",
+        plan: planDataNoTaskId.plan,
+        planLength: planDataNoTaskId.plan.length,
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+
+  it("should log plan length for very long plans", () => {
+    const longPlan = "Step ".repeat(1000); // Create a very long plan
+    const planData = {
+      plan: longPlan,
+      taskId: "task-long",
+      timestamp: Date.now(),
+    };
+
+    logger.addEvent("task:started", planData);
+
+    expect(loggerInfoSpy).toHaveBeenCalledWith(
+      "Task Plan Details",
+      expect.objectContaining({
+        taskId: "task-long",
+      }),
+      expect.objectContaining({
+        taskId: "task-long",
+        plan: longPlan,
+        planLength: longPlan.length,
+        timestamp: expect.any(Number),
+      }),
+    );
+  });
+});


### PR DESCRIPTION
Implement task plan logging functionality for the extension by capturing and logging task plans when tasks start. Adds a new handler for the `task:started event` that logs plan details to both the console and structured logs.