### PR TITLE
Add logger filtering architecture with secrets redaction

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -12,6 +12,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { MetricsCollector } from "../../loggers/metricsCollector.js";
 import { Logger } from "../../loggers/types.js";
+import { SecretsRedactor } from "../../loggers/secretsRedactor.js";
 
 /**
  * Creates the 'run' command for executing web automation tasks
@@ -144,9 +145,11 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
 
     // Create logger
     const logger: Logger = new MetricsCollector(
-      options.logger === "json"
-        ? new JSONConsoleLogger()
-        : new ChalkConsoleLogger({ metricsIncremental: options.metricsIncremental }),
+      new SecretsRedactor(
+        options.logger === "json"
+          ? new JSONConsoleLogger()
+          : new ChalkConsoleLogger({ metricsIncremental: options.metricsIncremental }),
+      ),
     );
 
     // Create browser instance

--- a/src/loggers/filter.ts
+++ b/src/loggers/filter.ts
@@ -1,0 +1,57 @@
+import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
+import { LoggerWrapper } from "./wrapper.js";
+
+/**
+ * Abstract base class for logger filters that intercept and transform events.
+ *
+ * LoggerFilter creates a new emitter that receives transformed events,
+ * allowing filtering, modification, or enrichment of event data before
+ * it reaches the wrapped logger.
+ *
+ * Subclasses must implement the transformData method to define their
+ * specific transformation logic.
+ */
+export abstract class LoggerFilter extends LoggerWrapper {
+  private filteredEmitter: WebAgentEventEmitter | null = null;
+  private handleEvent: ((eventType: string, data: any) => void) | null = null;
+
+  initialize(emitter: WebAgentEventEmitter): void {
+    if (this.emitter) {
+      this.dispose();
+    }
+
+    this.emitter = emitter;
+    this.filteredEmitter = new WebAgentEventEmitter();
+
+    // Create bound handler for cleanup
+    this.handleEvent = (eventType: string, data: any) => {
+      const transformedData = this.transformData(eventType as WebAgentEventType, data);
+      this.filteredEmitter!.emit(eventType, transformedData);
+    };
+
+    // Listen to wildcard event to intercept all events
+    emitter.on("*", this.handleEvent);
+
+    // Initialize wrapped logger with filtered emitter
+    this.wrappedLogger.initialize(this.filteredEmitter);
+  }
+
+  dispose(): void {
+    if (this.emitter && this.handleEvent) {
+      this.emitter.off("*", this.handleEvent);
+      this.wrappedLogger.dispose();
+      this.emitter = null;
+      this.filteredEmitter = null;
+      this.handleEvent = null;
+    }
+  }
+
+  /**
+   * Transform event data before passing it to the wrapped logger.
+   *
+   * @param eventType - The type of event being processed
+   * @param data - The original event data
+   * @returns The transformed event data
+   */
+  protected abstract transformData(eventType: WebAgentEventType, data: any): any;
+}

--- a/src/loggers/secretsRedactor.ts
+++ b/src/loggers/secretsRedactor.ts
@@ -1,0 +1,33 @@
+import { LoggerFilter } from "./filter.js";
+import { WebAgentEvent, WebAgentEventType } from "../events.js";
+
+export type WebAgentEventDataForWebAgentEventType<T extends WebAgentEventType> = Extract<
+  WebAgentEvent,
+  { type: T }
+>["data"];
+
+export type WebAgentEventDataFields = {
+  [K in WebAgentEventType]?: (keyof WebAgentEventDataForWebAgentEventType<K>)[];
+};
+
+export const SECRET_FIELDS_BY_EVENT_TYPE: WebAgentEventDataFields = {
+  [WebAgentEventType.TASK_SETUP]: ["pwEndpoint", "pwCdpEndpoint"],
+} as const;
+
+export class SecretsRedactor extends LoggerFilter {
+  protected transformData(eventType: WebAgentEventType, data: any): any {
+    const secretFields = SECRET_FIELDS_BY_EVENT_TYPE[eventType];
+    if (!secretFields || secretFields.length === 0) {
+      return data;
+    }
+
+    // Create shallow copy to avoid mutating original
+    const redacted = { ...data };
+    for (const field of secretFields) {
+      if (field in redacted && typeof redacted[field] === "string" && redacted[field] !== "") {
+        redacted[field] = "(redacted)";
+      }
+    }
+    return redacted;
+  }
+}

