### PR TITLE
 Add Google Generative AI and Ollama provider support to extension

### DIFF
--- a/extension/README.md
+++ b/extension/README.md
@@ -29,3 +29,37 @@ pnpm zip:chrome     # Chrome
 pnpm test           # Run tests
 pnpm test:watch     # Watch mode
 ```
+
+## Supported AI Providers
+
+The extension supports multiple AI providers:
+
+- **OpenAI** - Cloud service with API key authentication
+- **OpenRouter** - Cloud service with API key authentication (default)
+- **Google Generative AI** - Cloud service with API key authentication
+- **Ollama** - Local models with optional API key
+
+### Using Ollama (Local Models)
+
+To use Ollama with the browser extension, you need to configure CORS settings:
+
+**Option 1: Enable in Ollama App**
+
+1. Open Ollama app settings
+2. Enable "Expose Ollama to the network"
+3. Restart Ollama if needed
+
+**Option 2: Set Environment Variable**
+
+```bash
+OLLAMA_ORIGINS="*" ollama serve
+```
+
+This is required because the browser extension sends `Origin` headers with requests, and Ollama needs to be configured to accept cross-origin requests from browser extensions.
+
+In the extension settings:
+
+- **Provider**: Select "Ollama (Local)"
+- **Base URL**: Default is `http://localhost:11434/api`
+- **Model**: Use any model you have installed (e.g., `llama3`, `qwen3-vl`)
+- **API Key**: Optional (leave empty for local use)

