### PR TITLE
Set a conservative cooldown period for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    cooldown:
+      default-days: 14
     open-pull-requests-limit: 10
     versioning-strategy: increase


### PR DESCRIPTION
Adds a dependabot setting to wait at least 14 days between version updates - but not security updates.

This seems to be a good idea for riding out potential supply chain attacks

See also:
- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-