### PR TITLE
docs: add GOVERNANCE.md defining project roles and merge rights

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,72 @@
+# Governance
+
+This document describes the governance model for the Spark project.
+
+## Overview
+
+Spark is developed and maintained by the Tabstack team at Mozilla. We welcome contributions from the community and aim to make the contribution process transparent and collaborative.
+
+## Roles
+
+### Maintainers
+
+Maintainers have full write access to the repository and are responsible for:
+
+- Reviewing and merging pull requests
+- Managing releases
+- Setting project direction and priorities
+- Ensuring code quality and architectural consistency
+
+**Current Maintainers:**
+
+| Name            | GitHub                                     | Role            |
+| --------------- | ------------------------------------------ | --------------- |
+| Travis Beauvais | [@tbeauvais](https://github.com/tbeauvais) | Lead Maintainer |
+
+### Contributors
+
+Contributors are community members who contribute to the project through:
+
+- Submitting pull requests
+- Reporting bugs and issues
+- Improving documentation
+- Participating in discussions
+
+All contributors are expected to follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Decision Making
+
+### Day-to-Day Decisions
+
+Routine decisions (bug fixes, minor features, documentation updates) are made by maintainers through the normal pull request review process.
+
+### Significant Changes
+
+For significant changes (new features, architectural changes, breaking changes):
+
+1. Open an issue or discussion to propose the change
+2. Allow time for community feedback (typically 1-2 weeks for major changes)
+3. Maintainers will make the final decision, taking community input into account
+
+### Conflict Resolution
+
+If consensus cannot be reached, the Lead Maintainer has final decision-making authority.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
+
+## Becoming a Maintainer
+
+Maintainer status is granted to contributors who have demonstrated:
+
+- Consistent, high-quality contributions over time
+- Deep understanding of the codebase and project goals
+- Commitment to the project's long-term success
+- Alignment with Mozilla's values and mission
+
+If you're interested in becoming a maintainer, continue contributing and engage with the existing maintainers. We actively look for contributors to grow into maintainer roles.
+
+## Changes to Governance
+
+Changes to this governance document require approval from the Lead Maintainer and will be discussed openly with the community before implementation.


### PR DESCRIPTION
## Summary

Adds a governance document defining project roles, decision-making processes, and merge rights.

**Closes TABS-759**

## Changes

- Creates `GOVERNANCE.md` with:
  - **Roles**: Maintainers (with current maintainer table) and Contributors
  - **Decision Making**: Process for routine vs significant changes
  - **Conflict Resolution**: Lead Maintainer has final authority
  - **Path to Maintainership**: Criteria for becoming a maintainer
  - Links to Code of Conduct and Contributing guide

## Why

This is a P1 blocker for open-sourcing the repository. Clear governance ensures contributors understand who has merge rights and how decisions are made.

## Note

The maintainer table currently lists Travis Beauvais. This should be updated to reflect the actual maintainer team before open-sourcing.