--- a/extension/entrypoints/background.ts
+++ b/extension/entrypoints/background.ts
@@ -21,7 +21,7 @@ interface StorageSettings {
   apiKey?: string;
   apiEndpoint?: string;
   model?: string;
-  provider?: "openai" | "openrouter";
+  provider?: "openai" | "openrouter" | "google" | "ollama";
 }
 
 export default defineBackground(() => {
@@ -119,7 +119,8 @@ export default defineBackground(() => {
               apiEndpoint: settings.apiEndpoint,
             });
 
-            if (!settings.apiKey) {
+            // API key is optional for Ollama
+            if (!settings.apiKey && settings.provider !== "ollama") {
               response = {
                 success: false,
                 message: "API key not configured. Please set up your credentials first.",
@@ -174,7 +175,7 @@ export default defineBackground(() => {
 
               // Use AgentManager to run the task with AbortSignal
               const result = await AgentManager.runTask(executeMessage.task, {
-                apiKey: settings.apiKey,
+                apiKey: settings.apiKey || "",
                 apiEndpoint: settings.apiEndpoint,
                 model: settings.model || "gpt-4.1-mini",
                 provider: settings.provider,

--- a/extension/src/AgentManager.ts
+++ b/extension/src/AgentManager.ts
@@ -5,6 +5,8 @@ import { EventStoreLogger } from "./EventStoreLogger";
 import { WebAgent, Logger } from "spark/core";
 import { createOpenAI } from "@ai-sdk/openai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { createOllama } from "ollama-ai-provider-v2";
 
 /**
  * OpenRouter attribution headers
@@ -24,10 +26,10 @@ export class AgentManager {
    *
    * @param task - The task description in natural language
    * @param options - Configuration options
-   * @param options.apiKey - API key for the provider
+   * @param options.apiKey - API key for the provider (optional for Ollama)
    * @param options.provider - AI provider to use (defaults to "openai")
    * @param options.model - Model name (uses provider-specific defaults if not specified)
-   * @param options.apiEndpoint - Custom API endpoint (OpenAI only, ignored for OpenRouter)
+   * @param options.apiEndpoint - Custom API endpoint (used by OpenAI and Ollama)
    * @param options.logger - Custom logger implementation
    * @param options.tabId - Browser tab ID to operate on
    * @param options.data - Additional context data
@@ -40,7 +42,7 @@ export class AgentManager {
       apiKey: string;
       apiEndpoint?: string;
       model?: string;
-      provider?: "openai" | "openrouter";
+      provider?: "openai" | "openrouter" | "google" | "ollama";
       logger?: Logger;
       tabId?: number;
       data?: any;
@@ -83,36 +85,65 @@ export class AgentManager {
   /**
    * Get the default model for a provider
    */
-  private static getDefaultModel(provider: "openai" | "openrouter"): string {
-    return provider === "openrouter" ? "google/gemini-2.5-flash" : "gpt-4.1-mini";
+  private static getDefaultModel(provider: "openai" | "openrouter" | "google" | "ollama"): string {
+    switch (provider) {
+      case "openrouter":
+        return "google/gemini-2.5-flash";
+      case "google":
+        return "gemini-2.5-flash";
+      case "ollama":
+        return "llama3.2";
+      default:
+        return "gpt-4.1-mini";
+    }
   }
 
   /**
    * Create a provider-specific model instance
    *
-   * Note: apiEndpoint is only used for OpenAI provider.
-   * OpenRouter uses its own fixed endpoint and ignores this parameter.
+   * Note: apiEndpoint is used by OpenAI and Ollama providers.
+   * Other providers use their own fixed endpoints and ignore this parameter.
    */
   private static createProviderModel(
-    provider: "openai" | "openrouter",
+    provider: "openai" | "openrouter" | "google" | "ollama",
     apiKey: string,
     apiEndpoint: string | undefined,
     modelName: string,
   ) {
-    if (provider === "openrouter") {
-      // OpenRouter has its own endpoint, apiEndpoint parameter is ignored
-      const openrouter = createOpenRouter({
-        apiKey,
-        headers: OPENROUTER_HEADERS,
-      });
-      return openrouter(modelName);
-    } else {
-      const endpoint = apiEndpoint || "https://api.openai.com/v1";
-      const openai = createOpenAI({
-        apiKey,
-        baseURL: endpoint,
-      });
-      return openai(modelName);
+    switch (provider) {
+      case "openrouter": {
+        // OpenRouter has its own endpoint, apiEndpoint parameter is ignored
+        const openrouter = createOpenRouter({
+          apiKey,
+          headers: OPENROUTER_HEADERS,
+        });
+        return openrouter(modelName);
+      }
+
+      case "google": {
+        const google = createGoogleGenerativeAI({
+          apiKey,
+        });
+        return google(modelName);
+      }
+
+      case "ollama": {
+        const baseURL = apiEndpoint || "http://localhost:11434/api";
+        const ollama = createOllama({
+          baseURL,
+        });
+        return ollama(modelName);
+      }
+
+      default: {
+        // OpenAI
+        const endpoint = apiEndpoint || "https://api.openai.com/v1";
+        const openai = createOpenAI({
+          apiKey,
+          baseURL: endpoint,
+        });
+        return openai(modelName);
+      }
     }
   }
 }

--- a/extension/src/components/sidepanel/ChatView.tsx
+++ b/extension/src/components/sidepanel/ChatView.tsx
@@ -484,7 +484,8 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
 
   const handleExecute = async () => {
     if (!task.trim()) return;
-    if (!settings.apiKey) {
+    // API key is optional for Ollama
+    if (!settings.apiKey && settings.provider !== "ollama") {
       addMessage("system", "Please configure your API key in settings first");
       onOpenSettings();
       return;
@@ -530,7 +531,7 @@ export default function ChatView({ currentTab, onOpenSettings }: ChatViewProps):
       // once we add status events in, we should drop the number back down.
       const messagePromise = browser.runtime.sendMessage(message);
       const timeoutPromise = new Promise(
-        (_, reject) => setTimeout(() => reject(new Error("Background script timeout")), 300000), // 5 mins
+        (_, reject) => setTimeout(() => reject(new Error("Background script timeout")), 600000), // 10 mins
       );
 
       let response: ExecuteTaskResponse;

--- a/extension/src/components/sidepanel/SidePanel.tsx
+++ b/extension/src/components/sidepanel/SidePanel.tsx
@@ -72,11 +72,12 @@ export default function SidePanel(): ReactElement {
   }, []);
 
   // Show settings automatically if no API key is configured (only after settings load)
+  // API key is optional for Ollama
   useEffect(() => {
-    if (settingsLoaded && !settings.apiKey) {
+    if (settingsLoaded && !settings.apiKey && settings.provider !== "ollama") {
       setCurrentView("settings");
     }
-  }, [settingsLoaded, settings.apiKey]);
+  }, [settingsLoaded, settings.apiKey, settings.provider]);
 
   const loadCurrentTab = async () => {
     try {

--- a/extension/src/stores/settingsStore.ts
+++ b/extension/src/stores/settingsStore.ts
@@ -7,7 +7,7 @@ export interface Settings {
   apiKey: string;
   apiEndpoint: string;
   model: string;
-  provider: "openai" | "openrouter";
+  provider: "openai" | "openrouter" | "google" | "ollama";
 }
 
 export interface SettingsStore {
@@ -96,9 +96,13 @@ export const useSettingsStore = create<SettingsStore>()(
           ]);
 
           // Validate provider value
-          const isValidProvider = stored.provider === "openai" || stored.provider === "openrouter";
+          const isValidProvider =
+            stored.provider === "openai" ||
+            stored.provider === "openrouter" ||
+            stored.provider === "google" ||
+            stored.provider === "ollama";
           const provider = isValidProvider
-            ? (stored.provider as "openai" | "openrouter")
+            ? (stored.provider as "openai" | "openrouter" | "google" | "ollama")
             : defaultSettings.provider;
 
           const newSettings: Settings = {

--- a/extension/test/components/SettingsView.test.tsx
+++ b/extension/test/components/SettingsView.test.tsx
@@ -189,10 +189,10 @@ describe("SettingsView - Provider Dropdown", () => {
     it("should render all required fields including provider", () => {
       render(<SettingsView onBack={mockOnBack} />);
 
-      expect(screen.getByText("API Key")).toBeInTheDocument();
       expect(screen.getByText("Provider")).toBeInTheDocument();
-      expect(screen.getByText("API Endpoint")).toBeInTheDocument();
       expect(screen.getByText("Model")).toBeInTheDocument();
+      expect(screen.getByText(/API Endpoint/)).toBeInTheDocument();
+      expect(screen.getByText(/API Key/)).toBeInTheDocument();
     });
   });
 });

--- a/extension/test/stores/settingsStore.test.ts
+++ b/extension/test/stores/settingsStore.test.ts
@@ -113,7 +113,7 @@ describe("Storage Loading", () => {
     // Load settings
     await useSettingsStore.getState().loadSettings();
 
-    // Verify provider falls back to openrouter
+    // Verify provider falls back to openrouter (the default)
     expect(useSettingsStore.getState().settings.provider).toBe("openrouter");
   });
 
@@ -129,7 +129,7 @@ describe("Storage Loading", () => {
     // Load settings
     await useSettingsStore.getState().loadSettings();
 
-    // Verify provider falls back to openrouter
+    // Verify provider falls back to openrouter (the default)
     expect(useSettingsStore.getState().settings.provider).toBe("openrouter");
   });
 });


### PR DESCRIPTION
We might want to poke at this a bit more to decide if we want to support Google & Ollama in the extension directly. But this seems to work? Ollama works on my machine with a local model, albeit very very slowly

This is basically a follow-up to the more quick & dirty OpenRouter default in this PR: https://github.com/Mozilla-Ocho/spark/pull/251

Expands browser extension to support Google Generative AI (cloud) and
Ollama (local) providers in addition to existing OpenAI and OpenRouter
support. Browser extension environment bypasses CORS restrictions,
enabling direct connections to both cloud APIs and local Ollama servers.

Key changes:
- Add Google provider with simple API key authentication
- Add Ollama provider with optional API key and configurable base URL
- Unify apiEndpoint field to serve both OpenAI and Ollama endpoints
- Make API key optional when using Ollama provider
- Add dynamic UI labels and placeholders based on selected provider
- Refactor SettingsView helper functions for improved maintainability
- Update all tests to reflect new provider options and defaults