### PR TITLE
Only report error name in server errors, to avoid leaking secrets

### DIFF
--- a/server/src/routes/spark.test.ts
+++ b/server/src/routes/spark.test.ts
@@ -119,9 +119,7 @@ describe("Spark Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toBe(
-        "AI provider not configured: No OpenAI API key found. Please set OPENAI_API_KEY environment variable or configure globally.",
-      );
+      expect(data.error.message).toBe("AI provider not configured: Error");
       expect(data.error.code).toBe("MISSING_API_KEY");
       expect(data.error.timestamp).toBeDefined();
     });
@@ -165,7 +163,7 @@ describe("Spark Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toContain("not valid JSON");
+      expect(data.error.message).toBe("SyntaxError");
       expect(data.error.code).toBe("TASK_SETUP_FAILED");
       expect(data.error.timestamp).toBeDefined();
     });

--- a/server/src/routes/spark.ts
+++ b/server/src/routes/spark.ts
@@ -21,6 +21,11 @@ interface ErrorResponse {
   };
 }
 
+// Use error.name rather than error.message to avoid leaking sensitive data
+// (e.g. credentials embedded in proxy URLs that Playwright includes in error messages)
+const errorToString = (error: unknown): string =>
+  error instanceof Error ? error.name : "Unknown error";
+
 const createErrorResponse = (message: string, code: string): ErrorResponse => ({
   success: false,
   error: {
@@ -141,7 +146,7 @@ spark.post("/run", async (c) => {
     } catch (error) {
       return c.json(
         createErrorResponse(
-          `AI provider not configured: ${error instanceof Error ? error.message : String(error)}`,
+          `AI provider not configured: ${errorToString(error)}`,
           "MISSING_API_KEY",
         ),
         500,
@@ -268,10 +273,7 @@ spark.post("/run", async (c) => {
           await stream.writeSSE({
             event: "error",
             data: JSON.stringify(
-              createErrorResponse(
-                error instanceof Error ? error.message : "Unknown error",
-                "TASK_EXECUTION_FAILED",
-              ),
+              createErrorResponse(errorToString(error), "TASK_EXECUTION_FAILED"),
             ),
           });
         }
@@ -288,13 +290,7 @@ spark.post("/run", async (c) => {
     });
   } catch (error) {
     console.error("Spark task setup failed:", error);
-    return c.json(
-      createErrorResponse(
-        error instanceof Error ? error.message : "Unknown error",
-        "TASK_SETUP_FAILED",
-      ),
-      500,
-    );
+    return c.json(createErrorResponse(errorToString(error), "TASK_SETUP_FAILED"), 500);
   }
 });
 


### PR DESCRIPTION
The message property of Error objects can sometimes contain credentials. Only reporting the error name should prevent leaking secrets.

This is the same as the hotfix PR for main branch, just based off develop branch.