### PR TITLE
Change extension default provider to OpenRouter, default model to gemini-2.5-flash

### DIFF
--- a/extension/src/AgentManager.ts
+++ b/extension/src/AgentManager.ts
@@ -84,7 +84,7 @@ export class AgentManager {
    * Get the default model for a provider
    */
   private static getDefaultModel(provider: "openai" | "openrouter"): string {
-    return provider === "openrouter" ? "openai/gpt-4.1-mini" : "gpt-4.1-mini";
+    return provider === "openrouter" ? "google/gemini-2.5-flash" : "gpt-4.1-mini";
   }
 
   /**

--- a/extension/src/components/sidepanel/SettingsView.tsx
+++ b/extension/src/components/sidepanel/SettingsView.tsx
@@ -12,6 +12,21 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
 
   const focusRing = "focus:ring-2 focus:ring-blue-500 focus:border-transparent";
 
+  const handleProviderChange = (newProvider: "openai" | "openrouter") => {
+    const updates: Partial<typeof settings> = { provider: newProvider };
+
+    // If switching to OpenAI and endpoint is empty, prefill with default
+    if (newProvider === "openai" && !settings.apiEndpoint) {
+      updates.apiEndpoint = "https://api.openai.com/v1";
+    }
+    // If switching to OpenRouter, clear the endpoint (not used)
+    else if (newProvider === "openrouter") {
+      updates.apiEndpoint = "";
+    }
+
+    updateSettings(updates);
+  };
+
   const handleSave = async () => {
     await saveSettings();
     // Auto-close settings after successful save
@@ -43,9 +58,7 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
               <label className={`block text-sm font-medium ${t.text.secondary}`}>Provider</label>
               <select
                 value={settings.provider}
-                onChange={(e) =>
-                  updateSettings({ provider: e.target.value as "openai" | "openrouter" })
-                }
+                onChange={(e) => handleProviderChange(e.target.value as "openai" | "openrouter")}
                 className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} focus:outline-none ${focusRing}`}
               >
                 <option value="openai">OpenAI</option>
@@ -59,7 +72,7 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
                 type="text"
                 value={settings.model}
                 onChange={(e) => updateSettings({ model: e.target.value })}
-                placeholder="gpt-4.1-mini"
+                placeholder="google/gemini-2.5-flash"
                 className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} placeholder-gray-400 focus:outline-none ${focusRing}`}
               />
             </div>
@@ -72,7 +85,7 @@ export default function SettingsView({ onBack }: SettingsViewProps): ReactElemen
                 type="text"
                 value={settings.apiEndpoint}
                 onChange={(e) => updateSettings({ apiEndpoint: e.target.value })}
-                placeholder="https://api.openai.com/v1"
+                placeholder="Optional for OpenAI only"
                 className={`w-full px-3 py-2 ${t.bg.input} border ${t.border.input} rounded-lg ${t.text.primary} placeholder-gray-400 focus:outline-none ${focusRing}`}
               />
             </div>

--- a/extension/src/stores/settingsStore.ts
+++ b/extension/src/stores/settingsStore.ts
@@ -23,9 +23,9 @@ export interface SettingsStore {
 
 const defaultSettings: Settings = {
   apiKey: "",
-  apiEndpoint: "https://api.openai.com/v1",
-  model: "gpt-4.1-mini",
-  provider: "openai",
+  apiEndpoint: "",
+  model: "google/gemini-2.5-flash",
+  provider: "openrouter",
 };
 
 // Create browser storage adapter for settings

--- a/extension/test/AgentManager.test.ts
+++ b/extension/test/AgentManager.test.ts
@@ -103,13 +103,13 @@ describe("AgentManager", () => {
   });
 
   describe("OpenRouter Default Model", () => {
-    it("should use openai/gpt-4.1-mini as default for OpenRouter", async () => {
+    it("should use google/gemini-2.5-flash as default for OpenRouter", async () => {
       await AgentManager.runTask("test task", {
         apiKey: "test-openrouter-key",
         provider: "openrouter",
       });
 
-      expect(mockOpenRouter).toHaveBeenCalledWith("openai/gpt-4.1-mini");
+      expect(mockOpenRouter).toHaveBeenCalledWith("google/gemini-2.5-flash");
     });
 
     it("should use gpt-4.1-mini as default for OpenAI", async () => {

--- a/extension/test/components/SettingsView.test.tsx
+++ b/extension/test/components/SettingsView.test.tsx
@@ -10,9 +10,9 @@ vi.mock("src/stores/settingsStore", () => ({
   useSettings: vi.fn(() => ({
     settings: {
       apiKey: "test-key",
-      apiEndpoint: "https://api.openai.com/v1",
-      model: "gpt-4.1-mini",
-      provider: "openai",
+      apiEndpoint: "",
+      model: "google/gemini-2.5-flash",
+      provider: "openrouter",
     },
     saveStatus: null,
     updateSettings: mockUpdateSettings,
@@ -74,7 +74,7 @@ describe("SettingsView - Provider Dropdown", () => {
       render(<SettingsView onBack={mockOnBack} />);
 
       const providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
-      expect(providerSelect.value).toBe("openai");
+      expect(providerSelect.value).toBe("openrouter");
     });
 
     it("should show OpenAI and OpenRouter options", () => {
@@ -107,7 +107,7 @@ describe("SettingsView - Provider Dropdown", () => {
       const providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
 
       // Check that provider value is set
-      expect(providerSelect.value).toBe("openai");
+      expect(providerSelect.value).toBe("openrouter");
     });
   });
 
@@ -116,12 +116,12 @@ describe("SettingsView - Provider Dropdown", () => {
       const { rerender } = render(<SettingsView onBack={mockOnBack} />);
 
       let providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
-      expect(providerSelect.value).toBe("openai");
+      expect(providerSelect.value).toBe("openrouter");
 
       rerender(<SettingsView onBack={mockOnBack} />);
 
       providerSelect = screen.getByRole("combobox") as HTMLSelectElement;
-      expect(providerSelect.value).toBe("openai");
+      expect(providerSelect.value).toBe("openrouter");
     });
 
     it("should have save button", () => {
@@ -162,13 +162,13 @@ describe("SettingsView - Provider Dropdown", () => {
   });
 
   describe("Provider-specific behavior", () => {
-    it("should display OpenAI as default provider", () => {
+    it("should display OpenRouter as default provider", () => {
       render(<SettingsView onBack={mockOnBack} />);
 
       const providerSelect = screen.getByRole("combobox");
 
-      // Should start as OpenAI
-      expect((providerSelect as HTMLSelectElement).value).toBe("openai");
+      // Should start as OpenRouter
+      expect((providerSelect as HTMLSelectElement).value).toBe("openrouter");
     });
 
     it("should have both OpenAI and OpenRouter as selectable options", () => {

--- a/extension/test/stores/settingsStore.test.ts
+++ b/extension/test/stores/settingsStore.test.ts
@@ -78,9 +78,9 @@ describe("Storage Loading", () => {
     useSettingsStore.setState({
       settings: {
         apiKey: "",
-        apiEndpoint: "https://api.openai.com/v1",
-        model: "gpt-4.1-mini",
-        provider: "openai",
+        apiEndpoint: "",
+        model: "google/gemini-2.5-flash",
+        provider: "openrouter",
       },
       saveStatus: null,
     });
@@ -113,8 +113,8 @@ describe("Storage Loading", () => {
     // Load settings
     await useSettingsStore.getState().loadSettings();
 
-    // Verify provider falls back to openai
-    expect(useSettingsStore.getState().settings.provider).toBe("openai");
+    // Verify provider falls back to openrouter
+    expect(useSettingsStore.getState().settings.provider).toBe("openrouter");
   });
 
   it("should fallback to default provider for invalid values", async () => {
@@ -129,7 +129,7 @@ describe("Storage Loading", () => {
     // Load settings
     await useSettingsStore.getState().loadSettings();
 
-    // Verify provider falls back to openai
-    expect(useSettingsStore.getState().settings.provider).toBe("openai");
+    // Verify provider falls back to openrouter
+    expect(useSettingsStore.getState().settings.provider).toBe("openrouter");
   });
 });


### PR DESCRIPTION
https://linear.app/moztabs/issue/TABS-510/make-gemini-25-flash-add-on-default

Quick & dirty approach, here: Switch to openrouter with gemini 2.5 flash as defaults.

Can add further model provider support as a follow up - i.e. to support google gemini APIs directly