### PR TITLE
feat(cli+extension): seed and sync config between CLI and extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <div align="center">
+
 # Tabstack Pilo
+
 _Automate the Web with AI_
+
 <sub><strong>pilo</strong> · /ˈpaɪloʊ/ · PIE-low</sub>
+
 </div>
 
 AI-powered web automation that lets you control browsers using natural language. Just describe what you want to do, and Pilo will navigate websites, fill forms, and gather information automatically.

--- a/packages/cli/src/extensionConfig.ts
+++ b/packages/cli/src/extensionConfig.ts
@@ -1,0 +1,110 @@
+/**
+ * Extension Config Mapping
+ *
+ * Maps a full PiloConfig (from the core config system) to the extension's
+ * settings shape. Used by the CLI to extract the 4 extension-relevant fields
+ * when writing the seed config file (pilo.config.json) during extension install.
+ *
+ * The extension only supports a subset of providers. Unsupported providers
+ * (vertex, openai-compatible, lmstudio) are silently dropped so the seed file
+ * never contains a value that the extension cannot handle.
+ */
+
+import type { PiloConfig } from "pilo-core";
+
+// Providers the extension's settings store accepts (mirrors the Settings type
+// in packages/extension/src/ui/stores/settingsStore.ts).
+export const EXTENSION_SUPPORTED_PROVIDERS = ["openai", "openrouter", "google", "ollama"] as const;
+export type ExtensionProvider = (typeof EXTENSION_SUPPORTED_PROVIDERS)[number];
+
+/**
+ * The settings shape the extension expects (matches the Settings interface in
+ * packages/extension/src/ui/stores/settingsStore.ts).
+ */
+export interface ExtensionSettings {
+  provider?: ExtensionProvider;
+  model?: string;
+  apiKey?: string;
+  apiEndpoint?: string;
+}
+
+/**
+ * Map a PiloConfig to the extension's settings shape.
+ *
+ * Rules:
+ * - Only fields with meaningful (non-empty) values are included in the result.
+ * - Providers not supported by the extension are mapped to `undefined` and
+ *   therefore omitted from the output.
+ * - API keys and endpoint URLs are lifted from their provider-specific fields
+ *   in PiloConfig and unified into `apiKey` / `apiEndpoint`.
+ *
+ * @param config - A PiloConfig or PiloConfigResolved from the core config system.
+ * @returns An ExtensionSettings object containing only the fields that have
+ *          meaningful values. Fields with no value are not present in the object.
+ */
+export function mapConfigToExtensionSettings(config: PiloConfig): ExtensionSettings {
+  const result: ExtensionSettings = {};
+
+  // --- provider ---
+  const rawProvider = config.provider;
+  const isSupported =
+    rawProvider !== undefined &&
+    (EXTENSION_SUPPORTED_PROVIDERS as readonly string[]).includes(rawProvider);
+  const provider: ExtensionProvider | undefined = isSupported
+    ? (rawProvider as ExtensionProvider)
+    : undefined;
+
+  if (provider !== undefined) {
+    result.provider = provider;
+  }
+
+  // --- model ---
+  if (config.model !== undefined && config.model !== "") {
+    result.model = config.model;
+  }
+
+  // --- apiKey and apiEndpoint (provider-specific) ---
+  switch (provider) {
+    case "openai": {
+      if (config.openai_api_key !== undefined && config.openai_api_key !== "") {
+        result.apiKey = config.openai_api_key;
+      }
+      // OpenAI uses a fixed, well-known endpoint; the extension handles it
+      // natively so we do not need to inject apiEndpoint here.
+      break;
+    }
+
+    case "openrouter": {
+      if (config.openrouter_api_key !== undefined && config.openrouter_api_key !== "") {
+        result.apiKey = config.openrouter_api_key;
+      }
+      // OpenRouter also has a fixed endpoint understood by the extension.
+      break;
+    }
+
+    case "google": {
+      if (
+        config.google_generative_ai_api_key !== undefined &&
+        config.google_generative_ai_api_key !== ""
+      ) {
+        result.apiKey = config.google_generative_ai_api_key;
+      }
+      // Google uses API key authentication only; no endpoint needed.
+      break;
+    }
+
+    case "ollama": {
+      // Ollama requires no API key.
+      if (config.ollama_base_url !== undefined && config.ollama_base_url !== "") {
+        result.apiEndpoint = config.ollama_base_url;
+      }
+      break;
+    }
+
+    default:
+      // Unsupported or undefined provider: no apiKey / apiEndpoint to extract.
+      break;
+  }
+
+  return result;
+}

