### PR TITLE
fix(server): adds missing start command

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
+    "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",


### PR DESCRIPTION
## Description

I am encountering this error when deploying the server:

` ERR_PNPM_NO_SCRIPT_OR_SERVER  Missing script start or file server.js`

Using LLM assistance we added this missing start param which will hopefully fix the server deployment

## PR Type

<!-- Delete the types that don't apply -->

- Bug Fix
- Infrastructure

## Related issues

<!-- e.g. "Fixes #123" or "Related to #456" -->

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`)
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

<!-- We welcome the use of AI to aid in contribution! Please indicate your AI usage below. -->

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- Optional: What LLM and tooling did you use? (e.g., Claude with Claude Code, GPT-4 with Copilot) -->
