### PR TITLE
Fix extension rendering by insisting on Markdown (fixes #135)

### DIFF
--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -63,7 +63,7 @@ export const TOOL_STRINGS = {
     done: {
       description: "Complete the task with your final answer",
       result:
-        "The complete, standalone deliverable in Markdown format. Use headers, lists, bold text, and links. NEVER use raw JSON - format all data as readable Markdown.",
+        "The complete, standalone deliverable in Markdown format. NEVER use raw JSON - format all data as Markdown.",
     },
     abort: {
       description:
@@ -271,10 +271,8 @@ Provide your final answer:
 - Match the depth to the task (brief for simple queries, detailed for research)
 - Write naturally and informatively
 - Include all requested information
-- Format results as readable Markdown (use headers, lists, bold text, links)
+- Format results as readable Markdown
 - NEVER return raw JSON - always format structured data as Markdown
-- For multiple items: use numbered lists or separate sections with headers
-- For URLs: create proper Markdown links [text](url)
 
 {% if hasGuardrails %}
 🚨 **GUARDRAIL COMPLIANCE:** Any action violating the provided guardrails is FORBIDDEN.

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -63,7 +63,7 @@ export const TOOL_STRINGS = {
     done: {
       description: "Complete the task with your final answer",
       result:
-        "The complete, standalone deliverable in Markdown format. NEVER use raw JSON - format all data as Markdown.",
+        "The complete, standalone deliverable in VALID Markdown format. NEVER use raw JSON - format ALL data as VALID Markdown.",
     },
     abort: {
       description:
@@ -80,15 +80,16 @@ export const TOOL_STRINGS = {
     /** Common parameter descriptions */
     common: {
       successCriteria: "What would make a great response - key information and detail level needed",
-      plan: "Step-by-step plan for the task, formatted as Markdown",
+      plan: "Step-by-step plan for the task, formatted as VALID Markdown",
     },
     /** Individual tool descriptions */
     create_plan: {
-      description: "Create a step-by-step plan for completing the task, formatted as Markdown",
+      description:
+        "Create a step-by-step plan for completing the task, formatted as VALID Markdown",
     },
     create_plan_with_url: {
       description:
-        "Create a step-by-step plan formatted as Markdown and determine the best starting URL",
+        "Create a step-by-step plan formatted as VALID Markdown and determine the best starting URL",
       url: "Starting URL for the task",
     },
   },
@@ -271,8 +272,8 @@ Provide your final answer:
 - Match the depth to the task (brief for simple queries, detailed for research)
 - Write naturally and informatively
 - Include all requested information
-- Format results as readable Markdown
-- NEVER return raw JSON - always format structured data as Markdown
+- Format results as VALID Markdown
+- NEVER return raw JSON - ALwAYS format structured data as VALID Markdown
 
 {% if hasGuardrails %}
 🚨 **GUARDRAIL COMPLIANCE:** Any action violating the provided guardrails is FORBIDDEN.

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -63,7 +63,7 @@ export const TOOL_STRINGS = {
     done: {
       description: "Complete the task with your final answer",
       result:
-        "The complete, standalone deliverable that fulfills the user's request. Be concise. This will be used on its own.",
+        "The complete, standalone deliverable in Markdown format. Use headers, lists, bold text, and links. NEVER use raw JSON - format all data as readable Markdown.",
     },
     abort: {
       description:
@@ -80,14 +80,15 @@ export const TOOL_STRINGS = {
     /** Common parameter descriptions */
     common: {
       successCriteria: "What would make a great response - key information and detail level needed",
-      plan: "Step-by-step plan for the task",
+      plan: "Step-by-step plan for the task, formatted as Markdown",
     },
     /** Individual tool descriptions */
     create_plan: {
-      description: "Create a step-by-step plan for completing the task",
+      description: "Create a step-by-step plan for completing the task, formatted as Markdown",
     },
     create_plan_with_url: {
-      description: "Create a step-by-step plan and determine the best starting URL",
+      description:
+        "Create a step-by-step plan formatted as Markdown and determine the best starting URL",
       url: "Starting URL for the task",
     },
   },
@@ -270,7 +271,10 @@ Provide your final answer:
 - Match the depth to the task (brief for simple queries, detailed for research)
 - Write naturally and informatively
 - Include all requested information
-- Use a format that's easy to read and use
+- Format results as readable Markdown (use headers, lists, bold text, links)
+- NEVER return raw JSON - always format structured data as Markdown
+- For multiple items: use numbered lists or separate sections with headers
+- For URLs: create proper Markdown links [text](url)
 
 {% if hasGuardrails %}
 🚨 **GUARDRAIL COMPLIANCE:** Any action violating the provided guardrails is FORBIDDEN.

--- a/test/tools/planningTools.test.ts
+++ b/test/tools/planningTools.test.ts
@@ -26,7 +26,7 @@ describe("Planning Tools", () => {
       const tools = createPlanningTools();
 
       expect(tools.create_plan.description).toBe(
-        "Create a step-by-step plan for completing the task",
+        "Create a step-by-step plan for completing the task, formatted as Markdown",
       );
     });
 
@@ -34,7 +34,7 @@ describe("Planning Tools", () => {
       const tools = createPlanningTools();
 
       expect(tools.create_plan_with_url.description).toBe(
-        "Create a step-by-step plan and determine the best starting URL",
+        "Create a step-by-step plan formatted as Markdown and determine the best starting URL",
       );
     });
 

--- a/test/tools/planningTools.test.ts
+++ b/test/tools/planningTools.test.ts
@@ -26,7 +26,7 @@ describe("Planning Tools", () => {
       const tools = createPlanningTools();
 
       expect(tools.create_plan.description).toBe(
-        "Create a step-by-step plan for completing the task, formatted as Markdown",
+        "Create a step-by-step plan for completing the task, formatted as VALID Markdown",
       );
     });
 
@@ -34,7 +34,7 @@ describe("Planning Tools", () => {
       const tools = createPlanningTools();
 
       expect(tools.create_plan_with_url.description).toBe(
-        "Create a step-by-step plan formatted as Markdown and determine the best starting URL",
+        "Create a step-by-step plan formatted as VALID Markdown and determine the best starting URL",
       );
     });
 


### PR DESCRIPTION
This fixes somewhat regular rendering issues in the extension caused by an LLM returning something other than valid Markdown (eg lists as JSON arrays, or lists in pseudo-markdown that doesn't have newlines, etc).  See #135 for an example.

I'm concerned that this might go a little too far and have unintended consequences.  I'd be curious to hear thoughts from @lmorchard and @nchapman on this approach before I put together tests and keep driving this forward...