### PR TITLE
Make lists styled in WebExt, fixes #112

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -33,6 +33,7 @@
     "@types/marked": "^6.0.0",
     "@types/webextension-polyfill": "^0.12.4",
     "@wxt-dev/webextension-polyfill": "^1.0.0",
+    "clsx": "^2.1.1",
     "marked": "^16.0.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type ReactElement } from "react";
 import browser from "webextension-polyfill";
 import { marked } from "marked";
+import clsx from "clsx";
 import { ChatMessage } from "../../ChatMessage";
 import { useChat } from "../../useChat";
 import type { ChatMessage as ChatMessageType } from "../../hooks/useConversation";
@@ -36,7 +37,7 @@ interface ChatViewProps {
 // Markdown rendering utilities
 const renderMarkdown = (content: string): string => {
   return marked(content, {
-    breaks: true,
+    breaks: false,
     gfm: true,
   }) as string;
 };
@@ -47,8 +48,11 @@ interface MarkdownContentProps {
   className?: string;
 }
 
-const MarkdownContent = ({ children, className = "" }: MarkdownContentProps): ReactElement => (
-  <span className={className} dangerouslySetInnerHTML={{ __html: renderMarkdown(children) }} />
+const MarkdownContent = ({ children, className }: MarkdownContentProps): ReactElement => (
+  <div
+    className={clsx("markdown-content", className)}
+    dangerouslySetInnerHTML={{ __html: renderMarkdown(children) }}
+  />
 );
 
 // Task message component

--- a/extension/src/components/sidepanel/SidePanel.css
+++ b/extension/src/components/sidepanel/SidePanel.css
@@ -1,1 +1,35 @@
 @import "tailwindcss";
+
+/* Add custom styles to Tailwind's components layer to ensure they're included in build */
+@layer components {
+  /* Restore list styles for markdown content */
+  .markdown-content ol {
+    list-style-type: decimal;
+    list-style-position: inside;
+  }
+
+  .markdown-content ul {
+    list-style-type: disc;
+    list-style-position: inside;
+  }
+
+  /* The `marked` library generates <p> tags inside <li> elements when
+   * rendering markdown lists, causing line breaks between list numbers
+   * and content.  The next two rules are to workaround this.
+   * 
+   * XXX If/when we switch away from the `marked` library, we should see if
+   * we can get rid of this.
+   */
+
+  /* Make paragraph tags inside list items display inline */
+  .markdown-content li > p {
+    display: inline;
+    margin: 0;
+  }
+
+  /* Handle multiple paragraphs in a list item */
+  .markdown-content li > p:not(:first-child) {
+    display: block;
+    margin-top: 0.5em;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@wxt-dev/webextension-polyfill':
         specifier: ^1.0.0
         version: 1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.11(@types/node@24.9.1)(lightningcss@1.30.1)(rollup@4.44.2))
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       marked:
         specifier: ^16.0.0
         version: 16.1.1
@@ -1474,6 +1477,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -4663,6 +4670,8 @@ snapshots:
       wrap-ansi: 7.0.0
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:


### PR DESCRIPTION
Overrides the Tailwind pre-flight resets for lists so that we get relatively reasonable styling (I.e., numbers and bullets).