### PR TITLE
Improve received background thread message logging

### DIFF
--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -63,16 +63,17 @@ export default defineBackground(() => {
       return Promise.resolve({ success: false, message: "Invalid message format" });
     }
 
+    const typedMessage = message as ExtensionMessage;
+
     // Handle realtimeEvent messages immediately - just ignore them
-    if ((message as any).type === "realtimeEvent") {
+    if (typedMessage.type === "realtimeEvent") {
       // These are meant for sidepanel consumption, not background handling
-      console.log("Background received message: realtimeEvent");
+      console.log("Background received message: realtimeEvent", typedMessage.event);
       // Return undefined to indicate no response
       return;
     }
 
-    const typedMessage = message as ExtensionMessage;
-    console.log("Background received message:", typedMessage.type);
+    console.log("Background received message:", typedMessage.type, typedMessage);
 
     // Return a Promise for async processing
     return (async () => {

--- a/extension/src/types/browser.ts
+++ b/extension/src/types/browser.ts
@@ -58,8 +58,18 @@ export interface CancelTaskResponse {
   message?: string;
 }
 
+export interface RealtimeEventMessage {
+  type: "realtimeEvent";
+  event: {
+    type: string;
+    data: any;
+    timestamp: number;
+  };
+}
+
 export type ExtensionMessage =
   | ExecuteTaskMessage
   | GetPageInfoMessage
   | ExecutePageActionMessage
-  | CancelTaskMessage;
+  | CancelTaskMessage
+  | RealtimeEventMessage;


### PR DESCRIPTION
Make the extension logs much more informative by logging the event from each message received on the background thread.