### PR TITLE
Make add-on sidebar Markdown CSS easy to adjust

### DIFF
--- a/extension/docs/prose-typography-customization-plan.md
+++ b/extension/docs/prose-typography-customization-plan.md
@@ -1,0 +1,28 @@
+# Prose Typography Customization Plan
+
+## Goal
+
+Customize the `@tailwindcss/typography` plugin's typography to match our design requirements by creating a `prose-chat` modifier, following the plugin's established pattern (`prose-sm`, `prose-lg`, etc.).
+
+## Approach
+
+Create a `prose-chat` utility class using Tailwind v4's `@utility` directive, with values defined in `@theme`. This approach:
+
+- Starts as a clone of `prose-base` metrics for a stable baseline
+- Follows the typography plugin's modifier pattern
+- Centralizes typography values in `@theme`
+- Is composable with other prose modifiers
+- Allows incremental customization from the baseline
+
+## Architecture Decisions
+
+| Decision               | Choice                | Rationale                          |
+| ---------------------- | --------------------- | ---------------------------------- |
+| Where to define values | `@theme` in CSS       | CSS-first, native Tailwind v4      |
+| Override strategy      | `prose-chat` utility  | Follows plugin pattern, composable |
+| Starting point         | Clone of `prose-base` | Stable baseline, then customize    |
+
+## Future Considerations
+
+- Adjust additional variables as design requirements emerge
+- If JS access to these values is needed, mirror them in `theme.ts`

--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -96,7 +96,7 @@ const MarkdownContent = ({ children, className }: MarkdownContentProps): ReactEl
     className={clsx(
       "markdown-content",
       "prose",
-      "prose-base",
+      "prose-chat",
       "prose-slate",
       "max-w-none",
       className,

--- a/extension/src/components/sidepanel/SidePanel.css
+++ b/extension/src/components/sidepanel/SidePanel.css
@@ -10,6 +10,35 @@
   --color-stone-225: #d8d6d2;
   --color-stone-875: #2f2f2f;
   --color-stone-925: #1c1b22;
+  /* Prose chat typography - cloned from prose-base, customize as needed */
+
+  /* Font sizes */
+  --prose-chat-font-size: 0.75rem;
+  --prose-chat-h1-font-size: 1.125rem;
+  --prose-chat-h2-font-size: 1.125rem;
+  --prose-chat-h3-font-size: 1rem;
+  --prose-chat-h4-font-size: 1em;
+  --prose-chat-code-font-size: 0.875em;
+  --prose-chat-lead-font-size: 1.25em;
+
+  /* Line heights */
+  --prose-chat-line-height: 1.333;
+  --prose-chat-h1-line-height: 1.4;
+  --prose-chat-h2-line-height: 1.144;
+  --prose-chat-h3-line-height: 1.6;
+  --prose-chat-h4-line-height: 1.5;
+
+  /* Margins */
+  --prose-chat-p-margin-top: 1.25em;
+  --prose-chat-p-margin-bottom: 1.25em;
+  --prose-chat-h1-margin-top: 0;
+  --prose-chat-h1-margin-bottom: 0.889em;
+  --prose-chat-h2-margin-top: 2em;
+  --prose-chat-h2-margin-bottom: 1em;
+  --prose-chat-h3-margin-top: 1.6em;
+  --prose-chat-h3-margin-bottom: 0.6em;
+  --prose-chat-h4-margin-top: 1.5em;
+  --prose-chat-h4-margin-bottom: 0.5em;
 }
 
 /* Add custom styles to Tailwind's components layer to ensure they're included in build */
@@ -39,5 +68,52 @@
   .markdown-content ul {
     list-style-type: disc;
     list-style-position: inside;
+  }
+}
+
+/* Prose chat typography utility - similar to prose-sm, prose-lg */
+@utility prose-chat {
+  font-size: var(--prose-chat-font-size);
+  line-height: var(--prose-chat-line-height);
+
+  p {
+    margin-top: var(--prose-chat-p-margin-top);
+    margin-bottom: var(--prose-chat-p-margin-bottom);
+  }
+
+  h1 {
+    font-size: var(--prose-chat-h1-font-size);
+    line-height: var(--prose-chat-h1-line-height);
+    margin-top: var(--prose-chat-h1-margin-top);
+    margin-bottom: var(--prose-chat-h1-margin-bottom);
+  }
+
+  h2 {
+    font-size: var(--prose-chat-h2-font-size);
+    line-height: var(--prose-chat-h2-line-height);
+    margin-top: var(--prose-chat-h2-margin-top);
+    margin-bottom: var(--prose-chat-h2-margin-bottom);
+  }
+
+  h3 {
+    font-size: var(--prose-chat-h3-font-size);
+    line-height: var(--prose-chat-h3-line-height);
+    margin-top: var(--prose-chat-h3-margin-top);
+    margin-bottom: var(--prose-chat-h3-margin-bottom);
+  }
+
+  h4 {
+    font-size: var(--prose-chat-h4-font-size);
+    line-height: var(--prose-chat-h4-line-height);
+    margin-top: var(--prose-chat-h4-margin-top);
+    margin-bottom: var(--prose-chat-h4-margin-bottom);
+  }
+
+  code {
+    font-size: var(--prose-chat-code-font-size);
+  }
+
+  [class~="lead"] {
+    font-size: var(--prose-chat-lead-font-size);
   }
 }

--- a/extension/src/theme.ts
+++ b/extension/src/theme.ts
@@ -300,3 +300,7 @@ export const theme = {
 
 export type Theme = typeof theme.light;
 export type ThemeMode = "light" | "dark";
+
+// Prose typography for markdown content is defined in CSS via @theme variables.
+// See: src/components/sidepanel/SidePanel.css (--prose-chat-* variables)
+// Documentation: docs/prose-typography-customization-plan.md


### PR DESCRIPTION
The @tailwindcss/typography plug-in makes it much easier to render Markdown easily.  Unfortunately, none of its pre-existing sizes quite work for what we need, so I've forked the base size and started adjusting some values.