### PR TITLE
Show some actions in add-on chat view as feedback

### DIFF
--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -25,6 +25,7 @@ import {
   isTaskValidationErrorData,
   isBrowserActionCompletedData,
   isBrowserActionStartedData,
+  isAgentActionData,
 } from "../../utils/typeGuards";
 import type { BrowserActionStartedEventData } from "../../types/browser";
 
@@ -375,6 +376,16 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
             const statusMessage = formatBrowserAction(eventData);
             if (statusMessage) {
               addMessage("status", statusMessage, currentTaskId);
+            }
+          }
+        }
+
+        // Handle agent action events (e.g., extract)
+        if (typedMessage.event.type === "agent:action") {
+          const eventData = typedMessage.event.data;
+          if (isAgentActionData(eventData) && currentTaskId) {
+            if (eventData.action === "extract") {
+              addMessage("status", "Extracting data", currentTaskId);
             }
           }
         }

--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -24,7 +24,9 @@ import {
   isAIGenerationErrorData,
   isTaskValidationErrorData,
   isBrowserActionCompletedData,
+  isBrowserActionStartedData,
 } from "../../utils/typeGuards";
+import type { BrowserActionStartedEventData } from "../../types/browser";
 
 // Interface for events in ExecuteTaskResponse
 interface EventData {
@@ -43,6 +45,39 @@ interface ChatViewProps {
  * and are handled automatically by the agent.
  */
 const MAX_VALIDATION_RETRIES = 3;
+
+/**
+ * Formats a browser action into a human-readable status message.
+ *
+ * @param data - The browser action started event data
+ * @returns A human-readable description of the action
+ */
+export function formatBrowserAction(data: BrowserActionStartedEventData): string {
+  const { action, value } = data;
+
+  switch (action) {
+    case "click":
+      return "Clicking";
+    case "fill":
+      return "Filling";
+    case "goto": {
+      if (value) {
+        try {
+          const url = new URL(value);
+          return `Navigating to ${url.hostname}`;
+        } catch (error) {
+          console.warn("Failed to parse URL in formatBrowserAction:", error);
+          return `Navigating to ${value}`;
+        }
+      }
+      return "Navigating";
+    }
+    case "select":
+      return value ? `Selecting '${value}'` : "Selecting";
+    default:
+      return "";
+  }
+}
 
 /**
  * Determines whether an error event should be displayed to the user.
@@ -330,6 +365,17 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
         ) {
           if (typedMessage.event.data.message && currentTaskId) {
             addMessage("status", typedMessage.event.data.message, currentTaskId);
+          }
+        }
+
+        // Handle browser action started events
+        if (typedMessage.event.type === "browser:action_started") {
+          const eventData = typedMessage.event.data;
+          if (isBrowserActionStartedData(eventData) && currentTaskId) {
+            const statusMessage = formatBrowserAction(eventData);
+            if (statusMessage) {
+              addMessage("status", statusMessage, currentTaskId);
+            }
           }
         }
 

--- a/extension/src/types/browser.ts
+++ b/extension/src/types/browser.ts
@@ -88,6 +88,12 @@ export interface BrowserActionCompletedEventData {
   isRecoverable?: boolean;
 }
 
+export interface BrowserActionStartedEventData {
+  action: string;
+  ref?: string;
+  value?: string;
+}
+
 // Generic event data for unknown event types
 export interface GenericEventData {
   [key: string]: unknown;
@@ -101,6 +107,7 @@ export type RealtimeEvent =
   | { type: "ai:generation:error"; data: AIGenerationErrorEventData; timestamp: number }
   | { type: "task:validation_error"; data: TaskValidationErrorEventData; timestamp: number }
   | { type: "browser:action:completed"; data: BrowserActionCompletedEventData; timestamp: number }
+  | { type: "browser:action_started"; data: BrowserActionStartedEventData; timestamp: number }
   | { type: string; data: GenericEventData; timestamp: number };
 
 export interface RealtimeEventMessage {

--- a/extension/src/utils/typeGuards.ts
+++ b/extension/src/utils/typeGuards.ts
@@ -162,3 +162,12 @@ export function isValidRealtimeEvent(event: unknown): event is RealtimeEvent {
 
   return true;
 }
+
+/**
+ * Type guard for agent action event data (from agent:action events)
+ */
+export function isAgentActionData(data: unknown): data is { action: string; value?: string } {
+  if (typeof data !== "object" || data === null) return false;
+  const record = data as Record<string, unknown>;
+  return typeof record.action === "string";
+}

--- a/extension/src/utils/typeGuards.ts
+++ b/extension/src/utils/typeGuards.ts
@@ -9,19 +9,22 @@ import type {
   AIGenerationErrorEventData,
   TaskValidationErrorEventData,
   BrowserActionCompletedEventData,
+  BrowserActionStartedEventData,
   RealtimeEvent,
 } from "../types/browser";
 
 /**
  * Check if an object has an optional string property
+ * Accepts: missing property, string value, or explicit undefined
  */
 export function hasOptionalStringProp(obj: unknown, prop: string): boolean {
   if (typeof obj !== "object" || obj === null) return false;
   const record = obj as Record<string, unknown>;
   // If property doesn't exist in object, that's fine (optional)
   if (!(prop in record)) return true;
-  // If property exists, it must be a string (not undefined, null, etc)
-  return typeof record[prop] === "string";
+  const value = record[prop];
+  // If property exists, it must be a string or undefined
+  return typeof value === "string" || value === undefined;
 }
 
 /**
@@ -116,6 +119,19 @@ export function isBrowserActionCompletedData(
     hasRequiredBooleanProp(data, "success") &&
     hasOptionalStringProp(data, "error") &&
     hasOptionalBooleanProp(data, "isRecoverable")
+  );
+}
+
+/**
+ * Type guard for BrowserActionStartedEventData
+ */
+export function isBrowserActionStartedData(data: unknown): data is BrowserActionStartedEventData {
+  if (typeof data !== "object" || data === null) return false;
+  const record = data as Record<string, unknown>;
+  return (
+    typeof record.action === "string" &&
+    hasOptionalStringProp(data, "ref") &&
+    hasOptionalStringProp(data, "value")
   );
 }
 

--- a/extension/test/components/sidepanel/ChatView.test.tsx
+++ b/extension/test/components/sidepanel/ChatView.test.tsx
@@ -931,6 +931,77 @@ describe("ChatView", () => {
     });
   });
 
