### PR TITLE
Add a `--channel` and `--executable-path` option to opt into WebDriver BiDi

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,9 @@ pnpm spark run "check shipping costs" --guardrails "don't submit any payment for
 ### Advanced Options
 
 ```bash
+# Run a vanilla Firefox with WebDriver BiDi as protocol
+pnpm spark run "test checkout flow" --channel moz-firefox
+
 # Chrome browser testing
 pnpm spark run "test checkout flow" --browser chrome --headless
 
@@ -330,6 +333,7 @@ Built with TypeScript, Playwright, and the Vercel AI SDK.
 | `--openai-api-key <key>`        | OpenAI API key                                             | -                | `--openai-api-key sk-...`               |
 | `--openrouter-api-key <key>`    | OpenRouter API key                                         | -                | `--openrouter-api-key sk-or-...`        |
 | `--browser <browser>`           | Browser (firefox, chrome, chromium, safari, webkit, edge)  | firefox          | `--browser chrome`                      |
+| `--channel <channel>`           | Browser channel (chrome, msedge, chrome-beta, moz-firefox) | -                | `--channel chrome-beta`                 |
 | `--headless`                    | Run browser in headless mode                               | false            | `--headless`                            |
 | `--debug`                       | Enable debug mode with snapshots                           | false            | `--debug`                               |
 | `--vision`                      | Enable vision capabilities                                 | false            | `--vision`                              |
@@ -369,6 +373,7 @@ All configuration options can be set via environment variables. Environment vari
 | `SPARK_OPENAI_COMPATIBLE_NAME`     | OpenAI-compatible provider name                            | -                           |
 | **Browser Configuration**          |                                                            |                             |
 | `SPARK_BROWSER`                    | Browser to use                                             | `--browser`                 |
+| `SPARK_CHANNEL`                    | Browser channel                                            | `--channel`                 |
 | `SPARK_HEADLESS`                   | Run headless (true/false)                                  | `--headless`                |
 | `SPARK_BLOCK_ADS`                  | Block ads (true/false)                                     | `--no-block-ads`            |
 | `SPARK_BLOCK_RESOURCES`            | Resources to block (comma-separated)                       | `--block-resources`         |

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ pnpm spark run "check shipping costs" --guardrails "don't submit any payment for
 # Run a vanilla Firefox with WebDriver BiDi as protocol
 pnpm spark run "test checkout flow" --channel moz-firefox
 
+# Use a specific browser executable
+pnpm spark run "test with custom Firefox" --executable-path /usr/bin/firefox
+
 # Chrome browser testing
 pnpm spark run "test checkout flow" --browser chrome --headless
 
@@ -334,6 +337,7 @@ Built with TypeScript, Playwright, and the Vercel AI SDK.
 | `--openrouter-api-key <key>`    | OpenRouter API key                                         | -                | `--openrouter-api-key sk-or-...`        |
 | `--browser <browser>`           | Browser (firefox, chrome, chromium, safari, webkit, edge)  | firefox          | `--browser chrome`                      |
 | `--channel <channel>`           | Browser channel (chrome, msedge, chrome-beta, moz-firefox) | -                | `--channel chrome-beta`                 |
+| `--executable-path <path>`      | Path to browser executable                                 | -                | `--executable-path /usr/bin/firefox`    |
 | `--headless`                    | Run browser in headless mode                               | false            | `--headless`                            |
 | `--debug`                       | Enable debug mode with snapshots                           | false            | `--debug`                               |
 | `--vision`                      | Enable vision capabilities                                 | false            | `--vision`                              |
@@ -374,6 +378,7 @@ All configuration options can be set via environment variables. Environment vari
 | **Browser Configuration**          |                                                            |                             |
 | `SPARK_BROWSER`                    | Browser to use                                             | `--browser`                 |
 | `SPARK_CHANNEL`                    | Browser channel                                            | `--channel`                 |
+| `SPARK_EXECUTABLE_PATH`            | Path to browser executable                                 | `--executable-path`         |
 | `SPARK_HEADLESS`                   | Run headless (true/false)                                  | `--headless`                |
 | `SPARK_BLOCK_ADS`                  | Block ads (true/false)                                     | `--no-block-ads`            |
 | `SPARK_BLOCK_RESOURCES`            | Resources to block (comma-separated)                       | `--block-resources`         |

--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -52,6 +52,7 @@ interface SparkTaskRequest {
   // Browser configuration overrides
   browser?: "firefox" | "chrome" | "chromium" | "safari" | "webkit" | "edge";
   channel?: string;
+  executablePath?: string;
   headless?: boolean;
   vision?: boolean;
   debug?: boolean;
@@ -124,6 +125,7 @@ spark.post("/run", async (c) => {
         const browserConfig = {
           browser: body.browser || serverConfig.browser || "firefox",
           channel: body.channel || serverConfig.channel,
+          executablePath: body.executablePath || serverConfig.executable_path,
           headless:
             body.headless !== undefined
               ? body.headless

--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -51,6 +51,7 @@ interface SparkTaskRequest {
 
   // Browser configuration overrides
   browser?: "firefox" | "chrome" | "chromium" | "safari" | "webkit" | "edge";
+  channel?: string;
   headless?: boolean;
   vision?: boolean;
   debug?: boolean;
@@ -122,6 +123,7 @@ spark.post("/run", async (c) => {
         // Merge server config with request overrides
         const browserConfig = {
           browser: body.browser || serverConfig.browser || "firefox",
+          channel: body.channel || serverConfig.channel,
           headless:
             body.headless !== undefined
               ? body.headless

--- a/src/browser/playwrightBrowser.ts
+++ b/src/browser/playwrightBrowser.ts
@@ -33,6 +33,8 @@ export interface PlaywrightBrowserOptions {
   bypassCSP?: boolean;
   /** Browser channel to use (e.g. 'chrome', 'msedge', 'chrome-beta', 'firefox') */
   channel?: string;
+  /** Path to a browser executable to use instead of the bundled browser (maps to launchOptions.executablePath) */
+  executablePath?: string;
   /** Run browser in headless mode (maps to launchOptions.headless) */
   headless?: boolean;
   /** Proxy server URL (http://host:port, https://host:port, socks5://host:port) */
@@ -148,6 +150,9 @@ export class PlaywrightBrowser implements AriaBrowser {
     }
     if (this.options.channel !== undefined) {
       launchOptions.channel = this.options.channel;
+    }
+    if (this.options.executablePath !== undefined) {
+      launchOptions.executablePath = this.options.executablePath;
     }
     if (this.options.proxyServer) {
       launchOptions.proxy = {

--- a/src/browser/playwrightBrowser.ts
+++ b/src/browser/playwrightBrowser.ts
@@ -29,20 +29,22 @@ export interface PlaywrightBrowserOptions {
   blockAds?: boolean;
   /** Block specific resource types to improve performance */
   blockResources?: Array<"image" | "stylesheet" | "font" | "media" | "manifest">;
-  /** Playwright endpoint URL to connect to remote browser */
-  pwEndpoint?: string;
-  /** Chrome DevTools Protocol endpoint URL (chromium browsers only) */
-  pwCdpEndpoint?: string;
-  /** Run browser in headless mode (maps to launchOptions.headless) */
-  headless?: boolean;
   /** Bypass Content Security Policy (maps to contextOptions.bypassCSP) */
   bypassCSP?: boolean;
+  /** Browser channel to use (e.g. 'chrome', 'msedge', 'chrome-beta', 'firefox') */
+  channel?: string;
+  /** Run browser in headless mode (maps to launchOptions.headless) */
+  headless?: boolean;
   /** Proxy server URL (http://host:port, https://host:port, socks5://host:port) */
   proxyServer?: string;
   /** Proxy authentication username */
   proxyUsername?: string;
   /** Proxy authentication password */
   proxyPassword?: string;
+  /** Chrome DevTools Protocol endpoint URL (chromium browsers only) */
+  pwCdpEndpoint?: string;
+  /** Playwright endpoint URL to connect to remote browser */
+  pwEndpoint?: string;
 }
 
 export interface ExtendedPlaywrightBrowserOptions extends PlaywrightBrowserOptions {
@@ -59,6 +61,7 @@ export interface ExtendedPlaywrightBrowserOptions extends PlaywrightBrowserOptio
  */
 export class PlaywrightBrowser implements AriaBrowser {
   public browserName: string;
+  public channel: string | undefined;
   private browser: PlaywrightOriginalBrowser | null = null;
   private context: BrowserContext | null = null;
   private page: Page | null = null;
@@ -69,6 +72,7 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   constructor(private options: ExtendedPlaywrightBrowserOptions = {}) {
     this.browserName = `playwright:${this.options.browser ?? "firefox"}`;
+    this.channel = this.options.channel ?? this.getDefaultChannel();
   }
 
   get pwEndpoint(): string | undefined {
@@ -84,6 +88,29 @@ export class PlaywrightBrowser implements AriaBrowser {
   }
 
   /**
+   * Get the default channel based on browser type
+   */
+  private getDefaultChannel(): string | undefined {
+    const browserType = this.options.browser ?? "firefox";
+
+    switch (browserType) {
+      case "edge":
+        // Edge uses the "msedge" channel in Playwright
+        return "msedge";
+      case "chrome":
+        return "chrome";
+      case "firefox":
+        return "firefox";
+      case "chromium":
+      case "safari":
+      case "webkit":
+      default:
+        // These browsers don't use channels or use bundled versions
+        return undefined;
+    }
+  }
+
+  /**
    * Maps Spark's top-level options into the appropriate Playwright options
    * Top-level options take precedence over Playwright options
    */
@@ -94,6 +121,7 @@ export class PlaywrightBrowser implements AriaBrowser {
   } {
     const launchOptions: LaunchOptions = {
       headless: false, // Spark default
+      channel: this.options.channel ?? this.getDefaultChannel(),
       ...this.options.launchOptions, // User-provided Playwright options
     };
 
@@ -117,6 +145,9 @@ export class PlaywrightBrowser implements AriaBrowser {
     }
     if (this.options.bypassCSP !== undefined) {
       contextOptions.bypassCSP = this.options.bypassCSP;
+    }
+    if (this.options.channel !== undefined) {
+      launchOptions.channel = this.options.channel;
     }
     if (this.options.proxyServer) {
       launchOptions.proxy = {
@@ -167,13 +198,13 @@ export class PlaywrightBrowser implements AriaBrowser {
         break;
 
       case "edge":
-        // Edge uses chromium with channel setting
+        // Edge uses chromium with channel setting (defaults to "msedge")
         if (this.options.pwCdpEndpoint) {
           this.browser = await chromium.connectOverCDP(this.options.pwCdpEndpoint, connectOptions);
         } else if (this.options.pwEndpoint) {
           this.browser = await chromium.connect(this.options.pwEndpoint, connectOptions);
         } else {
-          this.browser = await chromium.launch({ ...launchOptions, channel: "msedge" });
+          this.browser = await chromium.launch(launchOptions);
         }
         break;
 

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -42,6 +42,11 @@ export function createRunCommand(): Command {
       "Browser to use (firefox, chrome, chromium, safari, webkit, edge)",
       config.get("browser", "firefox"),
     )
+    .option(
+      "--channel <channel>",
+      "Browser channel to use (e.g., chrome, msedge, chrome-beta, moz-firefox)",
+      config.get("channel"),
+    )
     .option("--headless", "Run browser in headless mode", config.get("headless", false))
     .option("--debug", "Enable debug mode with page snapshots", config.get("debug", false))
     .option(
@@ -155,15 +160,16 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
     // Create browser instance
     const browser = new PlaywrightBrowser({
       browser: options.browser,
+      bypassCSP: options.bypassCsp,
+      channel: options.channel,
       blockAds: options.blockAds ?? config.get("block_ads", true),
       blockResources,
-      pwEndpoint: options.pwEndpoint,
-      pwCdpEndpoint: options.pwCdpEndpoint,
       headless: options.headless,
-      bypassCSP: options.bypassCsp,
       proxyServer: options.proxy,
       proxyUsername: options.proxyUsername,
       proxyPassword: options.proxyPassword,
+      pwEndpoint: options.pwEndpoint,
+      pwCdpEndpoint: options.pwCdpEndpoint,
     });
 
     // Create AI provider with CLI overrides

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -47,6 +47,11 @@ export function createRunCommand(): Command {
       "Browser channel to use (e.g., chrome, msedge, chrome-beta, moz-firefox)",
       config.get("channel"),
     )
+    .option(
+      "--executable-path <path>",
+      "Path to browser executable (e.g., /usr/bin/firefox, /Applications/Firefox.app/Contents/MacOS/firefox)",
+      config.get("executable_path"),
+    )
     .option("--headless", "Run browser in headless mode", config.get("headless", false))
     .option("--debug", "Enable debug mode with page snapshots", config.get("debug", false))
     .option(
@@ -162,6 +167,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       browser: options.browser,
       bypassCSP: options.bypassCsp,
       channel: options.channel,
+      executablePath: options.executablePath,
       blockAds: options.blockAds ?? config.get("block_ads", true),
       blockResources,
       headless: options.headless,

--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ export interface SparkConfig {
   // Browser Configuration
   browser?: "firefox" | "chrome" | "chromium" | "safari" | "webkit" | "edge";
   channel?: string;
+  executable_path?: string;
   headless?: boolean;
   block_ads?: boolean;
   block_resources?: string;
@@ -142,6 +143,9 @@ export class ConfigManager {
       }),
       ...(process.env.SPARK_CHANNEL && {
         channel: process.env.SPARK_CHANNEL,
+      }),
+      ...(process.env.SPARK_EXECUTABLE_PATH && {
+        executable_path: process.env.SPARK_EXECUTABLE_PATH,
       }),
       ...(process.env.SPARK_HEADLESS && {
         headless: process.env.SPARK_HEADLESS === "true",
@@ -336,6 +340,7 @@ export class ConfigManager {
     if (process.env.SPARK_BROWSER)
       env.browser = process.env.SPARK_BROWSER as SparkConfig["browser"];
     if (process.env.SPARK_CHANNEL) env.channel = process.env.SPARK_CHANNEL;
+    if (process.env.SPARK_EXECUTABLE_PATH) env.executable_path = process.env.SPARK_EXECUTABLE_PATH;
     if (process.env.SPARK_HEADLESS) env.headless = process.env.SPARK_HEADLESS === "true";
     if (process.env.SPARK_BLOCK_ADS) env.block_ads = process.env.SPARK_BLOCK_ADS === "true";
     if (process.env.SPARK_BLOCK_RESOURCES) env.block_resources = process.env.SPARK_BLOCK_RESOURCES;

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ export interface SparkConfig {
 
   // Browser Configuration
   browser?: "firefox" | "chrome" | "chromium" | "safari" | "webkit" | "edge";
+  channel?: string;
   headless?: boolean;
   block_ads?: boolean;
   block_resources?: string;
@@ -138,6 +139,9 @@ export class ConfigManager {
       // Browser Configuration
       ...(process.env.SPARK_BROWSER && {
         browser: process.env.SPARK_BROWSER as SparkConfig["browser"],
+      }),
+      ...(process.env.SPARK_CHANNEL && {
+        channel: process.env.SPARK_CHANNEL,
       }),
       ...(process.env.SPARK_HEADLESS && {
         headless: process.env.SPARK_HEADLESS === "true",
@@ -331,6 +335,7 @@ export class ConfigManager {
     // Browser Configuration
     if (process.env.SPARK_BROWSER)
       env.browser = process.env.SPARK_BROWSER as SparkConfig["browser"];
+    if (process.env.SPARK_CHANNEL) env.channel = process.env.SPARK_CHANNEL;
     if (process.env.SPARK_HEADLESS) env.headless = process.env.SPARK_HEADLESS === "true";
     if (process.env.SPARK_BLOCK_ADS) env.block_ads = process.env.SPARK_BLOCK_ADS === "true";
     if (process.env.SPARK_BLOCK_RESOURCES) env.block_resources = process.env.SPARK_BLOCK_RESOURCES;

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -149,6 +149,43 @@ describe("Config Integration", () => {
     });
   });
 
+  describe("channel configuration", () => {
+    it("should merge channel environment variable", () => {
+      const mockSparkConfig: SparkConfig = {
+        browser: "chrome",
+        channel: "chrome-beta",
+      };
+
+      mockConfig.getConfig.mockReturnValue(mockSparkConfig);
+
+      const result = mockConfig.getConfig();
+      expect(result.channel).toBe("chrome-beta");
+    });
+
+    it("should handle missing channel config gracefully", () => {
+      mockConfig.getConfig.mockReturnValue({
+        browser: "firefox",
+      });
+
+      const result = mockConfig.getConfig();
+      expect(result.channel).toBeUndefined();
+    });
+
+    it("should support various channel values", () => {
+      const channels = ["firefox", "moz-firefox"];
+
+      channels.forEach((channel) => {
+        mockConfig.getConfig.mockReturnValue({
+          browser: "firefox",
+          channel,
+        });
+
+        const result = mockConfig.getConfig();
+        expect(result.channel).toBe(channel);
+      });
+    });
+  });
+
   describe("proxy environment variables", () => {
     it("should merge proxy environment variables", () => {
       const mockSparkConfig: SparkConfig = {

--- a/test/cli/config.test.ts
+++ b/test/cli/config.test.ts
@@ -186,6 +186,59 @@ describe("Config Integration", () => {
     });
   });
 
+  describe("executablePath configuration", () => {
+    it("should merge executable_path environment variable", () => {
+      const mockSparkConfig: SparkConfig = {
+        browser: "chrome",
+        executable_path: "/usr/bin/google-chrome-beta",
+      };
+
+      mockConfig.getConfig.mockReturnValue(mockSparkConfig);
+
+      const result = mockConfig.getConfig();
+      expect(result.executable_path).toBe("/usr/bin/google-chrome-beta");
+    });
+
+    it("should handle missing executable_path config gracefully", () => {
+      mockConfig.getConfig.mockReturnValue({
+        browser: "firefox",
+      });
+
+      const result = mockConfig.getConfig();
+      expect(result.executable_path).toBeUndefined();
+    });
+
+    it("should support various executable_path values", () => {
+      const paths = [
+        "/usr/bin/firefox",
+        "/Applications/Firefox.app/Contents/MacOS/firefox",
+        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
+      ];
+
+      paths.forEach((executable_path) => {
+        mockConfig.getConfig.mockReturnValue({
+          browser: "firefox",
+          executable_path,
+        });
+
+        const result = mockConfig.getConfig();
+        expect(result.executable_path).toBe(executable_path);
+      });
+    });
+
+    it("should handle executable_path with channel", () => {
+      mockConfig.getConfig.mockReturnValue({
+        browser: "chrome",
+        channel: "chrome-beta",
+        executable_path: "/usr/bin/google-chrome-beta",
+      });
+
+      const result = mockConfig.getConfig();
+      expect(result.channel).toBe("chrome-beta");
+      expect(result.executable_path).toBe("/usr/bin/google-chrome-beta");
+    });
+  });
+
   describe("proxy environment variables", () => {
     it("should merge proxy environment variables", () => {
       const mockSparkConfig: SparkConfig = {

--- a/test/playwrightBrowser.test.ts
+++ b/test/playwrightBrowser.test.ts
@@ -379,6 +379,97 @@ describe("PlaywrightBrowser", () => {
     });
   });
 
+  describe("executablePath configuration", () => {
+    it("should handle explicit executablePath option", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "firefox",
+        executablePath: "/usr/bin/firefox",
+      });
+      expect(browser).toBeDefined();
+      expect(browser).toBeInstanceOf(PlaywrightBrowser);
+    });
+
+    it("should handle executablePath on different platforms", () => {
+      const paths = [
+        "/usr/bin/firefox",
+        "/Applications/Firefox.app/Contents/MacOS/firefox",
+        "C:\\Program Files\\Mozilla Firefox\\firefox.exe",
+      ];
+
+      paths.forEach((executablePath) => {
+        const browser = new PlaywrightBrowser({
+          browser: "firefox",
+          executablePath,
+        });
+        expect(browser).toBeDefined();
+        expect(browser).toBeInstanceOf(PlaywrightBrowser);
+      });
+    });
+
+    it("should pass executablePath to launch options", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        executablePath: "/usr/bin/google-chrome",
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.executablePath).toBe("/usr/bin/google-chrome");
+    });
+
+    it("should handle executablePath with other options", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        executablePath: "/usr/bin/chromium",
+        headless: true,
+        blockAds: true,
+        blockResources: ["image"],
+      });
+      expect(browser).toBeDefined();
+      expect(browser).toBeInstanceOf(PlaywrightBrowser);
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.executablePath).toBe("/usr/bin/chromium");
+    });
+
+    it("should prioritize top-level executablePath over launchOptions executablePath", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        executablePath: "/usr/bin/google-chrome-beta",
+        launchOptions: {
+          executablePath: "/usr/bin/google-chrome",
+        },
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.executablePath).toBe("/usr/bin/google-chrome-beta");
+    });
+
+    it("should handle undefined executablePath gracefully", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "firefox",
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.executablePath).toBeUndefined();
+    });
+
+    it("should work with channel and executablePath together", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        channel: "chrome-beta",
+        executablePath: "/usr/bin/google-chrome-beta",
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.channel).toBe("chrome-beta");
+      expect(mappedOptions.launchOptions.executablePath).toBe("/usr/bin/google-chrome-beta");
+    });
+  });
+
   describe("proxy configuration", () => {
     it("should handle proxy options", () => {
       const browser = new PlaywrightBrowser({

--- a/test/playwrightBrowser.test.ts
+++ b/test/playwrightBrowser.test.ts
@@ -262,6 +262,123 @@ describe("PlaywrightBrowser", () => {
     });
   });
 
+  describe("channel configuration", () => {
+    it("should handle explicit channel option", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "firefox",
+        channel: "moz-firefox",
+      });
+      expect(browser).toBeDefined();
+      expect(browser).toBeInstanceOf(PlaywrightBrowser);
+      expect(browser.channel).toBe("moz-firefox");
+    });
+
+    it("should use default channel for edge when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "edge",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBe("msedge");
+    });
+
+    it("should use default channel for chrome when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBe("chrome");
+    });
+
+    it("should use default channel for firefox when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "firefox",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBe("firefox");
+    });
+
+    it("should have undefined channel for chromium when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBeUndefined();
+    });
+
+    it("should have undefined channel for safari when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "safari",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBeUndefined();
+    });
+
+    it("should have undefined channel for webkit when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "webkit",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBeUndefined();
+    });
+
+    it("should override default channel when explicitly provided", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "edge",
+        channel: "chrome",
+      });
+      expect(browser).toBeDefined();
+      expect(browser.channel).toBe("chrome");
+    });
+
+    it("should pass channel to launch options", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        channel: "chrome-beta",
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.channel).toBe("chrome-beta");
+    });
+
+    it("should use default channel in launch options when not specified", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "firefox",
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.channel).toBe("firefox");
+    });
+
+    it("should handle channel with other options", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        channel: "chrome-beta",
+        headless: true,
+        blockAds: true,
+        blockResources: ["image"],
+      });
+      expect(browser).toBeDefined();
+      expect(browser).toBeInstanceOf(PlaywrightBrowser);
+      expect(browser.channel).toBe("chrome-beta");
+    });
+
+    it("should prioritize top-level channel over launchOptions channel", () => {
+      const browser = new PlaywrightBrowser({
+        browser: "chrome",
+        channel: "chrome-beta",
+        launchOptions: {
+          channel: "chrome",
+        },
+      });
+      expect(browser).toBeDefined();
+
+      const mappedOptions = (browser as any).mapOptionsToPlaywright();
+      expect(mappedOptions.launchOptions.channel).toBe("chrome-beta");
+    });
+  });
+
   describe("proxy configuration", () => {
     it("should handle proxy options", () => {
       const browser = new PlaywrightBrowser({


### PR DESCRIPTION
With this PR we are now able to run Spark commands by using the WebDriver BiDi protocol. When `--channel moz-firefox` is specified Playwright will not use its own downloaded / customized Firefox but the default version as installed on the system. 

Note that for most features it should work but some interactions where the network reponse body needs to be read the upcoming Firefox 146 release is needed. Alternatively specify the executable binary path to your Beta, Nightly, or own local build.

For trace log output you can use the following environment variables:

* PWTEST_FIREFOX_USER_PREFS='{"remote.log.truncate": false, "remote.log.level":"Trace"}' 
* DEBUG="pw:*"