### PR TITLE
GitHub Actions workflow for automated Spark evaluations

### DIFF
--- a/.github/workflows/trigger_eval.yml
+++ b/.github/workflows/trigger_eval.yml
@@ -1,0 +1,86 @@
+name: Trigger Spark Eval via Repository Dispatch
+
+# Triggers evaluation in spark-evals-judge via repository_dispatch event
+# when pushing to evals/** branches
+
+on:
+  push:
+    branches:
+      - "evals/**"
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-eval:
+    name: Trigger Eval in spark-evals-judge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Parse eval name from branch
+        id: parse
+        run: |
+          BRANCH="${{ github.ref }}"
+          echo "Branch: $BRANCH"
+
+          # Extract eval name from branch: refs/heads/evals/{eval_name}/...
+          if [[ "$BRANCH" =~ ^refs/heads/evals/([^/]+)/ ]]; then
+            EVAL_NAME="${BASH_REMATCH[1]}"
+            echo "eval_name=$EVAL_NAME" >> $GITHUB_OUTPUT
+            echo "✅ Parsed eval name: $EVAL_NAME"
+          else
+            echo "❌ Error: Branch does not match evals/{eval_name}/* pattern"
+            echo "   Expected format: evals/single/*, evals/partial/*, evals/full/*"
+            exit 1
+          fi
+
+      - name: Trigger repository_dispatch
+        run: |
+          echo "Sending repository_dispatch event to spark-evals-judge..."
+          echo ""
+          echo "Payload:"
+          echo "  eval_name: ${{ steps.parse.outputs.eval_name }}"
+          echo "  git_sha: ${{ github.sha }}"
+          echo "  git_ref: ${{ github.ref }}"
+          echo "  repo: ${{ github.repository }}"
+          echo "  commit_timestamp: ${{ github.event.head_commit.timestamp }}"
+          echo "  run_id: ${{ github.run_id }}"
+          echo ""
+
+          # Escape commit message for JSON (replace newlines, quotes, backslashes)
+          COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | jq -Rs .)
+
+          # Create payload file with proper JSON escaping
+          cat > payload.json <<EOF
+          {
+            "event_type": "spark_eval",
+            "client_payload": {
+              "eval_name": "${{ steps.parse.outputs.eval_name }}",
+              "git_sha": "${{ github.sha }}",
+              "git_ref": "${{ github.ref }}",
+              "repo": "${{ github.repository }}",
+              "commit_timestamp": "${{ github.event.head_commit.timestamp }}",
+              "commit_message": $COMMIT_MSG,
+              "trigger_timestamp": "${{ github.event.repository.updated_at }}",
+              "workflow_name": "${{ github.workflow }}",
+              "run_id": "${{ github.run_id }}",
+              "actor": "${{ github.actor }}"
+            }
+          }
+          EOF
+
+          # Send repository_dispatch event
+          curl -f -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.SPARK_EVALS_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Mozilla-Ocho/spark-evals-judge/dispatches \
+            --data @payload.json
+
+          echo ""
+          echo "✅ Repository dispatch event sent"
+          echo ""
+          echo "Monitor the eval at:"
+          echo "  https://github.com/Mozilla-Ocho/spark-evals-judge/actions"
+          echo ""
+          echo "Check commit status at:"
+          echo "  https://github.com/${{ github.repository }}/commit/${{ github.sha }}"

--- a/.github/workflows/trigger_eval.yml
+++ b/.github/workflows/trigger_eval.yml
@@ -49,6 +49,9 @@ jobs:
           # Escape commit message for JSON (replace newlines, quotes, backslashes)
           COMMIT_MSG=$(echo '${{ github.event.head_commit.message }}' | jq -Rs .)
 
+          # Generate current timestamp
+          TRIGGER_TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
           # Create payload file with proper JSON escaping
           cat > payload.json <<EOF
           {
@@ -60,7 +63,7 @@ jobs:
               "repo": "${{ github.repository }}",
               "commit_timestamp": "${{ github.event.head_commit.timestamp }}",
               "commit_message": $COMMIT_MSG,
-              "trigger_timestamp": "${{ github.event.repository.updated_at }}",
+              "trigger_timestamp": "$TRIGGER_TIMESTAMP",
               "workflow_name": "${{ github.workflow }}",
               "run_id": "${{ github.run_id }}",
               "actor": "${{ github.actor }}"
@@ -69,12 +72,39 @@ jobs:
           EOF
 
           # Send repository_dispatch event
-          curl -f -X POST \
+          HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" \
+            -X POST \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.SPARK_EVALS_DISPATCH_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/Mozilla-Ocho/spark-evals-judge/dispatches \
-            --data @payload.json
+            --data @payload.json)
+
+          echo ""
+          echo "GitHub API HTTP status: $HTTP_STATUS"
+
+          # Check HTTP status code
+          if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
+            echo "❌ Error: Failed to send repository_dispatch event (HTTP $HTTP_STATUS)"
+            if [[ -s response.json ]]; then
+              echo "Response body:"
+              cat response.json
+            fi
+            exit 1
+          fi
+
+          # Even with 200 OK, check for error in response body
+          if [[ -s response.json ]]; then
+            if grep -q '"message"' response.json || grep -q '"error"' response.json; then
+              echo "⚠️  Warning: Response contains error/message field:"
+              cat response.json
+              # GitHub API sometimes returns errors with 200 OK
+              if grep -qi '"Not Found"' response.json || grep -qi '"Bad credentials"' response.json; then
+                echo "❌ Error: API call failed despite 200 OK status"
+                exit 1
+              fi
+            fi
+          fi
 
           echo ""
           echo "✅ Repository dispatch event sent"

--- a/README.md
+++ b/README.md
@@ -322,6 +322,22 @@ pnpm run format
 
 Built with TypeScript, Playwright, and the Vercel AI SDK.
 
+## Evaluation System
+
+Spark includes an automated evaluation system that tests changes against the WebVoyager benchmark. Push to an `evals/**` branch to trigger evaluation runs:
+
+```bash
+# Quick smoke test (1 task)
+git checkout -b evals/single/my-test
+git push origin evals/single/my-test
+
+# Validation run (30 tasks)
+git checkout -b evals/partial/my-experiment
+git push origin evals/partial/my-experiment
+```
+
+Results appear as commit status checks with links to detailed HTML reports. See [spark-evals-judge/docs/spark-evaluations.md](https://github.com/Mozilla-Ocho/spark-evals-judge/blob/main/docs/spark-evaluations.md) for complete documentation.
+
 ## Configuration Reference
 
 ### Complete CLI Options


### PR DESCRIPTION
This PR adds a workflow that kicks off a workflow in the spark-evals-judge [via repository_dispatch API](https://github.com/Mozilla-Ocho/spark-evals-judge/actions/workflows/handle_spark_eval.yml). That keeps the spark repo side of things simple and concentrates eval-related code & secrets over in spark-evals-judge.

Should be able to see the system in action with the commit status checks that show up in this PR.