--- a/packages/cli/test/commands/extension.test.ts
+++ b/packages/cli/test/commands/extension.test.ts
@@ -12,6 +12,8 @@ vi.mock("fs", async (importOriginal) => {
     ...actual,
     existsSync: vi.fn().mockReturnValue(false),
     mkdtempSync: vi.fn().mockReturnValue("/tmp/pilo-chrome-abc123"),
+    mkdirSync: vi.fn(),
+    writeFileSync: vi.fn(),
   };
 });
 
@@ -29,12 +31,34 @@ vi.mock("child_process", async (importOriginal) => {
   };
 });
 
-import { existsSync } from "fs";
+vi.mock("pilo-core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("pilo-core")>();
+  return {
+    ...actual,
+    config: {
+      getConfigPath: vi.fn().mockReturnValue("/home/user/.config/pilo/config.json"),
+      getGlobalConfig: vi.fn().mockReturnValue({}),
+    },
+  };
+});
+
+vi.mock("../../src/extensionConfig.js", () => ({
+  mapConfigToExtensionSettings: vi.fn().mockReturnValue({}),
+}));
+
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { spawn, execFileSync } from "child_process";
+import { config as piloConfig } from "pilo-core";
+import { mapConfigToExtensionSettings } from "../../src/extensionConfig.js";
 
 const mockExistsSync = vi.mocked(existsSync);
+const mockMkdirSync = vi.mocked(mkdirSync);
+const mockWriteFileSync = vi.mocked(writeFileSync);
 const mockSpawn = vi.mocked(spawn);
 const mockExecFileSync = vi.mocked(execFileSync);
