### PR TITLE
Quiet down hint chatter from new versions of dotenv module

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -93,7 +93,7 @@ export class ConfigManager {
 
     // Load local .env file if it exists (for development)
     try {
-      loadDotenv({ path: ".env" });
+      loadDotenv({ path: ".env", quiet: true });
     } catch {
       // Ignore if .env doesn't exist
     }


### PR DESCRIPTION
For some reason, new versions of the dotenv module have started spewing lots of promotional "hints" in log messages. This should squelch them

<img width="755" height="370" alt="image" src="https://github.com/user-attachments/assets/4e66c9bc-63ca-4bf6-87f2-178795b10c6b" />
