### PR TITLE
Add local secret scanning with gitleaks for TABS-758

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Pre-commit hook to scan for secrets using gitleaks
+# This hook is optional - see CLAUDE.md for installation instructions
+
+set -e
+
+echo "🔍 Scanning for secrets with gitleaks..."
+
+# Check if gitleaks is installed
+if ! command -v gitleaks &> /dev/null; then
+    echo "❌ gitleaks is not installed. Install it with:"
+    echo "   brew install gitleaks  (macOS)"
+    echo "   or visit: https://github.com/gitleaks/gitleaks"
+    exit 1
+fi
+
+# Run gitleaks on staged changes
+if gitleaks protect --staged -v; then
+    echo "✅ No secrets detected"
+    exit 0
+else
+    echo ""
+    echo "❌ Gitleaks found potential secrets!"
+    echo ""
+    echo "Options:"
+    echo "  1. Remove the secret from your staged changes"
+    echo "  2. If it's a false positive, add the fingerprint to .gitleaksignore"
+    echo "  3. Use 'git commit --no-verify' to bypass this check (not recommended)"
+    echo ""
+    exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@ dist
 .env.*
 .DS_Store
 *.txt
-CLAUDE.md
 scripts/docker-build.sh
 debug
 coverage

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,6 @@
+# Gitleaks ignore file
+# Add fingerprints of false positives to ignore specific findings
+# Format: commit_hash:file_path:rule_id:line_number
+
+# False positive: test value in historical commit (fixed in current code)
+12323684c2a470321a34fea845a9556eb8b644d1:test/cli/provider.test.ts:generic-api-key:223

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# Spark Project - Claude Instructions
+
+## Project Overview
+
+Spark is an AI-powered web automation library and CLI tool that lets you control browsers using natural language. The project consists of:
+
+- **Core library** (`src/`) - Main automation engine
+- **CLI** (`src/cli/`) - Command-line interface
+- **Extension** (`extension/`) - Browser extension
+- **Server** (`server/`) - Server component
+
+## Common Commands
+
+### Testing
+
+```bash
+pnpm test              # Run all tests
+pnpm test:watch        # Run tests in watch mode
+```
+
+### Development
+
+```bash
+pnpm build             # Build the project (TypeScript compilation)
+pnpm typecheck         # Run TypeScript type checking
+pnpm format            # Format code with Prettier
+pnpm format:check      # Check code formatting
+pnpm check             # Run format + typecheck + test (full validation)
+```
+
+### Running Spark CLI
+
+```bash
+pnpm spark <command>   # Run spark CLI locally (uses tsx)
+pnpm spark run "task"  # Run an automation task
+pnpm spark config      # Configure AI provider settings
+```
+
+### Installation & Setup
+
+```bash
+pnpm install           # Install dependencies
+pnpm playwright install # Install browser automation drivers
+pnpm install-cli       # Build and install CLI globally
+```
+
+## Project Structure
+
+- `src/` - Core library source code
+  - `browser/` - Browser automation implementations
+  - `cli/` - CLI commands and configuration
+  - `tools/` - AI agent tools
+  - `utils/` - Utility functions
+- `test/` - Test files (mirrors src structure)
+- `extension/` - Browser extension code
+- `server/` - Server component
+- `docs/` - Documentation
+- `scripts/` - Build and deployment scripts
+
+## Development Workflow
+
+1. **Before making changes**: Run `pnpm check` to ensure everything is clean
+2. **After making changes**:
+   - Run `pnpm format` to format code
+   - Run `pnpm typecheck` to check types
+   - Run `pnpm test` to verify tests pass
+3. **Full validation**: Run `pnpm check` (does all three)
+
+## Testing
+
+- Tests use Vitest
+- Test files are in `test/` directory, mirroring the `src/` structure
+- Mocking is done with `vi.mock()` from Vitest
+
+## AI Provider Configuration
+
+Spark supports multiple AI providers:
+
+- OpenAI
+- OpenRouter (default)
+- Google Generative AI
+- Ollama
+- Vertex AI
+
+Configure with: `pnpm spark config --init`
+
+## Security - Secret Scanning
+
+**⚠️ CRITICAL: Always scan for secrets before committing and especially before pushing to GitHub!**
+
+### Scanning for Secrets
+
+```bash
+# Scan uncommitted changes (fast - use before commits)
+gitleaks protect -v
+
+# Scan entire Git history (slower - good for audits)
+gitleaks detect -v
+
+# Install gitleaks if not already installed
+brew install gitleaks  # macOS
+```
+
+### Workflow
+
+1. **Before committing**: Run `gitleaks protect -v` to catch secrets in staged changes
+2. **Before pushing**: Run `gitleaks detect -v` to scan recent commits
+3. **If a false positive is found**: Add the fingerprint to `.gitleaksignore`
+
+### Optional: Pre-Commit Hook (Recommended)
+
+A pre-commit hook is available to automatically scan for secrets before each commit. **This is optional but recommended.**
+
+To enable it:
+
+```bash
+# One-time setup: configure Git to use the .githooks directory
+git config core.hooksPath .githooks
+
+# Verify it's working (should run the gitleaks scan)
+git commit --allow-empty -m "test hook"
+```
+
+To disable it:
+
+```bash
+# Revert to default hooks directory
+git config --unset core.hooksPath
+```
+
+**Note**: The hook can be bypassed with `git commit --no-verify`, but this is not recommended unless you have a specific reason (e.g., known false positive already documented).
+
+### Best Practices
+
+- **Never commit real API keys** - use test values like `"fake-key-123"` in tests
+- **Test values should not look like real secrets** - avoid patterns like `sk-*`, `key_*`, etc.
+- `.gitleaksignore` contains fingerprints of known false positives
+
+### False Positives
+
+If gitleaks flags a test value:
+
+1. **Preferred**: Change the test value to something obviously fake (e.g., `"fake-test-key-123"`)
+2. **Alternative**: Add the fingerprint from gitleaks output to `.gitleaksignore`
+
+## Important Notes
+
+- Node version: ^22.0.0 (specified in package.json engines)
+- Package manager: pnpm 9.0.0
+- The project is working toward being open-sourced

