### PR TITLE
Fix local dev workflow after repo restructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepare": "pnpm --filter spark-core run build",
     "prebuild": "pnpm --filter spark-core run build && pnpm --filter spark-extension run build:publish",
     "build": "tsup",
     "prepublishOnly": "pnpm run build",
@@ -33,7 +34,7 @@
     "pretest": "pnpm --filter spark-core run bundle:aria",
     "test": "pnpm -r run test",
     "check": "pnpm run typecheck && pnpm run test",
-    "spark": "pnpm --filter spark-cli run spark",
+    "spark": "tsx packages/cli/src/cli.ts",
     "dev:extension": "pnpm --filter spark-extension run dev --",
     "dev:server": "pnpm --filter spark-server run dev",
     "release": "./scripts/release.sh"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,8 @@
     "clean": "rm -rf dist",
     "build": "tsc",
     "typecheck": "tsc --project tsconfig.check.json",
-    "test": "vitest run"
+    "test": "vitest run",
+    "spark": "tsx src/cli.ts"
   },
   "dependencies": {
     "chalk": "^5.6.2",

--- a/packages/cli/src/commands/config.ts
+++ b/packages/cli/src/commands/config.ts
@@ -210,6 +210,8 @@ async function initializeGlobalConfiguration(): Promise<void> {
   console.log(chalk.blue.bold("🔧 Initializing Spark Global Configuration"));
   console.log("");
 
+  config.initialize();
+
   const currentConfig = config.getConfig();
 
   // Check if already configured
@@ -244,7 +246,7 @@ async function initializeGlobalConfiguration(): Promise<void> {
   console.log(chalk.gray("2. Local .env file (development)"));
   console.log(chalk.gray("3. Global config file (lowest priority)"));
   console.log("");
-  console.log(chalk.gray("Global config saved to: " + config.getConfigPath()));
+  console.log(chalk.gray("Global config location: " + config.getConfigPath()));
 }
 
 /**

--- a/packages/cli/test/commands/config.test.ts
+++ b/packages/cli/test/commands/config.test.ts
@@ -15,6 +15,7 @@ vi.mock("spark-core", async (importOriginal) => {
       set: vi.fn(),
       unset: vi.fn(),
       reset: vi.fn(),
+      initialize: vi.fn(),
       getConfigPath: vi.fn().mockReturnValue("/home/user/.config/spark/config.json"),
       listSources: vi.fn().mockReturnValue({
         global: { provider: "openai" },

--- a/packages/core/src/config/manager.ts
+++ b/packages/core/src/config/manager.ts
@@ -155,6 +155,19 @@ export class ConfigManager {
   }
 
   /**
+   * Create the config directory and an empty config file if neither exists yet.
+   * Safe to call multiple times — does nothing if the file already exists.
+   */
+  public initialize(): void {
+    if (!existsSync(this.configDir)) {
+      mkdirSync(this.configDir, { recursive: true });
+    }
+    if (!existsSync(this.configPath)) {
+      writeFileSync(this.configPath, JSON.stringify({}, null, 2), "utf-8");
+    }
+  }
+
+  /**
    * Reset the global config by removing the config file.
    */
   public reset(): void {


### PR DESCRIPTION
I was running through README and CONTRIBUTING and hist some snags. These are the changes I worked out with claude that got these commands working for me from a fresh checkout of develop and a copy of my old `.env` file from Spark:

```
pnpm install
pnpm spark config init
pnpm spark run "what's the weather in Portland, OR?"
```

- Add `pilo` script to pilo-cli package (was missing, breaking `pnpm pilo` delegation)
- Run CLI via `tsx packages/cli/src/cli.ts` from repo root so `.env` is found by dotenv
- Add `prepare` script to root so `pnpm install` auto-generates the ariaTree bundle
- Add `ConfigManager.initialize()` to create empty config file on `pilo config init`
- Fix misleading "Global config saved to:" message (now "Global config location:")
- Relax run guard to also pass when API key is available via env vars / `.env`
- Add `initialize` mock to CLI config test suite
