### PR TITLE
Improved error handling and retry

### DIFF
--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -71,6 +71,14 @@ interface SparkTaskRequest {
   proxyUsername?: string;
   proxyPassword?: string;
 
+  // Navigation retry configuration overrides
+  navigationTimeoutMs?: number;
+  navigationMaxAttempts?: number;
+  navigationTimeoutMultiplier?: number;
+
+  // Action timeout configuration
+  actionTimeoutMs?: number;
+
   // Logging configuration
   logger?: "console" | "json";
 }
@@ -145,6 +153,13 @@ spark.post("/run", async (c) => {
           proxyServer: body.proxy || serverConfig.proxy,
           proxyUsername: body.proxyUsername || serverConfig.proxy_username,
           proxyPassword: body.proxyPassword || serverConfig.proxy_password,
+          actionTimeoutMs: body.actionTimeoutMs || serverConfig.action_timeout_ms,
+          navigationRetry: {
+            baseTimeoutMs: body.navigationTimeoutMs || serverConfig.navigation_timeout_ms,
+            maxAttempts: body.navigationMaxAttempts || serverConfig.navigation_max_attempts,
+            timeoutMultiplier:
+              body.navigationTimeoutMultiplier || serverConfig.navigation_timeout_multiplier,
+          },
         };
 
         const webAgentConfig = {

--- a/src/browser/navigationRetry.ts
+++ b/src/browser/navigationRetry.ts
@@ -1,0 +1,42 @@
+/**
+ * Configuration for navigation retry behavior.
+ * See NavigationTimeoutException in errors.ts for the error thrown on timeout.
+ */
+export interface NavigationRetryConfig {
+  /** Base timeout in milliseconds (default: 15000) */
+  baseTimeoutMs: number;
+  /** Maximum timeout in milliseconds to prevent runaway values (default: 60000) */
+  maxTimeoutMs: number;
+  /** Maximum total attempts including initial (default: 3, meaning 15s → 30s → 60s) */
+  maxAttempts: number;
+  /** Timeout multiplier for each subsequent attempt (default: 2) */
+  timeoutMultiplier: number;
+  /** Callback for retry events */
+  onRetry?: (attempt: number, error: Error, nextTimeoutMs: number) => void;
+}
+
+/**
+ * Default navigation retry configuration
+ */
+export const DEFAULT_NAVIGATION_RETRY_CONFIG: NavigationRetryConfig = {
+  baseTimeoutMs: 15000,
+  maxTimeoutMs: 60000,
+  maxAttempts: 3,
+  timeoutMultiplier: 2,
+};
+
+/**
+ * Calculate timeout for a given retry attempt.
+ * Uses exponential backoff: base * multiplier^(attempt-1), capped at maxTimeoutMs.
+ *
+ * With defaults (base: 15s, multiplier: 2, max: 60s):
+ * - Attempt 1: 15,000ms
+ * - Attempt 2: 30,000ms
+ * - Attempt 3: 60,000ms (capped)
+ */
+export function calculateTimeout(attempt: number, config: NavigationRetryConfig): number {
+  const calculated = Math.round(
+    config.baseTimeoutMs * Math.pow(config.timeoutMultiplier, attempt - 1),
+  );
+  return Math.min(calculated, config.maxTimeoutMs);
+}

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -111,6 +111,26 @@ export function createRunCommand(): Command {
       "Proxy authentication password",
       config.get("proxy_password"),
     )
+    .option(
+      "--navigation-timeout-ms <number>",
+      "Base navigation timeout in milliseconds",
+      String(config.get("navigation_timeout_ms", 15000)),
+    )
+    .option(
+      "--navigation-max-attempts <number>",
+      "Maximum navigation attempts (e.g., 3 means try up to 3 times)",
+      String(config.get("navigation_max_attempts", 3)),
+    )
+    .option(
+      "--navigation-timeout-multiplier <number>",
+      "Timeout multiplier for each retry (e.g., 2 means 15s -> 30s -> 60s)",
+      String(config.get("navigation_timeout_multiplier", 2)),
+    )
+    .option(
+      "--action-timeout-ms <number>",
+      "Timeout for page load and element actions in milliseconds",
+      String(config.get("action_timeout_ms", 10000)),
+    )
     .option("--logger <logger>", "Logger to use (console, json)", config.get("logger", "console"))
     .option(
       "--metrics-incremental",
@@ -162,7 +182,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       ),
     );
 
-    // Create browser instance
+    // Create browser instance with navigation retry config
     const browser = new PlaywrightBrowser({
       browser: options.browser,
       bypassCSP: options.bypassCsp,
@@ -176,6 +196,24 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       proxyPassword: options.proxyPassword,
       pwEndpoint: options.pwEndpoint,
       pwCdpEndpoint: options.pwCdpEndpoint,
+      actionTimeoutMs: options.actionTimeoutMs ? parseInt(options.actionTimeoutMs) : undefined,
+      navigationRetry: {
+        baseTimeoutMs: options.navigationTimeoutMs
+          ? parseInt(options.navigationTimeoutMs)
+          : undefined,
+        maxAttempts: options.navigationMaxAttempts
+          ? parseInt(options.navigationMaxAttempts)
+          : undefined,
+        timeoutMultiplier: options.navigationTimeoutMultiplier
+          ? parseFloat(options.navigationTimeoutMultiplier)
+          : undefined,
+        onRetry: (attempt, error, nextTimeout) => {
+          console.log(
+            chalk.yellow(`⚠️ Navigation retry ${attempt}: ${error.message}`),
+            chalk.gray(`(next timeout: ${Math.round(nextTimeout / 1000)}s)`),
+          );
+        },
+      },
     });
 
     // Create AI provider with CLI overrides

--- a/src/config.ts
+++ b/src/config.ts
@@ -57,6 +57,14 @@ export interface SparkConfig {
   pw_endpoint?: string;
   pw_cdp_endpoint?: string;
   bypass_csp?: boolean;
+
+  // Navigation Retry Configuration
+  navigation_timeout_ms?: number;
+  navigation_max_attempts?: number;
+  navigation_timeout_multiplier?: number;
+
+  // Action Timeout Configuration
+  action_timeout_ms?: number;
 }
 
 export class ConfigManager {
@@ -214,6 +222,22 @@ export class ConfigManager {
       }),
       ...(process.env.SPARK_BYPASS_CSP && {
         bypass_csp: process.env.SPARK_BYPASS_CSP === "true",
+      }),
+
+      // Navigation Retry Configuration
+      ...(process.env.SPARK_NAVIGATION_TIMEOUT_MS && {
+        navigation_timeout_ms: parseInt(process.env.SPARK_NAVIGATION_TIMEOUT_MS, 10),
+      }),
+      ...(process.env.SPARK_NAVIGATION_MAX_ATTEMPTS && {
+        navigation_max_attempts: parseInt(process.env.SPARK_NAVIGATION_MAX_ATTEMPTS, 10),
+      }),
+      ...(process.env.SPARK_NAVIGATION_TIMEOUT_MULTIPLIER && {
+        navigation_timeout_multiplier: parseFloat(process.env.SPARK_NAVIGATION_TIMEOUT_MULTIPLIER),
+      }),
+
+      // Action Timeout Configuration
+      ...(process.env.SPARK_ACTION_TIMEOUT_MS && {
+        action_timeout_ms: parseInt(process.env.SPARK_ACTION_TIMEOUT_MS, 10),
       }),
     };
 
