### PR TITLE
refactor: consolidate CLI structure and extract browser setup to core

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,42 +1,31 @@
-#!/usr/bin/env node
-
 /**
  * @tabstack/spark-cli entry point
  *
- * This re-implements the CLI entry from the root package but with
- * proper package.json resolution for the published npm package.
+ * This is a thin wrapper that imports the CLI implementation from src/cli.ts
  */
 
+// Set up package info injection before importing CLI
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const packageJson = JSON.parse(readFileSync(join(__dirname, "./package.json"), "utf-8"));
+
+(globalThis as any).__SPARK_PACKAGE_INFO = {
+  version: packageJson.version,
+  name: "spark",
+  description: packageJson.description,
+};
+
+// Import CLI components
 import { Command } from "commander";
 import { createRunCommand } from "../../../src/cli/commands/run.js";
 import { createConfigCommand } from "../../../src/cli/commands/config.js";
 import { createExamplesCommand } from "../../../src/cli/commands/examples.js";
+import { getPackageInfo } from "../../../src/cli/utils.js";
 
-/**
- * Get package.json information from the CLI package
- */
-function getPackageInfo(): { version: string; name: string; description: string } {
-  const __dirname = dirname(fileURLToPath(import.meta.url));
-  const packageJson = JSON.parse(readFileSync(join(__dirname, "./package.json"), "utf-8"));
-
-  return {
-    version: packageJson.version,
-    name: "spark", // Keep the command name as "spark"
-    description: packageJson.description,
-  };
-}
-
-/**
- * Spark CLI - AI-powered web automation tool
- *
- * This is the main entry point for the Spark command-line interface.
- * It sets up the commander.js program and registers all available commands.
- */
-
-// Get package information
+// Get package information (will use the injected __SPARK_PACKAGE_INFO)
 const packageInfo = getPackageInfo();
 
 // Create the main program

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "tsup";
 import { copyFileSync } from "fs";
 
 export default defineConfig({
-  // Entry point that re-exports from root
+  // Entry point: thin wrapper that imports from ../../src/cli/
   entry: ["src/index.ts"],
 
   // Output configuration
@@ -10,21 +10,11 @@ export default defineConfig({
   format: ["esm"],
   target: "node22",
 
-  // Bundle everything except large external dependencies
-  // Playwright, AI SDKs, and other large deps stay external
-  external: [
-    "playwright",
-    "@ai-sdk/google",
-    "@ai-sdk/google-vertex",
-    "@ai-sdk/openai",
-    "@ai-sdk/openai-compatible",
-    "@openrouter/ai-sdk-provider",
-    "ollama-ai-provider-v2",
-    "ai",
-    "@ghostery/adblocker-playwright",
-    "turndown",
-    "liquidjs",
-  ],
+  // Keep all node_modules external (will be installed alongside the CLI)
+  // This prevents bundling issues with ESM/CJS interop
+  esbuildOptions(options) {
+    options.packages = "external";
+  },
 
   // Generate source maps for better debugging
   sourcemap: true,
@@ -32,19 +22,21 @@ export default defineConfig({
   // Clean output directory before build
   clean: true,
 
-  // Preserve shebang for CLI entry point
-  shims: true,
+  // Add shebang for CLI entry point
+  banner: {
+    js: "#!/usr/bin/env node",
+  },
 
   // Don't split code, keep it as a single bundle
   splitting: false,
 
-  // Generate TypeScript declaration files
-  dts: false, // We don't need type definitions for a CLI tool
+  // No TypeScript declarations needed for CLI
+  dts: false,
 
-  // Minify for production
-  minify: false, // Keep readable for debugging
+  // Keep readable for debugging
+  minify: false,
 
-  // Don't bundle node built-ins
+  // Node platform
   platform: "node",
 
   // Copy package.json to dist after build

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Browser automation modules
+ *
+ * Core browser automation utilities including Playwright setup,
+ * ARIA browser interface, and navigation retry logic.
+ */
+
+export {
+  getPlaywrightBrowserPath,
+  areBrowsersInstalled,
+  isNonInteractive,
+  installBrowsers,
+} from "./playwrightSetup.js";
+
+export { PlaywrightBrowser } from "./playwrightBrowser.js";
+export { PageAction, LoadState } from "./ariaBrowser.js";
+export type { AriaBrowser } from "./ariaBrowser.js";
+export type { NavigationRetryConfig } from "./navigationRetry.js";
+export { DEFAULT_NAVIGATION_RETRY_CONFIG, calculateTimeout } from "./navigationRetry.js";

--- a/src/browser/playwrightSetup.ts
+++ b/src/browser/playwrightSetup.ts
@@ -1,0 +1,99 @@
+/**
+ * Playwright browser setup utilities
+ *
+ * Core module for detecting and installing Playwright browsers.
+ * Reusable across CLI, VS Code extension, Electron app, and server contexts.
+ */
+
+import { execSync } from "child_process";
+import { existsSync, readdirSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/**
+ * Returns the path where Playwright stores browser binaries for this platform.
+ *
+ * - Linux/macOS: ~/.cache/ms-playwright
+ * - Windows: %USERPROFILE%\AppData\Local\ms-playwright
+ *
+ * @returns The platform-specific browser path, or null for unknown platforms
+ */
+export function getPlaywrightBrowserPath(): string | null {
+  const platform = process.platform;
+
+  if (platform === "win32") {
+    return join(homedir(), "AppData", "Local", "ms-playwright");
+  } else if (platform === "darwin" || platform === "linux") {
+    return join(homedir(), ".cache", "ms-playwright");
+  }
+
+  return null;
+}
+
+/**
+ * Checks if Playwright browsers are installed.
+ *
+ * Verifies that the platform-specific browser directory exists and contains
+ * at least one browser folder (chromium-*, firefox-*, or webkit-*).
+ *
+ * @returns true if browsers are detected, false otherwise
+ */
+export function areBrowsersInstalled(): boolean {
+  const browserPath = getPlaywrightBrowserPath();
+
+  if (!browserPath || !existsSync(browserPath)) {
+    return false;
+  }
+
+  // Additional check: try to see if there are any browser folders
+  // Playwright typically has folders like chromium-1234, firefox-1234, etc.
+  try {
+    const contents = readdirSync(browserPath);
+    // If there's at least one browser folder, consider browsers installed
+    return contents.some(
+      (item: string) =>
+        item.startsWith("chromium-") || item.startsWith("firefox-") || item.startsWith("webkit-"),
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks if running in a non-interactive environment (CI, piped input, etc.)
+ *
+ * @returns true if stdin/stdout is not a TTY or CI environment variable is set
+ */
+export function isNonInteractive(): boolean {
+  return !process.stdin.isTTY || !process.stdout.isTTY || Boolean(process.env.CI);
+}
+
+/**
+ * Installs Playwright browsers using npx playwright install.
+ *
+ * @param options.onOutput - Optional callback to receive installation output.
+ *                           If not provided, output goes to stdout (inherit).
+ * @throws Error if installation fails
+ */
+export async function installBrowsers(options?: {
+  onOutput?: (data: string) => void;
+}): Promise<void> {
+  try {
+    if (options?.onOutput) {
+      // Custom output handling: capture stdout/stderr and pass to callback
+      const output = execSync("npx playwright install", {
+        cwd: process.cwd(),
+        encoding: "utf-8",
+      });
+      options.onOutput(output);
+    } else {
+      // Default behavior: show output directly to user
+      execSync("npx playwright install", {
+        stdio: "inherit",
+        cwd: process.cwd(),
+      });
+    }
+  } catch (error) {
+    throw new Error("Failed to install Playwright browsers");
+  }
+}


### PR DESCRIPTION
## Summary

This PR consolidates the CLI structure and extracts browser detection logic to the core.

### Changes

- **Slim down packages/cli/** - Converted to a thin wrapper that imports from src/cli/. Removed duplicate CLI code and kept only a minimal entry point for npm distribution.
- **Extract browser detection logic** - Moved browser detection logic from src/cli/browserSetup.ts to a new src/browser/ module, making it reusable by other consumers (extensions, servers, etc.).
- **Update browser setup** - src/cli/browserSetup.ts now uses the core browser detection module.
- **Update bundling config** - tsup config now bundles from src/cli/ entry point.

### Testing

- ✅ pnpm spark works from repo root
- ✅ CLI package builds and bundles correctly
- ✅ Code review passed

### Integration

This PR targets **travis/npm_cli_package** base branch. It will be merged into that branch first, then that branch gets merged to main via PR #272.