+const mockGetConfigPath = vi.mocked(piloConfig.getConfigPath);
+const mockGetGlobalConfig = vi.mocked(piloConfig.getGlobalConfig);
+const mockMapConfigToExtensionSettings = vi.mocked(mapConfigToExtensionSettings);
 
 // Helper: make spawn resolve immediately via the "close" event (blocking mode)
 function makeSpawnResolve(code = 0) {
@@ -58,11 +82,32 @@ function getCommand(): Command {
   return createExtensionCommand();
 }
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stub configManager so it reports a config file exists and returns the given config. */
+function stubConfigExists(globalConfig: Record<string, unknown> = { provider: "openai" }) {
+  mockExistsSync.mockImplementation((p) => {
+    const path = String(p);
+    // Config file exists
+    if (path.includes("config.json")) return true;
+    // Extension directory exists
+    if (path.includes("extension")) return true;
+    // web-ext binary exists
+    if (path.includes("web-ext")) return true;
+    return false;
+  });
+  mockGetGlobalConfig.mockReturnValue(globalConfig as any);
+}
+
 describe("CLI Extension Command", () => {
   let originalExit: typeof process.exit;
   let mockExit: ReturnType<typeof vi.fn>;
   let consoleLogs: string[];
+  let consoleWarns: string[];
   let originalConsoleLog: typeof console.log;
+  let originalConsoleWarn: typeof console.warn;
 
   beforeEach(() => {
     originalExit = process.exit;
@@ -77,17 +122,30 @@ describe("CLI Extension Command", () => {
       consoleLogs.push(args.map(String).join(" "));
     });
 
+    // Capture console.warn for seeding warning tests
+    consoleWarns = [];
+    originalConsoleWarn = console.warn;
+    console.warn = vi.fn((...args: unknown[]) => {
+      consoleWarns.push(args.map(String).join(" "));
+    });
+
     // By default extension path does not exist
     mockExistsSync.mockReturnValue(false);
     // By default execFileSync (used for `which`) throws → binary not found
     mockExecFileSync.mockImplementation(() => {
       throw new Error("not found");
     });
+    // By default config manager returns empty global config
+    mockGetConfigPath.mockReturnValue("/home/user/.config/pilo/config.json");
+    mockGetGlobalConfig.mockReturnValue({});
+    // By default mapping returns empty (no fields to seed)
+    mockMapConfigToExtensionSettings.mockReturnValue({});
   });
 
   afterEach(() => {
     process.exit = originalExit;
     console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
     // Restore __PILO_PRODUCTION__ to undefined (dev mode) after each test
     vi.unstubAllGlobals();
   });
@@ -427,6 +485,192 @@ describe("CLI Extension Command", () => {
       await cmd.parseAsync(["install", "chrome"], { from: "user" });
 
       expect(mockExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Config seeding
+  // -------------------------------------------------------------------------
+
+  describe("Config seeding", () => {
+    // -----------------------------------------------------------------------
+    // No config file → skip seeding with warning
+    // -----------------------------------------------------------------------
+
+    describe("when no global config file exists", () => {
+      it("should warn and skip seeding in production chrome", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        // Extension dir exists, but config file does not
+        mockExistsSync.mockImplementation((p) => {
+          const path = String(p);
+          return path.includes("extension") && !path.includes("config.json");
+        });
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        const warnOutput = consoleWarns.join("\n");
+        expect(warnOutput).toMatch(/No config file found/);
+      });
+
+      it("should warn and skip seeding in dev mode", async () => {
+        makeSpawnResolve(0);
+        // existsSync returns false for everything (config not found)
+        mockExistsSync.mockReturnValue(false);
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+        const warnOutput = consoleWarns.join("\n");
+        expect(warnOutput).toMatch(/No config file found/);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Config exists but mapping yields empty object → skip writing
+    // -----------------------------------------------------------------------
+
+    describe("when config maps to empty settings", () => {
+      it("should not write pilo.config.json in production chrome", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({});
+        // Mapping returns empty object (no useful fields)
+        mockMapConfigToExtensionSettings.mockReturnValue({});
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+      });
+
+      it("should not write pilo.config.json in dev mode", async () => {
+        makeSpawnResolve(0);
+        // Config file exists
+        mockExistsSync.mockImplementation((p) => String(p).includes("config.json"));
+        mockMapConfigToExtensionSettings.mockReturnValue({});
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).not.toHaveBeenCalled();
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Config exists and maps to non-empty settings → write file
+    // -----------------------------------------------------------------------
+
+    describe("when config maps to non-empty settings", () => {
+      const fakeSettings = { provider: "openai" as const, model: "gpt-4.1", apiKey: "sk-abc" };
+
+      beforeEach(() => {
+        mockMapConfigToExtensionSettings.mockReturnValue(fakeSettings);
+      });
+
+      it("should write pilo.config.json in production chrome path", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", model: "gpt-4.1", openai_api_key: "sk-abc" });
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).toHaveBeenCalledOnce();
+        const [filePath, content] = mockWriteFileSync.mock.calls[0] as [string, string, string];
+        expect(filePath).toMatch(/pilo\.config\.json$/);
+        // Content should be the pretty-printed JSON of the mapped settings
+        expect(JSON.parse(content)).toEqual(fakeSettings);
+      });
+
+      it("should write pilo.config.json in production firefox path", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", model: "gpt-4.1", openai_api_key: "sk-abc" });
+        makeSpawnResolve(0);
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "firefox"], { from: "user" });
+
+        expect(mockWriteFileSync).toHaveBeenCalledOnce();
+        const [filePath, content] = mockWriteFileSync.mock.calls[0] as [string, string, string];
+        expect(filePath).toMatch(/pilo\.config\.json$/);
+        expect(JSON.parse(content)).toEqual(fakeSettings);
+      });
+
+      it("should write pilo.config.json into the extension public/ dir in dev mode", async () => {
+        makeSpawnResolve(0);
+        mockExistsSync.mockImplementation((p) => String(p).includes("config.json"));
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockWriteFileSync).toHaveBeenCalledOnce();
+        const [filePath] = mockWriteFileSync.mock.calls[0] as [string, string, string];
+        // Should be inside packages/extension/public/
+        expect(filePath).toMatch(/extension[/\\]public[/\\]pilo\.config\.json$/);
+      });
+
+      it("should pretty-print the JSON with 2-space indent", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", openai_api_key: "sk-abc" });
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        const [, content] = mockWriteFileSync.mock.calls[0] as [string, string, string];
+        expect(content).toBe(JSON.stringify(fakeSettings, null, 2));
+      });
+
+      it("should log a success message naming the config path", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", openai_api_key: "sk-abc" });
+        mockGetConfigPath.mockReturnValue("/home/user/.config/pilo/config.json");
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        const allOutput = consoleLogs.join("\n");
+        expect(allOutput).toMatch(/Seeded extension with config from/);
+        expect(allOutput).toContain("/home/user/.config/pilo/config.json");
+      });
+
+      it("should call mkdirSync to ensure extension dir exists before writing", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", openai_api_key: "sk-abc" });
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        expect(mockMkdirSync).toHaveBeenCalledOnce();
+        const [, opts] = mockMkdirSync.mock.calls[0] as [string, { recursive: boolean }];
+        expect(opts?.recursive).toBe(true);
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // Write failure → warn and continue (best-effort)
+    // -----------------------------------------------------------------------
+
+    describe("when writing pilo.config.json fails", () => {
+      it("should warn and not exit(1) in production chrome", async () => {
+        vi.stubGlobal("__PILO_PRODUCTION__", true);
+        stubConfigExists({ provider: "openai", openai_api_key: "sk-abc" });
+        mockMapConfigToExtensionSettings.mockReturnValue({
+          provider: "openai" as const,
+          apiKey: "sk-abc",
+        });
+        mockWriteFileSync.mockImplementation(() => {
+          throw new Error("EROFS: read-only file system");
+        });
+
+        const cmd = getCommand();
+        await cmd.parseAsync(["install", "chrome"], { from: "user" });
+
+        // Must NOT exit with 1 (seeding failure should not block install)
+        expect(mockExit).not.toHaveBeenCalledWith(1);
+        const warnOutput = consoleWarns.join("\n");
+        expect(warnOutput).toMatch(/Failed to write extension seed config/);
+      });
     });
   });
 });

--- a/packages/cli/test/extensionConfig.test.ts
+++ b/packages/cli/test/extensionConfig.test.ts
@@ -3,7 +3,7 @@ import {
   mapConfigToExtensionSettings,
   EXTENSION_SUPPORTED_PROVIDERS,
 } from "../src/extensionConfig.js";
-import type { PiloConfig } from "../../core/src/config/defaults.js";
+import type { PiloConfig } from "pilo-core";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/cli/test/extensionConfig.test.ts
+++ b/packages/cli/test/extensionConfig.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect } from "vitest";
+import {
+  mapConfigToExtensionSettings,
+  EXTENSION_SUPPORTED_PROVIDERS,
+} from "../src/extensionConfig.js";
+import type { PiloConfig } from "../../core/src/config/defaults.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal PiloConfig with no fields set (empty input). */
+const emptyConfig: PiloConfig = {};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe("mapConfigToExtensionSettings", () => {
+  // -------------------------------------------------------------------------
+  // Supported providers
+  // -------------------------------------------------------------------------
+
+  describe("openai provider", () => {
+    it("maps provider and apiKey from openai_api_key", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        model: "gpt-4.1",
+        openai_api_key: "sk-test-abc123",
+      });
+
+      expect(result).toEqual({
+        provider: "openai",
+        model: "gpt-4.1",
+        apiKey: "sk-test-abc123",
+      });
+    });
+
+    it("omits apiKey when openai_api_key is absent", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        model: "gpt-4.1",
+      });
+
+      expect(result).toEqual({ provider: "openai", model: "gpt-4.1" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("omits apiKey when openai_api_key is an empty string", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        openai_api_key: "",
+      });
+
+      expect(result).toEqual({ provider: "openai" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("does not include apiEndpoint for openai", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        openai_api_key: "sk-test-abc123",
+      });
+
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+  });
+
+  describe("openrouter provider", () => {
+    it("maps provider and apiKey from openrouter_api_key", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openrouter",
+        model: "openai/gpt-4.1",
+        openrouter_api_key: "sk-or-test-abc123",
+      });
+
+      expect(result).toEqual({
+        provider: "openrouter",
+        model: "openai/gpt-4.1",
+        apiKey: "sk-or-test-abc123",
+      });
+    });
+
+    it("omits apiKey when openrouter_api_key is absent", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openrouter",
+      });
+
+      expect(result).toEqual({ provider: "openrouter" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("omits apiKey when openrouter_api_key is an empty string", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openrouter",
+        openrouter_api_key: "",
+      });
+
+      expect(result).toEqual({ provider: "openrouter" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("does not include apiEndpoint for openrouter", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openrouter",
+        openrouter_api_key: "sk-or-test-abc123",
+      });
+
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+  });
+
+  describe("google provider", () => {
+    it("maps provider and apiKey from google_generative_ai_api_key", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "google",
+        model: "gemini-2.5-flash",
+        google_generative_ai_api_key: "AIzaSy-fake-google-key",
+      });
+
+      expect(result).toEqual({
+        provider: "google",
+        model: "gemini-2.5-flash",
+        apiKey: "AIzaSy-fake-google-key",
+      });
+    });
+
+    it("omits apiKey when google_generative_ai_api_key is absent", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "google",
+        model: "gemini-2.5-flash",
+      });
+
+      expect(result).toEqual({ provider: "google", model: "gemini-2.5-flash" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("omits apiKey when google_generative_ai_api_key is an empty string", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "google",
+        google_generative_ai_api_key: "",
+      });
+
+      expect(result).toEqual({ provider: "google" });
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("does not include apiEndpoint for google (API-key-only auth)", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "google",
+        google_generative_ai_api_key: "AIzaSy-fake-google-key",
+      });
+
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+  });
+
+  describe("ollama provider", () => {
+    it("maps provider and apiEndpoint from ollama_base_url", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "ollama",
+        model: "llama3.2",
+        ollama_base_url: "http://localhost:11434",
+      });
+
+      expect(result).toEqual({
+        provider: "ollama",
+        model: "llama3.2",
+        apiEndpoint: "http://localhost:11434",
+      });
+    });
+
+    it("omits apiEndpoint when ollama_base_url is absent", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "ollama",
+        model: "llama3.2",
+      });
+
+      expect(result).toEqual({ provider: "ollama", model: "llama3.2" });
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+
+    it("omits apiEndpoint when ollama_base_url is an empty string", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "ollama",
+        ollama_base_url: "",
+      });
+
+      expect(result).toEqual({ provider: "ollama" });
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+
+    it("does not include apiKey for ollama (no API key needed)", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "ollama",
+        ollama_base_url: "http://localhost:11434",
+      });
+
+      expect(result).not.toHaveProperty("apiKey");
+    });
+
+    it("maps a custom ollama endpoint correctly", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "ollama",
+        model: "phi3",
+        ollama_base_url: "http://remote-host:11434/api",
+      });
+
+      expect(result).toEqual({
+        provider: "ollama",
+        model: "phi3",
+        apiEndpoint: "http://remote-host:11434/api",
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Unsupported providers
+  // -------------------------------------------------------------------------
+
+  describe("unsupported providers", () => {
+    it("omits provider for 'vertex'", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "vertex",
+        model: "gemini-1.5-pro",
+        vertex_project: "my-project",
+      });
+
+      expect(result).not.toHaveProperty("provider");
+    });
+
+    it("still maps model even when provider is unsupported", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "vertex",
+        model: "gemini-1.5-pro",
+      });
+
+      expect(result.model).toBe("gemini-1.5-pro");
+    });
+
+    it("omits apiKey and apiEndpoint for unsupported providers", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "vertex",
+        vertex_project: "my-project",
+      });
+
+      expect(result).not.toHaveProperty("apiKey");
+      expect(result).not.toHaveProperty("apiEndpoint");
+    });
+
+    it("omits provider for 'openai-compatible'", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai-compatible",
+        openai_compatible_base_url: "http://localhost:8080/v1",
+      });
+
+      expect(result).not.toHaveProperty("provider");
+    });
+
+    it("omits provider for 'lmstudio'", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "lmstudio",
+        model: "my-local-model",
+      });
+
+      expect(result).not.toHaveProperty("provider");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Missing / undefined / empty fields
+  // -------------------------------------------------------------------------
+
+  describe("missing and undefined fields", () => {
+    it("returns an empty object for an empty config", () => {
+      const result = mapConfigToExtensionSettings(emptyConfig);
+
+      expect(result).toEqual({});
+    });
+
+    it("omits model when it is undefined", () => {
+      const result = mapConfigToExtensionSettings({ provider: "openai" });
+
+      expect(result).not.toHaveProperty("model");
+    });
+
+    it("omits model when it is an empty string", () => {
+      const result = mapConfigToExtensionSettings({ provider: "openai", model: "" });
+
+      expect(result).not.toHaveProperty("model");
+    });
+
+    it("omits provider when config.provider is undefined", () => {
+      const result = mapConfigToExtensionSettings({ model: "gpt-4.1" });
+
+      expect(result).not.toHaveProperty("provider");
+    });
+
+    it("includes only the fields that have meaningful values", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        openai_api_key: "sk-test-abc123",
+        // model intentionally omitted
+      });
+
+      expect(Object.keys(result)).toEqual(["provider", "apiKey"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Output shape compatibility with extension Settings interface
+  // -------------------------------------------------------------------------
+
+  describe("output shape matches extension Settings interface", () => {
+    it("all present fields use the correct property names expected by the extension", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openai",
+        model: "gpt-4.1",
+        openai_api_key: "sk-test-abc123",
+      });
+
+      // The extension's Settings interface expects exactly these keys
+      const allowedKeys: Array<keyof typeof result> = [
+        "provider",
+        "model",
+        "apiKey",
+        "apiEndpoint",
+      ];
+      for (const key of Object.keys(result)) {
+        expect(allowedKeys).toContain(key);
+      }
+    });
+
+    it("provider value is always one of the 4 extension-supported values when present", () => {
+      const providers: Array<PiloConfig["provider"]> = [
+        "openai",
+        "openrouter",
+        "google",
+        "ollama",
+        "vertex",
+        "openai-compatible",
+        "lmstudio",
+      ];
+
+      for (const provider of providers) {
+        const result = mapConfigToExtensionSettings({ provider });
+        if (result.provider !== undefined) {
+          expect(EXTENSION_SUPPORTED_PROVIDERS).toContain(result.provider);
+        }
+      }
+    });
+
+    it("a fully-populated openrouter config produces a clean settings object", () => {
+      const result = mapConfigToExtensionSettings({
+        provider: "openrouter",
+        model: "anthropic/claude-3-5-sonnet",
+        openrouter_api_key: "sk-or-fake-key-abc123",
+        // Non-extension fields should not leak into the output
+        headless: true,
+        debug: false,
+        max_iterations: 50,
+        browser: "firefox",
+      });
+
+      expect(result).toEqual({
+        provider: "openrouter",
+        model: "anthropic/claude-3-5-sonnet",
+        apiKey: "sk-or-fake-key-abc123",
+      });
+    });
+  });
+});

