### PR TITLE
hotfix to main: Only report error name in server errors, to avoid leaking secrets

### DIFF
--- a/server/src/routes/spark.test.ts
+++ b/server/src/routes/spark.test.ts
@@ -119,9 +119,7 @@ describe("Spark Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toBe(
-        "AI provider not configured: No OpenAI API key found. Please set OPENAI_API_KEY environment variable or configure globally.",
-      );
+      expect(data.error.message).toBe("AI provider not configured: Error");
       expect(data.error.code).toBe("MISSING_API_KEY");
       expect(data.error.timestamp).toBeDefined();
     });
@@ -165,7 +163,7 @@ describe("Spark Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toContain("not valid JSON");
+      expect(data.error.message).toBe("SyntaxError");
       expect(data.error.code).toBe("TASK_SETUP_FAILED");
       expect(data.error.timestamp).toBeDefined();
     });


### PR DESCRIPTION
The message property of Error objects can sometimes contain credentials. Only reporting the error name should prevent leaking secrets.