### PR TITLE
Make add-on display "Creating task plan" as status

### DIFF
--- a/src/webAgent.ts
+++ b/src/webAgent.ts
@@ -1019,6 +1019,12 @@ export class WebAgent {
       iterationId: this.currentIterationId || "planning",
     });
 
+    // Also emit as status so extension ChatView shows it to user
+    this.emit(WebAgentEventType.AGENT_STATUS, {
+      message: "Creating task plan",
+      iterationId: this.currentIterationId || "planning",
+    });
+
     try {
       const planningTools = createPlanningTools();
 

--- a/test/webAgent.test.ts
+++ b/test/webAgent.test.ts
@@ -1704,6 +1704,79 @@ describe("WebAgent", () => {
       );
       expect(thinkingEvents.length).toBeGreaterThanOrEqual(1); // at least one thinking event
     });
+
+    it("should emit AGENT_STATUS event when creating task plan", async () => {
+      // Plan
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Planning",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: {
+              successCriteria: "Test",
+              plan: "1. Test",
+            },
+            output: {
+              successCriteria: "Test",
+              plan: "1. Test",
+            },
+          },
+        ],
+      } as any);
+
+      // Done
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "Complete" },
+              output: {
+                action: "done",
+                result: "Complete",
+                isTerminal: true,
+              },
+            },
+          ],
+          response: {
+            messages: [
+              {
+                role: "assistant",
+                content: "Done",
+              },
+              {
+                role: "tool",
+                content: [
+                  {
+                    type: "tool-result",
+                    toolCallId: "done_1",
+                    toolName: "done",
+                    output: { action: "done", result: "Complete", isTerminal: true },
+                  },
+                ],
+              },
+            ],
+          },
+        }) as any,
+      );
+
+      await webAgent.execute("Test status events", { startingUrl: "https://example.com" });
+
+      // Check AGENT_STATUS event was emitted for "Creating task plan"
+      const statusEvents = mockLogger.events.filter(
+        (e) => e.type === WebAgentEventType.AGENT_STATUS,
+      );
+
+      const creatingPlanStatus = statusEvents.find((e) => e.data.message === "Creating task plan");
+
+      expect(creatingPlanStatus).toBeDefined();
+      expect(creatingPlanStatus?.data.iterationId).toBe("planning");
+    });
   });
 
   describe("task validation", () => {


### PR DESCRIPTION
It can take 4-5 seconds for the task plan to be created, so I've made the `action:processing` event be also sent as an `action:status` event and tweaked the ChatView to show it.  Not the prettiest choice, but the other options seemed uglier:

<img width="1069" height="1005" alt="image" src="https://github.com/user-attachments/assets/6ab090c5-baf3-4a19-978d-d18f874922af" />
