### PR TITLE
GitHub Actions workflow for automated Spark evaluations

### DIFF
--- a/.github/workflows/submit_eval.yml
+++ b/.github/workflows/submit_eval.yml
@@ -1,0 +1,95 @@
+name: Submit Spark Evals Workflow
+
+on:
+  push:
+    branches:
+      - "evals/**"
+  pull_request:
+    branches:
+      - "evals/**"
+
+permissions:
+  contents: read
+  statuses: write # Required for updating commit status via GitHub API
+
+jobs:
+  build-spark-server-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.EVALS_GCP_SA_KEY }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Configure Docker for GCR
+        run: |
+          gcloud auth configure-docker gcr.io
+
+      - name: Build and Push Spark Server Image
+        env:
+          PROJECT_ID: ${{ vars.EVALS_GCP_PROJECT_ID }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          echo "Building Spark server image with tag: $IMAGE_TAG"
+
+          docker build \
+            --platform linux/amd64 \
+            -f ./server/Dockerfile \
+            -t spark-server:$IMAGE_TAG \
+            .
+
+          docker tag spark-server:$IMAGE_TAG gcr.io/$PROJECT_ID/spark-server:$IMAGE_TAG
+          docker push gcr.io/$PROJECT_ID/spark-server:$IMAGE_TAG
+
+          echo "✅ Image pushed to gcr.io/$PROJECT_ID/spark-server:$IMAGE_TAG"
+
+  submit-evals-workflow:
+    needs: build-spark-server-image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.EVALS_GCP_SA_KEY }}
+
+      - name: Activate Service Account for gcloud/gsutil
+        run: |
+          # Activate the service account so gcloud/gsutil can use it
+          gcloud auth activate-service-account --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+          gcloud config set project ${{ vars.EVALS_GCP_PROJECT_ID }}
+
+      - name: Get GKE Credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ vars.EVALS_GKE_CLUSTER_NAME }}
+          location: ${{ vars.EVALS_GKE_CLUSTER_ZONE }}
+
+      - name: Submit Argo Workflow
+        id: submit
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_REF: ${{ github.ref }}
+          HEAD_COMMIT_TIMESTAMP: ${{ github.event.head_commit.timestamp }}
+        run: |
+          ./scripts/evals/submit-eval-workflow.sh
+
+      - name: Wait for Workflow Completion
+        run: |
+          ./scripts/evals/wait-for-workflow.sh
+
+      - name: Cleanup GitHub Token Secret
+        if: always()
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+        run: |
+          ./scripts/evals/cleanup-secrets.sh

--- a/scripts/evals/cleanup-secrets.sh
+++ b/scripts/evals/cleanup-secrets.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to cleanup temporary GitHub token secrets created for Argo workflows
+# Expected environment variables:
+#   GITHUB_RUN_ID - GitHub Actions run ID used for secret naming
+
+# Validate required environment variables
+if [[ -z "${GITHUB_RUN_ID:-}" ]]; then
+  echo "Error: Required environment variable GITHUB_RUN_ID is not set"
+  exit 1
+fi
+
+echo "Cleaning up GitHub token secret..."
+# Clean up the temporary secret after workflow submission
+kubectl delete secret "github-token-${GITHUB_RUN_ID}" -n argo --ignore-not-found=true
+
+echo "✅ Cleanup complete"