+  describe("agent:action event handling", () => {
+    it("should add status message when agent:action event with extract action is received", () => {
+      // Arrange: Set currentTaskId before rendering
+      mockCurrentTaskId = "task-agent-action";
+      render(<ChatView {...defaultProps} />);
+
+      // Get the registered handler
+      const mockAddListener = browser.runtime.onMessage.addListener as MockedFunction<
+        typeof browser.runtime.onMessage.addListener
+      >;
+      const registeredHandler = mockAddListener.mock.calls[
+        mockAddListener.mock.calls.length - 1
+      ][0] as (message: unknown) => void;
+
+      // Act: Simulate agent:action event with extract action
+      const message = createRealtimeMessage("agent:action", {
+        action: "extract",
+      });
+      registeredHandler(message);
+
+      // Assert: addMessage should have been called with status message
+      expect(mockAddMessage).toHaveBeenCalledWith("status", "Extracting data", "task-agent-action");
+    });
+
+    it("should not add status message when agent:action event with done action is received", () => {
+      // Arrange: Set currentTaskId before rendering
+      mockCurrentTaskId = "task-agent-done";
+      render(<ChatView {...defaultProps} />);
+
+      // Get the registered handler
+      const mockAddListener = browser.runtime.onMessage.addListener as MockedFunction<
+        typeof browser.runtime.onMessage.addListener
+      >;
+      const registeredHandler = mockAddListener.mock.calls[
+        mockAddListener.mock.calls.length - 1
+      ][0] as (message: unknown) => void;
+
+      // Act: Simulate agent:action event with done action
+      const message = createRealtimeMessage("agent:action", {
+        action: "done",
+      });
+      registeredHandler(message);
+
+      // Assert: addMessage should NOT have been called
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+
+    it("should not add status message when agent:action event with abort action is received", () => {
+      // Arrange: Set currentTaskId before rendering
+      mockCurrentTaskId = "task-agent-abort";
+      render(<ChatView {...defaultProps} />);
+
+      // Get the registered handler
+      const mockAddListener = browser.runtime.onMessage.addListener as MockedFunction<
+        typeof browser.runtime.onMessage.addListener
+      >;
+      const registeredHandler = mockAddListener.mock.calls[
+        mockAddListener.mock.calls.length - 1
+      ][0] as (message: unknown) => void;
+
+      // Act: Simulate agent:action event with abort action
+      const message = createRealtimeMessage("agent:action", {
+        action: "abort",
+      });
+      registeredHandler(message);
+
+      // Assert: addMessage should NOT have been called
+      expect(mockAddMessage).not.toHaveBeenCalled();
+    });
+  });
+
   describe("Markdown Rendering", () => {
     it("renders double newlines as separate paragraphs with spacing", () => {
       // Arrange: Create a message with double newlines

--- a/extension/test/utils/typeGuards.test.ts
+++ b/extension/test/utils/typeGuards.test.ts
@@ -13,6 +13,7 @@ import {
   isBrowserActionCompletedData,
   isBrowserActionStartedData,
   isValidRealtimeEvent,
+  isAgentActionData,
 } from "../../src/utils/typeGuards";
 import type {
   TaskStartedEventData,
@@ -487,5 +488,30 @@ describe("isBrowserActionStartedData", () => {
       iterationId: "iter-123",
     };
     expect(isBrowserActionStartedData(data)).toBe(true);
+  });
+});
+
+describe("isAgentActionData", () => {
+  it("should return true for valid agent action data with action property", () => {
+    const data = { action: "extract" };
+    expect(isAgentActionData(data)).toBe(true);
+  });
+
+  it("should return true for valid agent action data with action and value", () => {
+    const data = { action: "extract", value: "some data" };
+    expect(isAgentActionData(data)).toBe(true);
+  });
+
+  it("should return false for object without action property", () => {
+    const data = { value: "some data" };
+    expect(isAgentActionData(data)).toBe(false);
+  });
+
+  it("should return false for null", () => {
+    expect(isAgentActionData(null)).toBe(false);
+  });
+
+  it("should return false for string", () => {
+    expect(isAgentActionData("extract")).toBe(false);
   });
 });


### PR DESCRIPTION
Show various actions to the add-on user to give a sense of progress being made and the agent being on track rather than feeling stuck. 