### PR TITLE
ci(addon): Run E2E tests in CI pipeline

### DIFF
--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -110,9 +110,21 @@ jobs:
           path: extension/playwright-report/
           retention-days: 30
 
+      - name: Check for test results
+        id: check-test-results
+        if: ${{ !cancelled() }}
+        run: |
+          if [ -d "extension/test-results" ]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "✓ Test results directory exists (tests failed or retried)"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "✓ No test results directory (all tests passed on first try)"
+          fi
+
       - name: Upload Playwright test results
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+        if: steps.check-test-results.outputs.exists == 'true'
         with:
           name: playwright-test-results
           path: extension/test-results/

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -82,7 +82,14 @@ jobs:
 
       - name: Get Playwright version
         id: playwright-version
-        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' extension/package.json)" >> $GITHUB_OUTPUT
+        run: |
+          set -euo pipefail
+          if [ ! -f extension/package.json ]; then
+            echo "Error: extension/package.json not found" >&2
+            exit 1
+          fi
+          version=$(jq -er '.devDependencies["@playwright/test"]' extension/package.json)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4
@@ -110,21 +117,9 @@ jobs:
           path: extension/playwright-report/
           retention-days: 30
 
-      - name: Check for test results
-        id: check-test-results
-        if: ${{ !cancelled() }}
-        run: |
-          if [ -d "extension/test-results" ]; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "✓ Test results directory exists (tests failed or retried)"
-          else
-            echo "exists=false" >> $GITHUB_OUTPUT
-            echo "✓ No test results directory (all tests passed on first try)"
-          fi
-
       - name: Upload Playwright test results
         uses: actions/upload-artifact@v4
-        if: steps.check-test-results.outputs.exists == 'true'
+        if: ${{ !cancelled() && hashFiles('extension/test-results/**') != '' }}
         with:
           name: playwright-test-results
           path: extension/test-results/

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -79,3 +79,41 @@ jobs:
 
       - name: Build extension for Chrome
         run: pnpm --filter spark-extension run build:chrome
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(jq -r '.devDependencies["@playwright/test"]' extension/package.json)" >> $GITHUB_OUTPUT
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm --filter spark-extension exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm --filter spark-extension exec playwright install-deps chromium
+
+      - name: Run extension e2e tests
+        run: pnpm --filter spark-extension run test:e2e:headless:chrome
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: extension/playwright-report/
+          retention-days: 30
+
+      - name: Upload Playwright test results
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-test-results
+          path: extension/test-results/
+          retention-days: 30

--- a/.github/workflows/extension_ci.yml
+++ b/.github/workflows/extension_ci.yml
@@ -88,7 +88,11 @@ jobs:
             echo "Error: extension/package.json not found" >&2
             exit 1
           fi
-          version=$(jq -er '.devDependencies["@playwright/test"]' extension/package.json)
+          version=$(jq -re '.devDependencies["@playwright/test"] // empty' extension/package.json)
+          if [ -z "$version" ]; then
+            echo "Error: @playwright/test devDependency not found in extension/package.json" >&2
+            exit 1
+          fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
@@ -119,8 +123,9 @@ jobs:
 
       - name: Upload Playwright test results
         uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && hashFiles('extension/test-results/**') != '' }}
+        if: ${{ !cancelled() }}
         with:
           name: playwright-test-results
           path: extension/test-results/
           retention-days: 30
+          if-no-files-found: ignore

--- a/extension/playwright.config.ts
+++ b/extension/playwright.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   retries: process.env.CI ? 2 : 0,
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: [["html", { outputFolder: "playwright-report" }]],
+  outputDir: "test-results",
   use: {
     trace: "on-first-retry",
   },


### PR DESCRIPTION
Add Playwright E2E test execution to extension CI workflow to catch bugs automatically on every push and pull request.

Cache Playwright browsers between runs to avoid ~200MB Chromium download on each CI execution. Upload test reports and traces as artifacts for debugging test failures.