### PR TITLE
Avoid WebExt task aborts w/longer thread message timeout

### DIFF
--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -394,9 +394,13 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
       console.log("Sending message to background script:", message);
 
       // Add timeout to prevent hanging in Firefox
+      // XXXdmose Ultimately, we should make this abort anything that's in
+      // flight; likely using the handleCancel function, perhaps with a few
+      // tweaks (ie clean and clear presentation to the user). It could be that
+      // once we add status events in, we should drop the number back down.
       const messagePromise = browser.runtime.sendMessage(message);
       const timeoutPromise = new Promise(
-        (_, reject) => setTimeout(() => reject(new Error("Background script timeout")), 60000), // 60 second timeout
+        (_, reject) => setTimeout(() => reject(new Error("Background script timeout")), 300000), // 5 mins
       );
 
       let response: ExecuteTaskResponse;


### PR DESCRIPTION
Because we're currently not sending status events back to the main thread (and we've removed sending the alarming non-fatal errors, at least for the moment), tasks often timeout after having not heard anything from the background thread for 60 seconds. 

Bumping this up to 5 minutes, at least for now.

Once we start getting regular status events back, we will probably want to ratchet this back down or perhaps even do something else if we don't hear back after a while. 