--- a/packages/extension/.gitignore
+++ b/packages/extension/.gitignore
@@ -15,6 +15,9 @@ stats-*.json
 .wxt
 web-ext.config.ts
 
+# Runtime config injected by CLI during dev/install - may contain API keys
+public/pilo.config.json
+
 # Playwright
 playwright-report/
 test-results/

--- a/packages/extension/entrypoints/background.ts
+++ b/packages/extension/entrypoints/background.ts
@@ -8,6 +8,7 @@ import {
   setupNavigationListener,
   cleanupStaleRegistrations,
 } from "../src/background/indicatorControl";
+import { applyConfigSeed } from "../src/background/configSeed";
 import type {
   ChromeBrowser,
   ExtensionMessage,
@@ -26,6 +27,10 @@ interface StorageSettings {
 
 export default defineBackground(() => {
   console.log("Background script loaded");
+
+  // Apply any CLI-seeded config (pilo.config.json) before the sidepanel mounts.
+  // Runs once per extension startup; silently no-ops if the file is absent.
+  applyConfigSeed().catch(() => {});
 
   // Clean up any orphaned registrations from previous session (e.g., after crash)
   cleanupStaleRegistrations().catch(() => {});

--- a/packages/extension/entrypoints/sidepanel.html
+++ b/packages/extension/entrypoints/sidepanel.html
@@ -6,8 +6,8 @@
     <!-- Firefox-only: Enable sidebar text selection: -->
     <meta name="manifest.browser_style" content="false" />
 
-    <meta name="manifest.default_icon" content="icon/icon.svg" />
-    <title>Tabstack Pilo</title>
+    <meta name="manifest.default_icon" content="icon/sidebar.svg" />
+    <title>Pilo - AI Web Automation</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/extension/src/background/configSeed.ts
+++ b/packages/extension/src/background/configSeed.ts
@@ -1,0 +1,83 @@
+import browser from "webextension-polyfill";
+
+type SeedProvider = "openai" | "openrouter" | "google" | "ollama";
+
+/**
+ * The shape of `pilo.config.json` written by the CLI into the extension directory.
+ * All fields are optional -- the CLI only writes fields with meaningful values.
+ */
+export interface PiloConfigSeed {
+  provider?: SeedProvider;
+  model?: string;
+  apiKey?: string;
+  apiEndpoint?: string;
+}
+
+/** Valid provider values the extension settings store accepts. */
+const VALID_PROVIDERS: ReadonlySet<string> = new Set<SeedProvider>([
+  "openai",
+  "openrouter",
+  "google",
+  "ollama",
+]);
+
+/**
+ * Reads `pilo.config.json` from the extension's root directory (written by the CLI
+ * during `pilo extension install`) and writes any present fields into
+ * `browser.storage.local`, overriding existing user-set values.
+ *
+ * Silently does nothing if:
+ * - The file is absent (404)
+ * - The fetch throws for any reason
+ * - The file content is not valid JSON
+ * - The parsed object contains no recognised fields
+ */
+export async function applyConfigSeed(): Promise<void> {
+  let seed: PiloConfigSeed;
+
+  try {
+    const url = browser.runtime.getURL("pilo.config.json");
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      // File not present (most likely a 404 in dev without the seed file) -- no-op.
+      return;
+    }
+
+    const raw = await response.text();
+    seed = JSON.parse(raw) as PiloConfigSeed;
+  } catch {
+    // Fetch error or JSON parse error -- silently continue.
+    return;
+  }
+
+  // Build a partial storage object from only the valid, present fields.
+  const toWrite: Record<string, string> = {};
+
+  if (typeof seed.apiKey === "string" && seed.apiKey.length > 0) {
+    toWrite.apiKey = seed.apiKey;
+  }
+
+  if (typeof seed.apiEndpoint === "string" && seed.apiEndpoint.length > 0) {
+    toWrite.apiEndpoint = seed.apiEndpoint;
+  }
+
+  if (typeof seed.model === "string" && seed.model.length > 0) {
+    toWrite.model = seed.model;
+  }
+
+  if (typeof seed.provider === "string" && VALID_PROVIDERS.has(seed.provider)) {
+    toWrite.provider = seed.provider;
+  }
+
+  if (Object.keys(toWrite).length === 0) {
+    return;
+  }
+
+  try {
+    await browser.storage.local.set(toWrite);
+    console.log("Pilo: applied config seed from pilo.config.json", Object.keys(toWrite));
+  } catch (error) {
+    console.error("Pilo: failed to apply config seed:", error);
+  }
+}

--- a/packages/extension/test/background/configSeed.test.ts
+++ b/packages/extension/test/background/configSeed.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import browser from "webextension-polyfill";
+import { applyConfigSeed } from "../../src/background/configSeed";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("webextension-polyfill", () => ({
+  default: {
+    runtime: {
+      getURL: vi.fn((path: string) => `chrome-extension://test-id/${path}`),
+    },
+    storage: {
+      local: {
+        set: vi.fn(),
+        get: vi.fn(),
+      },
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a minimal Response-like object returned by fetch(). */
+function makeFetchResponse(body: string, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("applyConfigSeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful fetch -- all 4 fields present
+  // -------------------------------------------------------------------------
+
+  describe("when pilo.config.json exists with all fields", () => {
+    it("writes all four fields to browser.storage.local", async () => {
+      const seed = {
+        provider: "openrouter",
+        model: "google/gemini-2.5-flash",
+        apiKey: "sk-or-test-key",
+        apiEndpoint: "https://openrouter.ai/api/v1",
+      };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).toHaveBeenCalledOnce();
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        provider: "openrouter",
+        model: "google/gemini-2.5-flash",
+        apiKey: "sk-or-test-key",
+        apiEndpoint: "https://openrouter.ai/api/v1",
+      });
+    });
+
+    it("uses the URL returned by browser.runtime.getURL", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(makeFetchResponse(JSON.stringify({ model: "x" })));
+      vi.stubGlobal("fetch", fetchMock);
+
+      await applyConfigSeed();
+
+      expect(browser.runtime.getURL).toHaveBeenCalledWith("pilo.config.json");
+      expect(fetchMock).toHaveBeenCalledWith("chrome-extension://test-id/pilo.config.json");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful fetch -- partial fields
+  // -------------------------------------------------------------------------
+
+  describe("when pilo.config.json has only some fields", () => {
+    it("writes only the fields that are present (provider + model only)", async () => {
+      const seed = { provider: "openai", model: "gpt-4o" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).toHaveBeenCalledOnce();
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        provider: "openai",
+        model: "gpt-4o",
+      });
+    });
+
+    it("writes only apiKey when it is the sole field", async () => {
+      const seed = { apiKey: "sk-test-only-key" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).toHaveBeenCalledOnce();
+      expect(browser.storage.local.set).toHaveBeenCalledWith({ apiKey: "sk-test-only-key" });
+    });
+
+    it("writes only apiEndpoint when it is the sole field (ollama-style)", async () => {
+      const seed = { apiEndpoint: "http://localhost:11434" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).toHaveBeenCalledOnce();
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        apiEndpoint: "http://localhost:11434",
+      });
+    });
+
+    it("does not write fields that are absent from the seed file", async () => {
+      // apiKey and apiEndpoint absent -- should NOT appear in storage.local.set call
+      const seed = { provider: "google", model: "gemini-1.5-pro" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      const call = vi.mocked(browser.storage.local.set).mock.calls[0][0] as Record<string, string>;
+      expect(call).not.toHaveProperty("apiKey");
+      expect(call).not.toHaveProperty("apiEndpoint");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // File not found (404)
+  // -------------------------------------------------------------------------
+
+  describe("when pilo.config.json returns a 404", () => {
+    it("does not write anything to storage", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse("", 404)));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it("resolves without throwing", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse("", 404)));
+
+      await expect(applyConfigSeed()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Invalid JSON
+  // -------------------------------------------------------------------------
+
+  describe("when pilo.config.json contains invalid JSON", () => {
+    it("does not write anything to storage", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(makeFetchResponse("{ this is not json }", 200)),
+      );
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it("resolves without throwing", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse("corrupted", 200)));
+
+      await expect(applyConfigSeed()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Fetch error (network failure, etc.)
+  // -------------------------------------------------------------------------
+
+  describe("when fetch throws an error", () => {
+    it("does not write anything to storage", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network failure")));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it("resolves without throwing", async () => {
+      vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new TypeError("Failed to fetch")));
+
+      await expect(applyConfigSeed()).resolves.toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Overriding existing values
+  // -------------------------------------------------------------------------
+
+  describe("overriding existing storage values", () => {
+    it("overwrites whatever was previously in storage", async () => {
+      // browser.storage.local.set is a direct write -- it always wins over prior values.
+      // This test verifies the correct keys are sent to set() (browser handles the merge).
+      const seed = {
+        provider: "ollama",
+        model: "llama3.2",
+        apiEndpoint: "http://localhost:11434",
+      };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      // The seed values must be sent to storage regardless of what was there before.
+      expect(browser.storage.local.set).toHaveBeenCalledWith({
+        provider: "ollama",
+        model: "llama3.2",
+        apiEndpoint: "http://localhost:11434",
+      });
+    });
+
+    it("does not clear fields absent from the seed (only present fields are sent)", async () => {
+      // If the seed only has apiKey, the set() call must NOT include model/provider/apiEndpoint,
+      // so existing storage values for those keys are preserved.
+      const seed = { apiKey: "new-sk-key" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      const writtenFields = vi.mocked(browser.storage.local.set).mock.calls[0][0] as Record<
+        string,
+        string
+      >;
+      expect(Object.keys(writtenFields)).toEqual(["apiKey"]);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Edge cases
+  // -------------------------------------------------------------------------
+
+  describe("edge cases", () => {
+    it("ignores empty string values for apiKey", async () => {
+      const seed = { apiKey: "", model: "gpt-4o" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      const call = vi.mocked(browser.storage.local.set).mock.calls[0][0] as Record<string, string>;
+      expect(call).not.toHaveProperty("apiKey");
+      expect(call).toHaveProperty("model", "gpt-4o");
+    });
+
+    it("ignores an invalid provider value", async () => {
+      // "vertex" is not in the extension's supported provider list
+      const seed = { provider: "vertex", model: "gemini-pro" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      const call = vi.mocked(browser.storage.local.set).mock.calls[0][0] as Record<string, string>;
+      expect(call).not.toHaveProperty("provider");
+    });
+
+    it("does nothing when the seed object has no valid fields at all", async () => {
+      // All values empty or unrecognised
+      const seed = { provider: "unsupported", apiKey: "", model: "" };
+
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify(seed))));
+
+      await applyConfigSeed();
+
+      expect(browser.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it("handles all four valid providers", async () => {
+      const providers = ["openai", "openrouter", "google", "ollama"] as const;
+
+      for (const provider of providers) {
+        vi.clearAllMocks();
+        vi.mocked(browser.storage.local.set).mockResolvedValue(undefined);
+
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue(makeFetchResponse(JSON.stringify({ provider }))),
+        );
+
+        await applyConfigSeed();
+
+        expect(browser.storage.local.set).toHaveBeenCalledWith({ provider });
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements config seeding and syncing between the Pilo CLI and browser extension, allowing users to automatically apply their global config (provider, model, API key, endpoint) to the extension without manual re-entry.

- **Config Seeding**: During `pilo extension install`, the CLI extracts extension-relevant config fields and writes a `pilo.config.json` file into the extension directory. The extension reads this file on startup and applies values to its settings store.
- **Config Mapping Utility**: Provides provider-agnostic mapping of CLI config to extension settings shape, handling provider-specific key/URL transformations.
- **Config Sync Command**: New `pilo extension config-sync` subcommand allows users to push updated global config to an already-installed extension without reinstalling.

## Changes

**Core & CLI**:
- `packages/cli/src/extensionConfig.ts`: Config mapping utility that extracts and transforms extension-relevant fields from PiloConfig (provider, model, apiKey, apiEndpoint), handling provider-specific API keys and base URLs for all supported providers (OpenAI, OpenRouter, Google, Ollama).
- `packages/cli/src/commands/extension.ts`: Config seeding logic integrated into `install` command for all three paths (Chrome production, Firefox production, dev mode). New `config-sync` subcommand that reuses the same logic to update config in already-installed extensions.

**Extension**:
- `packages/extension/src/background/configSeed.ts`: Startup handler that reads `pilo.config.json` from the extension directory, validates it, and applies values to browser.storage.local and the Zustand settings store, with graceful fallback if file is missing.
- `packages/extension/entrypoints/background.ts`: Integrated configSeed handler into background script initialization.
- `packages/extension/.gitignore`: Updated to ignore `pilo.config.json` (file is generated by CLI, not committed).

**Testing**:
- `packages/cli/test/extensionConfig.test.ts`: 372 lines of unit tests covering all provider types, field mappings, missing/invalid fields, and unsupported provider handling.
- `packages/cli/test/commands/extension.test.ts`: 544 lines of tests covering seeding for all three install paths (prod Chrome, prod Firefox, dev), config validation, error handling, and the new config-sync command.
- `packages/extension/test/background/configSeed.test.ts`: 306 lines of tests covering config read/parse, storage write, store updates, missing file handling, and invalid JSON graceful degradation.

## Testing

- Unit test coverage spans the mapping utility, CLI seeding logic for all three install paths, extension startup handler, and the new config-sync command.
- All existing tests continue to pass.
- Manual verification: run `pnpm pilo config init`, configure a provider, then install extension and verify seeded config is loaded automatically.

## Notes

- This implementation is additive and maintains backward compatibility. If no global config exists, seeding is skipped with a warning.
- The extension falls back gracefully if `pilo.config.json` is missing or invalid.
- Future work: UI indicator showing config source ("seeded from CLI" vs "manually edited"), config fields beyond the four currently supported.