### PR TITLE
Visual cleanup of add-on assistant messages using @tailwindcss/typography

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -43,6 +43,7 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/extension/src/ChatMessage.tsx
+++ b/extension/src/ChatMessage.tsx
@@ -1,4 +1,7 @@
 import type { ReactElement } from "react";
+
+import clsx from "clsx";
+
 import type { Theme } from "./theme";
 
 import type { ChatMessage } from "./hooks/useConversation";
@@ -36,21 +39,40 @@ export function ChatMessage({
   isStreaming,
   reasoning,
 }: ChatMessageProps): ReactElement {
-  const isUser = type === "user";
-  const isSystem = type === "system";
+  let liClass = "";
+  let divClass = "";
+
+  switch (type) {
+    case "user":
+      liClass = "flex mb-4 justify-end";
+      divClass = clsx(
+        "px-4 py-2 rounded-lg max-w-xs lg:max-w-md",
+        t.bg.primary,
+        t.text.primary,
+        "border",
+        t.border.primary,
+      );
+      break;
+    case "system":
+      liClass = "flex mb-4";
+      divClass = clsx("px-4 py-2 rounded-lg w-full", t.bg.tertiary, t.text.muted);
+      break;
+    case "assistant":
+      liClass = "flex mb-4 justify-start";
+      divClass = clsx(
+        "px-4 py-2 rounded-lg max-w-xs lg:max-w-md",
+        t.bg.secondary,
+        t.text.primary,
+        "border",
+        t.border.primary,
+      );
+      break;
+  }
 
   return (
-    <li className={`flex ${isUser ? "justify-end" : "justify-start"} mb-4`}>
-      <div
-        className={`max-w-xs lg:max-w-md px-4 py-2 rounded-lg ${
-          isUser
-            ? `${t.bg.primary} ${t.text.primary} border ${t.border.primary}`
-            : isSystem
-              ? `${t.bg.tertiary} ${t.text.muted} border ${t.border.primary}`
-              : `${t.bg.secondary} ${t.text.primary} border ${t.border.primary}`
-        }`}
-      >
-        {!isUser && !isSystem && (
+    <li className={liClass}>
+      <div className={divClass}>
+        {type === "assistant" && (
           <div className="flex items-center gap-2 mb-1">
             <span className="text-lg">⚡</span>
             <span className={`text-xs font-medium ${t.text.secondary}`}>Spark</span>
@@ -72,7 +94,7 @@ export function ChatMessage({
         {/* Show content if not streaming or if streaming is finished */}
         {(!isStreaming || content) && (
           <div
-            className={`${isUser ? "text-message-user" : "text-message-assistant"} whitespace-pre-wrap`}
+            className={`${type === "user" ? "text-message-user" : "text-message-assistant"} whitespace-pre-wrap`}
           >
             {renderContent(content)}
           </div>

--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -92,7 +92,16 @@ interface MarkdownContentProps {
 }
 
 const MarkdownContent = ({ children, className }: MarkdownContentProps): ReactElement => (
-  <div className={clsx("markdown-content", className)}>
+  <div
+    className={clsx(
+      "markdown-content",
+      "prose",
+      "prose-base",
+      "prose-slate",
+      "max-w-none",
+      className,
+    )}
+  >
     <Markdown value={children} breaks gfm />
   </div>
 );
@@ -169,6 +178,8 @@ const TaskBubble = ({
 
   if (taskMessages.length === 0 && !latestStatus) return <></>;
 
+  const hasPlan = taskMessages.some((msg) => msg.type === "plan");
+
   // Track which section headings we've shown
   const seenTypes = new Set<string>();
 
@@ -188,11 +199,25 @@ const TaskBubble = ({
     }
   };
 
+  let liClass = "";
+  let divClass = "";
+
+  if (hasPlan) {
+    liClass = "flex mb-4";
+    divClass = clsx("w-full px-4 py-2 rounded-lg", t.bg.secondary, t.text.primary);
+  } else {
+    liClass = "flex mb-4 justify-start";
+    divClass = clsx(
+      "max-w-xs lg:max-w-md px-4 py-2 rounded-lg border",
+      t.bg.secondary,
+      t.text.primary,
+      t.border.primary,
+    );
+  }
+
   return (
-    <li className="flex justify-start mb-4">
-      <div
-        className={`max-w-xs lg:max-w-md px-4 py-2 rounded-lg ${t.bg.secondary} ${t.text.primary} border ${t.border.primary}`}
-      >
+    <li className={liClass}>
+      <div className={divClass}>
         {/* Header */}
         <div className="flex items-center gap-2 mb-1">
           <span className="text-lg">⚡</span>

--- a/extension/src/components/sidepanel/SidePanel.css
+++ b/extension/src/components/sidepanel/SidePanel.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
 
 /* Custom color tokens extending Tailwind's stone palette */
 @theme {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,9 @@ importers:
         specifier: ^5.0.8
         version: 5.0.8(@types/react@19.2.6)(react@19.2.0)(use-sync-external-store@1.5.0(react@19.2.0))
     devDependencies:
+      '@tailwindcss/typography':
+        specifier: ^0.5.19
+        version: 0.5.19(tailwindcss@4.1.17)
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
@@ -1309,6 +1312,11 @@ packages:
     resolution: {integrity: sha512-F0F7d01fmkQhsTjXezGBLdrl1KresJTcI3DB8EkScCldyKp3Msz4hub4uyYaVnk88BAS1g5DQjjF6F5qczheLA==}
     engines: {node: '>= 10'}
 
+  '@tailwindcss/typography@0.5.19':
+    resolution: {integrity: sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
+
   '@tailwindcss/vite@4.1.17':
     resolution: {integrity: sha512-4+9w8ZHOiGnpcGI6z1TVVfWaX/koK7fKeSYF3qlYg2xpBtbteP2ddBxiarL+HVgfSJGeK5RIxRQmKm4rTJJAwA==}
     peerDependencies:
@@ -1781,6 +1789,11 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   cssom@0.5.0:
     resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
@@ -2761,6 +2774,10 @@ packages:
     resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
     engines: {node: '>=18'}
     hasBin: true
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -4352,6 +4369,11 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.17
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.17
 
+  '@tailwindcss/typography@0.5.19(tailwindcss@4.1.17)':
+    dependencies:
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 4.1.17
+
   '@tailwindcss/vite@4.1.17(vite@7.2.2(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.1.17
@@ -4862,6 +4884,8 @@ snapshots:
   css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
+
+  cssesc@3.0.0: {}
 
   cssom@0.5.0: {}
 
@@ -5871,6 +5895,11 @@ snapshots:
       playwright-core: 1.56.1
     optionalDependencies:
       fsevents: 2.3.2
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss@8.5.6:
     dependencies:


### PR DESCRIPTION
* Made add-on ChatView spacing and indentation readable using @tailwindcss/typography
* Modified system message and task bubble layouts to conditionally use full width when displaying plans
* Make full-width system messages and plan-containing task bubbles borderless

Follow-on commits will clean up spacing and sizing of text itself.