--- a/README.md
+++ b/README.md
@@ -404,6 +404,33 @@ Contributions welcome! When submitting pull requests:
 - Run `pnpm check` before submitting
 - Follow existing code style and patterns
 
+### Optional: Pre-Commit Hook for Secret Scanning
+
+Spark includes an optional pre-commit hook that automatically scans for secrets before each commit using [gitleaks](https://github.com/gitleaks/gitleaks).
+
+**To enable (recommended for contributors):**
+
+```bash
+# Install gitleaks
+brew install gitleaks  # macOS
+# or download from: https://github.com/gitleaks/gitleaks
+
+# Enable the pre-commit hook (one-time setup)
+git config core.hooksPath .githooks
+```
+
+The hook will now run automatically before each commit. If a potential secret is detected, the commit will be blocked and you'll see instructions on how to proceed.
+
+**To disable:**
+
+```bash
+git config --unset core.hooksPath
+```
+
+**Note:** The hook can be bypassed with `git commit --no-verify` if needed, but this is not recommended unless you're certain the flagged content is a false positive that's already documented in `.gitleaksignore`.
+
+Built with TypeScript, Playwright, and the Vercel AI SDK.
+
 ## Evaluation System
 
 Spark includes an automated evaluation system that tests changes against the WebVoyager benchmark. Push to an `evals/**` branch to trigger evaluation runs:

--- a/test/cli/provider.test.ts
+++ b/test/cli/provider.test.ts
@@ -673,7 +673,7 @@ describe("Provider", () => {
       mockConfig.getConfig.mockReturnValue({
         ...defaults,
         provider: "openrouter",
-        openrouter_api_key: "sk-or-global123",
+        openrouter_api_key: "fake-global-key-123",
       });
 
       const info = getAIProviderInfo();


### PR DESCRIPTION
Implements secret scanning to prevent accidental credential leaks:

- Add optional pre-commit hook (.githooks/pre-commit) that runs gitleaks on staged changes before commit
- Create .gitleaksignore with fingerprint for historical false positive
- Update test value in provider.test.ts to avoid triggering scanner (changed "sk-or-global123" to "fake-global-key-123")
- Add comprehensive secret scanning documentation to CLAUDE.md including workflow, best practices, and setup instructions
- Document opt-in pre-commit hook setup in README.md

Using local-only scanning for now (pre-commit hook + manual scans). CI/CD scanning deferred until repo goes public and GitHub provides free secret scanning, or until gitleaks license is obtained.

Addresses: TABS-758