@@ -374,6 +398,20 @@ export class ConfigManager {
     if (process.env.SPARK_PW_ENDPOINT) env.pw_endpoint = process.env.SPARK_PW_ENDPOINT;
     if (process.env.SPARK_PW_CDP_ENDPOINT) env.pw_cdp_endpoint = process.env.SPARK_PW_CDP_ENDPOINT;
     if (process.env.SPARK_BYPASS_CSP) env.bypass_csp = process.env.SPARK_BYPASS_CSP === "true";
+
+    // Navigation Retry Configuration
+    if (process.env.SPARK_NAVIGATION_TIMEOUT_MS)
+      env.navigation_timeout_ms = parseInt(process.env.SPARK_NAVIGATION_TIMEOUT_MS, 10);
+    if (process.env.SPARK_NAVIGATION_MAX_ATTEMPTS)
+      env.navigation_max_attempts = parseInt(process.env.SPARK_NAVIGATION_MAX_ATTEMPTS, 10);
+    if (process.env.SPARK_NAVIGATION_TIMEOUT_MULTIPLIER)
+      env.navigation_timeout_multiplier = parseFloat(
+        process.env.SPARK_NAVIGATION_TIMEOUT_MULTIPLIER,
+      );
+
+    // Action Timeout Configuration
+    if (process.env.SPARK_ACTION_TIMEOUT_MS)
+      env.action_timeout_ms = parseInt(process.env.SPARK_ACTION_TIMEOUT_MS, 10);
 
     const merged = this.getConfig();
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -34,6 +34,13 @@ export type { Logger } from "./loggers/types.js";
 // Schema types (public API for type safety)
 export type { Action, TaskValidationResult } from "./schemas.js";
 
+// Error types
+export { RecoverableError, BrowserException, NavigationTimeoutException } from "./errors.js";
+
+// Navigation retry configuration
+export type { NavigationRetryConfig } from "./browser/navigationRetry.js";
+export { DEFAULT_NAVIGATION_RETRY_CONFIG, calculateTimeout } from "./browser/navigationRetry.js";
+
 // Note: createProvider not exported in core to avoid Node.js dependencies in browser
 // Use provider libraries directly in browser environments
 export * from "./schemas.js";

--- a/src/core.ts
+++ b/src/core.ts
@@ -7,7 +7,8 @@
 export { WebAgent } from "./webAgent.js";
 export type { AriaBrowser } from "./browser/ariaBrowser.js";
 export { PageAction, LoadState } from "./browser/ariaBrowser.js";
-export type { TaskExecutionResult, WebAgentOptions } from "./webAgent.js";
+export type { TaskExecutionResult, TaskError, WebAgentOptions } from "./webAgent.js";
+export { TaskErrorCode } from "./webAgent.js";
 export { WebAgentEventEmitter, WebAgentEventType } from "./events.js";
 export type {
   WebAgentEvent,

--- a/test/cli/commands/run.test.ts
+++ b/test/cli/commands/run.test.ts
@@ -285,6 +285,33 @@ describe("CLI Run Command", () => {
       );
     });
 
+    it("should pass navigation retry and action timeout options correctly", async () => {
+      const args = [
+        "--navigation-timeout-ms",
+        "20000",
+        "--navigation-max-attempts",
+        "5",
+        "--navigation-timeout-multiplier",
+        "1.5",
+        "--action-timeout-ms",
+        "15000",
+        "test task",
+      ];
+
+      await command.parseAsync(args, { from: "user" });
+
+      expect(mockPlaywrightBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionTimeoutMs: 15000,
+          navigationRetry: expect.objectContaining({
+            baseTimeoutMs: 20000,
+            maxAttempts: 5,
+            timeoutMultiplier: 1.5,
+          }),
+        }),
+      );
+    });
+
     it("should pass WebAgent options correctly", async () => {
       const args = [
         "--debug",

--- a/test/cli/commands/run.test.ts
+++ b/test/cli/commands/run.test.ts
@@ -210,17 +210,19 @@ describe("CLI Run Command", () => {
       const args = ["test task"];
       await command.parseAsync(args, { from: "user" });
 
-      expect(mockPlaywrightBrowser).toHaveBeenCalledWith({
-        browser: "firefox",
-        blockAds: true, // Default from --no-block-ads option
-        blockResources: ["media", "manifest"], // Default from config
-        pwEndpoint: undefined,
-        headless: false,
-        bypassCSP: false, // Default from config
-        proxyServer: undefined,
-        proxyUsername: undefined,
-        proxyPassword: undefined,
-      });
+      expect(mockPlaywrightBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browser: "firefox",
+          blockAds: true, // Default from --no-block-ads option
+          blockResources: ["media", "manifest"], // Default from config
+          pwEndpoint: undefined,
+          headless: false,
+          bypassCSP: false, // Default from config
+          proxyServer: undefined,
+          proxyUsername: undefined,
+          proxyPassword: undefined,
+        }),
+      );
 
       expect(mockCreateAIProvider).toHaveBeenCalledWith({
         provider: "openai",
@@ -268,17 +270,19 @@ describe("CLI Run Command", () => {
 
       await command.parseAsync(args, { from: "user" });
 
-      expect(mockPlaywrightBrowser).toHaveBeenCalledWith({
-        browser: "chromium",
-        blockAds: true, // Default from --no-block-ads option
-        blockResources: ["image", "stylesheet"],
-        pwEndpoint: "ws://localhost:9222",
-        headless: true,
-        bypassCSP: true,
-        proxyServer: undefined,
-        proxyUsername: undefined,
-        proxyPassword: undefined,
-      });
+      expect(mockPlaywrightBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browser: "chromium",
+          blockAds: true, // Default from --no-block-ads option
+          blockResources: ["image", "stylesheet"],
+          pwEndpoint: "ws://localhost:9222",
+          headless: true,
+          bypassCSP: true,
+          proxyServer: undefined,
+          proxyUsername: undefined,
+          proxyPassword: undefined,
+        }),
+      );
     });
 
     it("should pass WebAgent options correctly", async () => {
@@ -389,17 +393,19 @@ describe("CLI Run Command", () => {
 
       await command.parseAsync(args, { from: "user" });
 
-      expect(mockPlaywrightBrowser).toHaveBeenCalledWith({
-        browser: "firefox",
-        blockAds: true, // Default from --no-block-ads option
-        blockResources: ["media", "manifest"], // Default from config
-        pwEndpoint: undefined,
-        headless: false,
-        bypassCSP: false, // Default from config
-        proxyServer: "http://proxy.company.com:8080",
-        proxyUsername: "user",
-        proxyPassword: "pass",
-      });
+      expect(mockPlaywrightBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browser: "firefox",
+          blockAds: true, // Default from --no-block-ads option
+          blockResources: ["media", "manifest"], // Default from config
+          pwEndpoint: undefined,
+          headless: false,
+          bypassCSP: false, // Default from config
+          proxyServer: "http://proxy.company.com:8080",
+          proxyUsername: "user",
+          proxyPassword: "pass",
+        }),
+      );
     });
 
     it("should use JSON logger when specified", async () => {

--- a/test/navigationRetry.test.ts
+++ b/test/navigationRetry.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for navigation retry utilities and NavigationTimeoutException
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  calculateTimeout,
+  DEFAULT_NAVIGATION_RETRY_CONFIG,
+  NavigationRetryConfig,
+} from "../src/browser/navigationRetry.js";
+import { NavigationTimeoutException, BrowserException } from "../src/errors.js";
+
+describe("Navigation Retry Utilities", () => {
+  describe("calculateTimeout", () => {
+    it("should return base timeout for first attempt", () => {
+      const timeout = calculateTimeout(1, DEFAULT_NAVIGATION_RETRY_CONFIG);
+      expect(timeout).toBe(15000);
+    });
+
+    it("should double timeout for second attempt with default config", () => {
+      const timeout = calculateTimeout(2, DEFAULT_NAVIGATION_RETRY_CONFIG);
+      expect(timeout).toBe(30000);
+    });
+
+    it("should quadruple timeout for third attempt with default config", () => {
+      const timeout = calculateTimeout(3, DEFAULT_NAVIGATION_RETRY_CONFIG);
+      expect(timeout).toBe(60000);
+    });
+
+    it("should use custom base timeout", () => {
+      const config: NavigationRetryConfig = {
+        baseTimeoutMs: 5000,
+        maxTimeoutMs: 100000,
+        maxAttempts: 3,
+        timeoutMultiplier: 2,
+      };
+      expect(calculateTimeout(1, config)).toBe(5000);
+      expect(calculateTimeout(2, config)).toBe(10000);
+      expect(calculateTimeout(3, config)).toBe(20000);
+    });
+
+    it("should use custom multiplier", () => {
+      const config: NavigationRetryConfig = {
+        baseTimeoutMs: 10000,
+        maxTimeoutMs: 100000,
+        maxAttempts: 3,
+        timeoutMultiplier: 3,
+      };
+      expect(calculateTimeout(1, config)).toBe(10000);
+      expect(calculateTimeout(2, config)).toBe(30000);
+      expect(calculateTimeout(3, config)).toBe(90000);
+    });
+
+    it("should handle multiplier of 1 (no escalation)", () => {
+      const config: NavigationRetryConfig = {
+        baseTimeoutMs: 15000,
+        maxTimeoutMs: 100000,
+        maxAttempts: 3,
+        timeoutMultiplier: 1,
+      };
+      expect(calculateTimeout(1, config)).toBe(15000);
+      expect(calculateTimeout(2, config)).toBe(15000);
+      expect(calculateTimeout(3, config)).toBe(15000);
+    });
+
+    it("should round to whole numbers", () => {
+      const config: NavigationRetryConfig = {
+        baseTimeoutMs: 10000,
+        maxTimeoutMs: 100000,
+        maxAttempts: 3,
+        timeoutMultiplier: 1.5,
+      };
+      expect(calculateTimeout(1, config)).toBe(10000);
+      expect(calculateTimeout(2, config)).toBe(15000);
+      expect(calculateTimeout(3, config)).toBe(22500);
+    });
+
+    it("should cap timeout at maxTimeoutMs", () => {
+      const config: NavigationRetryConfig = {
+        baseTimeoutMs: 10000,
+        maxTimeoutMs: 25000,
+        maxAttempts: 5,
+        timeoutMultiplier: 2,
+      };
+      expect(calculateTimeout(1, config)).toBe(10000);
+      expect(calculateTimeout(2, config)).toBe(20000);
+      expect(calculateTimeout(3, config)).toBe(25000); // capped (would be 40000)
+      expect(calculateTimeout(4, config)).toBe(25000); // capped (would be 80000)
+      expect(calculateTimeout(5, config)).toBe(25000); // capped (would be 160000)
+    });
+  });
+
+  describe("DEFAULT_NAVIGATION_RETRY_CONFIG", () => {
+    it("should have sensible defaults", () => {
+      expect(DEFAULT_NAVIGATION_RETRY_CONFIG.baseTimeoutMs).toBe(15000);
+      expect(DEFAULT_NAVIGATION_RETRY_CONFIG.maxTimeoutMs).toBe(60000);
+      expect(DEFAULT_NAVIGATION_RETRY_CONFIG.maxAttempts).toBe(3);
+      expect(DEFAULT_NAVIGATION_RETRY_CONFIG.timeoutMultiplier).toBe(2);
+    });
+  });
+
+  describe("NavigationTimeoutException", () => {
+    it("should create timeout exception with url and timeout", () => {
+      const error = new NavigationTimeoutException("https://slow-site.com", 30000);
+
+      expect(error).toBeInstanceOf(Error);
+      expect(error).toBeInstanceOf(BrowserException);
+      expect(error).toBeInstanceOf(NavigationTimeoutException);
+      expect(error.name).toBe("NavigationTimeoutException");
+      expect(error.url).toBe("https://slow-site.com");
+      expect(error.timeoutMs).toBe(30000);
+      expect(error.attempt).toBe(1);
+      expect(error.maxAttempts).toBe(1);
+      expect(error.isRecoverable).toBe(true);
+    });
+
+    it("should accept attempt info in context", () => {
+      const error = new NavigationTimeoutException("https://example.com", 15000, {
+        attempt: 2,
+        maxAttempts: 3,
+      });
+
+      expect(error.attempt).toBe(2);
+      expect(error.maxAttempts).toBe(3);
+    });
+
+    it("should generate descriptive message", () => {
+      const error = new NavigationTimeoutException("https://example.com", 15000, {
+        attempt: 1,
+        maxAttempts: 3,
+      });
+
+      expect(error.message).toBe(
+        "Navigation to 'https://example.com' timed out after 15000ms (attempt 1/3)",
+      );
+    });
+
+    it("should generate message for final attempt", () => {
+      const error = new NavigationTimeoutException("https://example.com", 60000, {
+        attempt: 3,
+        maxAttempts: 3,
+      });
+
+      expect(error.message).toBe(
+        "Navigation to 'https://example.com' timed out after 60000ms (attempt 3/3)",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Adds intelligent retry logic for navigation operations (goto, goBack, goForward) that handles both slow-loading pages and transient network failures.

  Changes

  - Tiered timeout retries: Navigation attempts start at 15s and escalate to 30s → 60s on timeout
  - Network error retries: Retries on connection failures (Chromium net::ERR_*, Firefox NS_ERROR_*/NS_BINDING_*)
  - Structured error types: NavigationTimeoutException and NavigationNetworkException with attempt info
  - Configurable: CLI options for timeout, max attempts, and multiplier (--navigation-timeout-ms, --navigation-max-attempts, etc.)