### PR TITLE
Avoid alarming users with irrelevant recoverable errors

### DIFF
--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -35,6 +35,40 @@ interface ChatViewProps {
 }
 
 /**
+ * Maximum number of validation retries before showing error to user.
+ * Validation errors below this threshold are considered recoverable
+ * and are handled automatically by the agent.
+ */
+const MAX_VALIDATION_RETRIES = 3;
+
+/**
+ * Determines whether an error event should be displayed to the user.
+ * Filters out non-fatal errors that are handled automatically by the agent.
+ *
+ * Non-user-facing errors include:
+ * - Validation errors during retry attempts (below MAX_VALIDATION_RETRIES)
+ * - Recoverable browser action errors (agent will retry automatically)
+ *
+ * @param eventType - The type of error event
+ * @param data - The error event data
+ * @returns true if error should be shown to user, false otherwise
+ */
+export function shouldDisplayError(eventType: string, data: any): boolean {
+  // Filter validation errors during retries
+  if (eventType === "task:validation_error") {
+    return data.retryCount >= MAX_VALIDATION_RETRIES;
+  }
+
+  // Filter recoverable browser action errors
+  if (eventType === "browser:action:completed" && data.success === false) {
+    return !data.isRecoverable;
+  }
+
+  // Show all other errors by default
+  return true;
+}
+
+/**
  * Renders markdown with marked-react which provides better security by preventing XSS attacks through
  * HTML injection. The component supports GitHub Flavored Markdown (GFM) and handles
  * line breaks properly.
@@ -270,21 +304,23 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
           addMessage("error", `AI Error: ${typedMessage.event.data.error}`, currentTaskId);
         }
 
-        // Handle validation errors
+        // Handle validation errors (only show if max retries exceeded)
         if (
           typedMessage.event.type === "task:validation_error" &&
           typedMessage.event.data?.errors &&
-          currentTaskId
+          currentTaskId &&
+          shouldDisplayError(typedMessage.event.type, typedMessage.event.data)
         ) {
           const errorMessages = typedMessage.event.data.errors.join(", ");
           addMessage("error", `Validation Error: ${errorMessages}`, currentTaskId);
         }
 
-        // Handle browser action result failures
+        // Handle browser action result failures (only show non-recoverable errors)
         if (
           typedMessage.event.type === "browser:action:completed" &&
           typedMessage.event.data?.success === false &&
-          currentTaskId
+          currentTaskId &&
+          shouldDisplayError(typedMessage.event.type, typedMessage.event.data)
         ) {
           const errorText = typedMessage.event.data.error || "Browser action failed";
           addMessage("error", `Action Failed: ${errorText}`, currentTaskId);

--- a/src/tools/webActionTools.ts
+++ b/src/tools/webActionTools.ts
@@ -78,14 +78,15 @@ async function performActionWithValidation(
 
     return { success: true, action, ...(ref && { ref }), ...(value !== undefined && { value }) };
   } catch (error) {
-    // Emit failure
-    context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-      success: false,
-      action,
-    });
-
-    // For browser exceptions, return error info with recoverable flag
+    // For browser exceptions, emit failure with error details and return error info
     if (error instanceof BrowserException) {
+      context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+        success: false,
+        action,
+        error: error.message,
+        isRecoverable: true,
+      });
+
       return {
         success: false,
         action,
@@ -96,7 +97,12 @@ async function performActionWithValidation(
       };
     }
 
-    // Re-throw non-browser errors
+    // For non-browser errors, emit failure without recoverable flag and re-throw
+    context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+      success: false,
+      action,
+    });
+
     throw error;
   }
 }

--- a/src/webAgent.ts
+++ b/src/webAgent.ts
@@ -665,7 +665,12 @@ export class WebAgent {
     // Process tool results
     if (!aiResponse?.toolResults?.length) {
       console.error("[WebAgent] No tools called in action generation");
-      throw new Error("You must use exactly one tool. Please use one of the available tools.");
+      throw new ToolExecutionError(
+        "You must use exactly one tool. Please use one of the available tools.",
+        {
+          action: "none",
+        },
+      );
     }
 
     const toolResult = aiResponse.toolResults[0];

--- a/test/tools/webActionTools.test.ts
+++ b/test/tools/webActionTools.test.ts
@@ -221,6 +221,23 @@ describe("Web Action Tools", () => {
       expect(result.isRecoverable).toBe(true);
     });
 
+    it("should emit BROWSER_ACTION_COMPLETED with isRecoverable and error on browser exception", async () => {
+      const emitSpy = vi.spyOn(eventEmitter, "emit");
+      vi.spyOn(mockBrowser, "performAction").mockRejectedValueOnce(
+        new BrowserActionException("click", "Element is not clickable"),
+      );
+
+      await tools.click.execute({ ref: "btn1" });
+
+      // Should emit BROWSER_ACTION_COMPLETED with error details
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+        success: false,
+        action: "click",
+        error: "Element is not clickable",
+        isRecoverable: true,
+      });
+    });
+
     it("should re-throw non-browser errors", async () => {
       vi.spyOn(mockBrowser, "performAction").mockRejectedValueOnce(new Error("Network error"));
 

--- a/test/webAgent.test.ts
+++ b/test/webAgent.test.ts
@@ -1287,6 +1287,7 @@ describe("WebAgent", () => {
       );
       expect(errorEvent).toBeDefined();
       expect(errorEvent?.data.error).toContain("You must use exactly one tool");
+      expect(errorEvent?.data.isToolError).toBe(true); // Should be marked as tool error for UI filtering
     });
 
     it("should handle tool result without output property", async () => {


### PR DESCRIPTION
A variety of non-fatal errors are surfaced to the end user, which is confusing because there's nothing the user can or should do about them, and they will be retried automatically.  This hides those errors. We may ultimately want to have some sort of status about things since it's taking time, but right now, it's just unnecessarily alarming so we can at least get rid of that.