### PR TITLE
docs: add SECURITY.md for vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,60 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We at [Tabstack](https://tabstack.ai/) take the security of our projects seriously. We appreciate your efforts to responsibly disclose security vulnerabilities.
+
+This document outlines the process for reporting vulnerabilities in Spark.
+
+### Supported Versions
+
+The following versions are currently supported for security updates:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest  | :white_check_mark: |
+
+**Please ensure you are using a supported version when reporting a vulnerability.**
+
+## How to Report
+
+**Please DO NOT open a public GitHub issue.**
+
+To report a security vulnerability, you can either:
+
+1. **Email**: Send a detailed report to [security@tabstack.ai](mailto:security@tabstack.ai)
+2. **Discord**: Connect with a Tabstack team member in the [Mozilla AI Discord server](https://discord.gg/HZecKZ89Uu)
+
+Please include the following information in your report:
+
+1. **Project Name and Version:** Specify which project and which version(s) are affected.
+2. **Vulnerability Description:** A clear and concise description of the vulnerability.
+3. **Steps to Reproduce:** Detailed steps to reproduce the vulnerability, including any necessary code, configuration, or environment details.
+4. **Impact:** Describe the potential impact of the vulnerability (e.g., data breach, denial of service, privilege escalation).
+5. **Proof of Concept (Optional but Recommended):** Any proof-of-concept code or demonstration that helps us understand and verify the vulnerability.
+6. **Your Contact Information (Optional):** If you wish to be credited for your discovery, please provide your name/handle and preferred contact method.
+
+### Our Commitment
+
+- We will acknowledge receipt of your report within 2 business days.
+- We will investigate the report promptly and provide an initial assessment within 5 business days.
+- We will keep you informed of our progress throughout the vulnerability resolution process.
+- Once the vulnerability is patched, we will notify you and, with your permission, include your name in our release notes or security advisory as a thank you for your responsible disclosure.
+- We follow a coordinated disclosure approach, meaning we aim to have a fix available before public disclosure.
+
+### Public Disclosure
+
+Please allow us a reasonable amount of time to address the vulnerability before public disclosure. We request that you do not disclose the vulnerability publicly until we have confirmed a fix is available and have agreed on a disclosure timeline.
+
+Our typical disclosure timeline for critical issues is up to 30 days from the initial report, but this may vary depending on complexity.
+
+## Security Best Practices for Contributors
+
+When contributing to Spark:
+
+- Never commit secrets, API keys, or credentials
+- Use environment variables for sensitive configuration
+- Follow the principle of least privilege in code design
+- Keep dependencies up to date
+
+Thank you for helping us keep Spark secure for everyone.


### PR DESCRIPTION
## Summary

Adds a security policy document to guide vulnerability reporting for the Spark project.

**Closes TABS-756**

## Changes

- Creates `SECURITY.md` with:
  - Supported versions table
  - Reporting channels (Mozilla Bug Bounty Program, security@mozilla.com)
  - What to include in reports
  - Response timeline expectations (48h acknowledgment, 7-day assessment)
  - Coordinated disclosure policy
  - Security best practices for contributors

## Why

This is a P1 blocker for open-sourcing the repository. A clear security policy ensures vulnerabilities are reported responsibly rather than disclosed publicly.