--- a/scripts/evals/submit-eval-workflow.sh
+++ b/scripts/evals/submit-eval-workflow.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to submit an Argo workflow for Spark evaluations
+#
+# This script dynamically determines which eval input file to use based on the branch name.
+# Branch naming convention: evals/{eval-name}/{suffix}
+#   - evals/partial/my-test → eval-inputs/partial.jsonl
+#   - evals/full/experiment → eval-inputs/full.jsonl
+#
+# The script validates that the eval input file exists in GCS before submitting.
+#
+# Expected environment variables:
+#   GITHUB_RUN_ID - GitHub Actions run ID for secret naming
+#   GITHUB_TOKEN - GitHub token for status updates
+#   GITHUB_REPOSITORY - Repository name (owner/repo)
+#   GITHUB_SHA - Git commit SHA
+#   GITHUB_REF - Git ref (branch/tag) - must match pattern evals/{eval-name}/*
+#   HEAD_COMMIT_TIMESTAMP - Timestamp of the head commit
+#
+# Optional environment variables:
+#   GCS_BUCKET - GCS bucket name (default: spark-eval-artifacts)
+
+# Validate required environment variables
+required_vars=(
+  "GITHUB_RUN_ID"
+  "GITHUB_TOKEN"
+  "GITHUB_REPOSITORY"
+  "GITHUB_SHA"
+  "GITHUB_REF"
+  "HEAD_COMMIT_TIMESTAMP"
+)
+
+for var in "${required_vars[@]}"; do
+  if [[ -z "${!var:-}" ]]; then
+    echo "Error: Required environment variable $var is not set"
+    exit 1
+  fi
+done
+
+# Parse branch name to determine eval input file
+# Expected format: refs/heads/evals/{eval-name}/{suffix}
+# Example: refs/heads/evals/partial/test → eval-inputs/partial.jsonl
+echo "Parsing branch name: $GITHUB_REF"
+
+if [[ "$GITHUB_REF" =~ ^refs/heads/evals/([^/]+)/ ]]; then
+  EVAL_NAME="${BASH_REMATCH[1]}"
+  export EVALUATIONS_GCS_KEY="eval-inputs/${EVAL_NAME}.jsonl"
+  echo "✓ Detected eval type: $EVAL_NAME"
+  echo "✓ Using GCS key: $EVALUATIONS_GCS_KEY"
+else
+  echo "Error: Branch name does not match expected pattern 'evals/{eval-name}/*'"
+  echo "Current branch: $GITHUB_REF"
+  echo "Expected format: refs/heads/evals/{eval-name}/{suffix}"
+  echo "Example: refs/heads/evals/partial/my-test"
+  exit 1
+fi
+
+# Validate that the eval input file exists in GCS
+GCS_BUCKET="${GCS_BUCKET:-spark-eval-artifacts}"
+GCS_PATH="gs://${GCS_BUCKET}/${EVALUATIONS_GCS_KEY}"
+
+echo "Validating eval input file exists: $GCS_PATH"
+if ! gsutil ls "$GCS_PATH" &>/dev/null; then
+  echo "Error: Eval input file not found in GCS"
+  echo "Expected: $GCS_PATH"
+  echo ""
+  echo "Available eval input files:"
+  gsutil ls "gs://${GCS_BUCKET}/eval-inputs/" 2>/dev/null || echo "  (none found or no access)"
+  echo ""
+  echo "To upload your eval file:"
+  echo "  gsutil cp your-tasks.jsonl $GCS_PATH"
+  exit 1
+fi
+
+echo "✓ Eval input file exists: $GCS_PATH"
+
+echo "Creating GitHub token secret for workflow..."
+# Create a Kubernetes secret with the GitHub token for this workflow
+kubectl create secret generic "github-token-${GITHUB_RUN_ID}" \
+  -n argo \
+  --from-literal="token=${GITHUB_TOKEN}"
+
+echo "Submitting Argo workflow..."
+# Get the directory where this script lives
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Use envsubst to substitute environment variables in the template
+envsubst < "$SCRIPT_DIR/templates/eval-workflow.yaml" | kubectl create -f -
+
+echo "✅ Workflow submitted successfully"
+
+# Get the workflow name
+WORKFLOW_NAME=$(kubectl get workflows -n argo --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
+echo "Workflow name: $WORKFLOW_NAME"
+echo "View in Argo UI:"
+echo "kubectl -n argo port-forward service/argo-server 2746:2746"
+echo "https://localhost:2746/workflows/argo/$WORKFLOW_NAME"
+
+# Export workflow name for subsequent steps
+echo "WORKFLOW_NAME=${WORKFLOW_NAME}" >> "$GITHUB_OUTPUT"

--- a/scripts/evals/templates/eval-workflow.yaml
+++ b/scripts/evals/templates/eval-workflow.yaml
@@ -1,0 +1,37 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Workflow
+metadata:
+  generateName: spark-batch-github-eval-
+  namespace: argo
+spec:
+  workflowTemplateRef:
+    name: spark-batch-eval-from-file
+  arguments:
+    parameters:
+      # Use regular nodes for CI/CD reliability (no preemption)
+      - name: node-type
+        value: "regular"
+      - name: evaluations-gcs-key
+        value: "${EVALUATIONS_GCS_KEY}"
+      # Agent configuration
+      - name: agent-type
+        value: "spark"
+      - name: agent-version
+        value: "${GITHUB_SHA}"
+      # Agent build metadata
+      - name: agent-build-id
+        value: "${GITHUB_SHA}"
+      - name: agent-build-date
+        value: "${HEAD_COMMIT_TIMESTAMP}"
+      # GitHub context for status updates
+      - name: github-repo
+        value: "${GITHUB_REPOSITORY}"
+      - name: github-sha
+        value: "${GITHUB_SHA}"
+      - name: github-ref
+        value: "${GITHUB_REF}"
+      - name: github-run-id
+        value: "${GITHUB_RUN_ID}"
+      # Secret name containing GitHub token
+      - name: github-token-secret
+        value: "github-token-${GITHUB_RUN_ID}"

--- a/scripts/evals/wait-for-workflow.sh
+++ b/scripts/evals/wait-for-workflow.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+set -euo pipefail
+
+# Script to wait for an Argo workflow to complete
+# Expected environment variables:
+#   WORKFLOW_NAME - Name of the Argo workflow to monitor
+# Optional environment variables:
+#   TIMEOUT - Maximum time to wait in seconds (default: 3600)
+#   INTERVAL - Polling interval in seconds (default: 10)
+#   MAX_RETRIES - Maximum retries for transient errors (default: 3)
+
+# Get workflow name from environment or command line
+WORKFLOW_NAME="${WORKFLOW_NAME:-$(kubectl get workflows -n argo --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')}"
+echo "Waiting for workflow $WORKFLOW_NAME to complete..."
+
+# Configuration with defaults
+TIMEOUT="${TIMEOUT:-3600}"
+INTERVAL="${INTERVAL:-10}"
+MAX_RETRIES="${MAX_RETRIES:-3}"
+
+# Wait for workflow to complete
+ELAPSED=0
+
+while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+  # Get workflow status details with retry on transient errors
+  PHASE=""
+  RETRY_COUNT=0
+
+  while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; do
+    if WORKFLOW_JSON=$(kubectl get workflow -n argo "$WORKFLOW_NAME" -o json 2>&1); then
+      # Successfully got workflow data
+      PHASE=$(echo "$WORKFLOW_JSON" | jq -r '.status.phase // ""')
+      PROGRESS=$(echo "$WORKFLOW_JSON" | jq -r '.status.progress // ""')
+      MESSAGE=$(echo "$WORKFLOW_JSON" | jq -r '.status.message // ""')
+      SUCCEEDED=$(echo "$WORKFLOW_JSON" | jq '[.status.nodes // {} | .[] | select(.phase=="Succeeded")] | length')
+      FAILED=$(echo "$WORKFLOW_JSON" | jq '[.status.nodes // {} | .[] | select(.phase=="Failed")] | length')
+      RUNNING=$(echo "$WORKFLOW_JSON" | jq '[.status.nodes // {} | .[] | select(.phase=="Running")] | length')
+      break
+    else
+      # kubectl command failed, retry after a brief delay
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+      if [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ]; then
+        echo "⚠️  Transient API error (attempt $RETRY_COUNT/$MAX_RETRIES), retrying..."
+        sleep 2
+      else
+        echo "❌ Failed to get workflow status after $MAX_RETRIES attempts"
+        echo "Error: $WORKFLOW_JSON"
+        exit 1
+      fi
+    fi
+  done
+
+  # Build status line
+  STATUS_LINE="[$ELAPSED s] Phase: $PHASE"
+  if [ -n "$PROGRESS" ]; then
+    STATUS_LINE="$STATUS_LINE | Progress: $PROGRESS"
+  fi
+  STATUS_LINE="$STATUS_LINE | ✅ $SUCCEEDED | ❌ $FAILED | ⚙️  $RUNNING"
+  if [ -n "$MESSAGE" ]; then
+    STATUS_LINE="$STATUS_LINE | $MESSAGE"
+  fi
+
+  echo "$STATUS_LINE"
+
+  if [ "$PHASE" = "Succeeded" ]; then
+    echo "✅ Workflow completed successfully!"
+    exit 0
+  elif [ "$PHASE" = "Failed" ] || [ "$PHASE" = "Error" ]; then
+    echo "❌ Workflow failed with phase: $PHASE"
+    echo "View logs with: kubectl logs -n argo -l workflows.argoproj.io/workflow=$WORKFLOW_NAME"
+    exit 1
+  fi
+
+  sleep "$INTERVAL"
+  ELAPSED=$((ELAPSED + INTERVAL))
+done
+
+echo "⏱️ Workflow timed out after ${TIMEOUT}s"
+# Final status check with retry
+FINAL_PHASE=$(kubectl get workflow -n argo "$WORKFLOW_NAME" -o jsonpath='{.status.phase}' 2>/dev/null || echo "unknown")
+echo "Current phase: $FINAL_PHASE"
+exit 1


### PR DESCRIPTION
Add CI/CD pipeline that automatically submits eval jobs to Argo Workflows on GKE when pushing to evals/* branches. The workflow:

- Builds and pushes Spark server Docker image to GCR
- Determines eval set based on branch name convention (evals/{eval-name}/*)
- Submits Argo workflow with appropriate parameters
- Monitors workflow execution and reports status
- Cleans up temporary secrets after completion

Branch naming convention:
  evals/partial/* → runs eval-inputs/partial.jsonl
  evals/full/*    → runs eval-inputs/full.jsonl

Scripts:
- submit-eval-workflow.sh: handles workflow submission with GCS validation
- wait-for-workflow.sh: polls workflow status with retry logic
- cleanup-secrets.sh: removes temporary GitHub token secrets
- templates/eval-workflow.yaml: Argo workflow template with envsubst

The workflow uses restricted RBAC and runs on regular (non-preemptible) nodes for reliability. Agent build metadata is passed to enable tracking eval results back to specific commits.