--- a/src/loggers/wrapper.ts
+++ b/src/loggers/wrapper.ts
@@ -3,7 +3,7 @@ import { Logger } from "./types.js";
 
 export class LoggerWrapper implements Logger {
   protected emitter: WebAgentEventEmitter | null = null;
-  private wrappedLogger: Logger;
+  protected wrappedLogger: Logger;
 
   constructor(wrappedLogger: Logger) {
     this.wrappedLogger = wrappedLogger;

--- a/test/secretsRedactor.test.ts
+++ b/test/secretsRedactor.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { SecretsRedactor } from "../src/loggers/secretsRedactor.js";
+import { WebAgentEventEmitter, WebAgentEventType } from "../src/events.js";
+import type { TaskSetupEventData, TaskStartEventData } from "../src/events.js";
+import type { Logger } from "../src/loggers/types.js";
+
+describe("SecretsRedactor", () => {
+  let redactor: SecretsRedactor;
+  let originalEmitter: WebAgentEventEmitter;
+  let mockLogger: Logger;
+  let capturedEvents: Array<{ type: string; data: any }>;
+
+  beforeEach(() => {
+    capturedEvents = [];
+
+    // Create a mock logger that captures events
+    let listener: ((eventType: string, data: any) => void) | undefined;
+    let emitterRef: WebAgentEventEmitter | undefined;
+    mockLogger = {
+      initialize: vi.fn((emitter: WebAgentEventEmitter) => {
+        listener = (eventType: string, data: any) => {
+          capturedEvents.push({ type: eventType, data });
+        };
+        emitterRef = emitter;
+        emitter.on("*", listener);
+      }),
+      dispose: vi.fn(() => {
+        if (emitterRef && listener) {
+          emitterRef.off("*", listener);
+        }
+        emitterRef = undefined;
+        listener = undefined;
+      }),
+    };
+
+    originalEmitter = new WebAgentEventEmitter();
+    redactor = new SecretsRedactor(mockLogger);
+    redactor.initialize(originalEmitter);
+  });
+
+  afterEach(() => {
+    redactor.dispose();
+  });
+
+  describe("Secret redaction", () => {
+    it("should redact pwEndpoint from TASK_SETUP events", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: "ws://localhost:9222/devtools/browser/secret-id",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].type).toBe(WebAgentEventType.TASK_SETUP);
+      expect(capturedEvents[0].data.pwEndpoint).toBe("(redacted)");
+    });
+
+    it("should redact pwCdpEndpoint from TASK_SETUP events", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwCdpEndpoint: "http://localhost:9222/secret-cdp-endpoint",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].type).toBe(WebAgentEventType.TASK_SETUP);
+      expect(capturedEvents[0].data.pwCdpEndpoint).toBe("(redacted)");
+    });
+
+    it("should redact multiple secret fields simultaneously", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: "ws://localhost:9222/devtools/browser/secret-id",
+        pwCdpEndpoint: "http://localhost:9222/secret-cdp-endpoint",
+        proxy: "http://proxy.example.com:8080",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].data.pwEndpoint).toBe("(redacted)");
+      expect(capturedEvents[0].data.pwCdpEndpoint).toBe("(redacted)");
+    });
+
+    it("should not redact undefined secret fields", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: undefined,
+        pwCdpEndpoint: undefined,
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].data.pwEndpoint).toBeUndefined();
+      expect(capturedEvents[0].data.pwCdpEndpoint).toBeUndefined();
+    });
+
+    it("should not redact empty string secret fields", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: "",
+        pwCdpEndpoint: "",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].data.pwEndpoint).toBe("");
+      expect(capturedEvents[0].data.pwCdpEndpoint).toBe("");
+    });
+  });
+
+  describe("Data preservation", () => {
+    it("should preserve non-secret fields from TASK_SETUP events", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: 12345,
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        vision: true,
+        proxy: "http://proxy.example.com:8080",
+        pwEndpoint: "ws://localhost:9222/secret",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      const capturedData = capturedEvents[0].data;
+      expect(capturedData.timestamp).toBe(12345);
+      expect(capturedData.iterationId).toBe("test-1");
+      expect(capturedData.task).toBe("Test task");
+      expect(capturedData.browserName).toBe("playwright:firefox");
+      expect(capturedData.vision).toBe(true);
+      expect(capturedData.proxy).toBe("http://proxy.example.com:8080");
+    });
+
+    it("should not mutate original event data", () => {
+      const eventData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: "ws://localhost:9222/secret",
+      };
+
+      const originalPwEndpoint = eventData.pwEndpoint;
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: eventData,
+      });
+
+      // Original data should not be mutated
+      expect(eventData.pwEndpoint).toBe(originalPwEndpoint);
+
+      // But captured data should be redacted
+      expect(capturedEvents[0].data.pwEndpoint).toBe("(redacted)");
+    });
+  });
+
+  describe("Pass-through for non-secret events", () => {
+    it("should pass through events with no secret fields unchanged", () => {
+      const eventData: TaskStartEventData = {
+        timestamp: 12345,
+        iterationId: "test-1",
+        task: "Test task",
+        successCriteria: "Test criteria",
+        plan: "Test plan",
+        url: "https://example.com",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_STARTED,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].type).toBe(WebAgentEventType.TASK_STARTED);
+      expect(capturedEvents[0].data).toEqual(eventData);
+    });
+
+    it("should handle event types not in SECRET_FIELDS_BY_EVENT", () => {
+      const eventData: TaskStartEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        successCriteria: "Test criteria",
+        plan: "Test plan",
+        url: "https://example.com",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_STARTED,
+        data: eventData,
+      });
+
+      expect(capturedEvents).toHaveLength(1);
+      expect(capturedEvents[0].data).toEqual(eventData);
+    });
+  });
+
+  describe("Multiple events", () => {
+    it("should handle multiple events correctly", () => {
+      const setupData: TaskSetupEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        browserName: "playwright:firefox",
+        pwEndpoint: "ws://localhost:9222/secret",
+      };
+
+      const startData: TaskStartEventData = {
+        timestamp: Date.now(),
+        iterationId: "test-1",
+        task: "Test task",
+        successCriteria: "Test criteria",
+        plan: "Test plan",
+        url: "https://example.com",
+      };
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_SETUP,
+        data: setupData,
+      });
+
+      originalEmitter.emitEvent({
+        type: WebAgentEventType.TASK_STARTED,
+        data: startData,
+      });
+
+      expect(capturedEvents).toHaveLength(2);
+
+      // First event should have redacted secrets
+      expect(capturedEvents[0].type).toBe(WebAgentEventType.TASK_SETUP);
+      expect(capturedEvents[0].data.pwEndpoint).toBe("(redacted)");
+
+      // Second event should pass through unchanged
+      expect(capturedEvents[1].type).toBe(WebAgentEventType.TASK_STARTED);
+      expect(capturedEvents[1].data).toEqual(startData);
+    });
+  });
+});


### PR DESCRIPTION
Implemented a new logger filtering system that allows event transformation before reaching loggers, with initial support for redacting sensitive fields from event data.

SecretsRedactor
- Extends LoggerFilter to redact sensitive fields from events
- Type-safe field mapping via WebAgentEventDataFields type
- Currently redacts pwEndpoint and pwCdpEndpoint from TASK_SETUP events
- Creates shallow copy to avoid mutating original event data
- Only redacts non-empty, defined values

CLI changes
- Wraps loggers with SecretsRedactor in logger chain
- Architecture: MetricsCollector -> SecretsRedactor -> (JSON|Chalk)Logger
- Ensures secrets are redacted before any logging output

LoggerFilter
- Provides generic event interception and transformation pattern
- Intercepts all events via wildcard listener on original emitter
- Creates separate filtered emitter for transformed events
- Subclasses implement `transformData()` for custom transformations
- Enables composable event processing pipeline

LoggerWrapper
- Changed wrappedLogger from private to protected
- Allows LoggerFilter subclass to access wrapped logger