### PR TITLE
Improvements to prompts.ts, Dockerfile for CLI (easier eval runs)

### DIFF
--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,0 +1,69 @@
+FROM node:22-slim
+
+# Install pnpm
+RUN npm install -g pnpm
+
+# Build argument to control Playwright browser installation
+ARG INSTALL_PLAYWRIGHT_BROWSERS=true
+
+# Set working directory to repo root
+WORKDIR /app
+
+# Copy workspace manifests so pnpm can resolve the workspace graph
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+
+# Copy all package manifests before installing so pnpm can link the workspace
+COPY packages/core/package.json ./packages/core/package.json
+COPY packages/cli/package.json ./packages/cli/package.json
+COPY packages/server/package.json ./packages/server/package.json
+COPY packages/extension/package.json ./packages/extension/package.json
+
+# Install all workspace dependencies.
+# --ignore-scripts prevents the root prepare lifecycle script from running
+# pilo-core build before its source has been copied into the image.
+# We then selectively rebuild only packages with native binaries (esbuild)
+# so their postinstall scripts run without triggering the root prepare.
+RUN pnpm install --frozen-lockfile --ignore-scripts
+RUN pnpm rebuild esbuild
+
+# Copy core source and build it (CLI depends on pilo-core)
+COPY packages/core/ ./packages/core/
+RUN pnpm --filter pilo-core run build
+
+# Install Playwright system dependencies as root (requires apt)
+RUN if [ "$INSTALL_PLAYWRIGHT_BROWSERS" = "true" ]; then \
+    npx playwright install-deps chromium; \
+    fi
+
+# Copy CLI source and build
+COPY packages/cli/ ./packages/cli/
+RUN pnpm --filter pilo-cli run build
+
+# Set environment variables
+ENV NODE_ENV=production
+
+# Create minimal stub config for root user (container may run as root)
+RUN mkdir -p /root/.config/pilo && echo '{}' > /root/.config/pilo/config.json
+
+# Ensure node user owns the app files
+RUN chown -R node:node /app
+
+# Switch to non-root user
+USER node
+
+# Create minimal stub configs to satisfy the CLI config guard.
+# The guard only checks for file existence; actual provider/key config
+# is supplied via environment variables (dev-mode env var loading).
+# Both root and node user paths are created because callers may run
+# the container as either user.
+RUN mkdir -p /home/node/.config/pilo && echo '{}' > /home/node/.config/pilo/config.json
+
+# Install Playwright browsers as node user (so they end up in /home/node/.cache)
+# ARG must be redeclared after USER to be accessible (with same default)
+ARG INSTALL_PLAYWRIGHT_BROWSERS=true
+RUN if [ "$INSTALL_PLAYWRIGHT_BROWSERS" = "true" ]; then \
+    npx playwright install chromium; \
+    fi
+
+# Run pilo CLI - subcommand args are appended by the caller
+ENTRYPOINT ["node", "/app/packages/cli/dist/cli/src/cli.js"]

--- a/packages/core/src/loggers/json.ts
+++ b/packages/core/src/loggers/json.ts
@@ -13,16 +13,63 @@ const DEFAULT_EXCLUDED_EVENTS: readonly WebAgentEventType[] = [
 export interface JSONConsoleLoggerOptions {
   /** Include screenshot image events (default: false) */
   includeScreenshotImages?: boolean;
+  /**
+   * Strip binary image data from ai:generation message history (default: true).
+   * Images are replaced with { type, mediaType, size, data: '<omitted>' }.
+   * Disable only if you need the raw bytes for debugging.
+   */
+  sanitizeGenerationImages?: boolean;
+}
+
+/**
+ * Strip binary image data from ai:generation event data before logging.
+ * Image content blocks are replaced with a lightweight descriptor:
+ *   { type: 'image', mediaType, size, data: '<omitted>' }
+ * The actual JPEG files are already saved separately alongside stdout.txt.
+ */
+function sanitizeAiGenerationData(data: unknown): unknown {
+  if (!data || typeof data !== "object") return data;
+  const d = data as Record<string, unknown>;
+  if (!Array.isArray(d.messages)) return data;
+
+  return {
+    ...d,
+    messages: d.messages.map((msg: unknown) => {
+      if (!msg || typeof msg !== "object") return msg;
+      const m = msg as Record<string, unknown>;
+      if (!Array.isArray(m.content)) return msg;
+
+      return {
+        ...m,
+        content: m.content.map((block: unknown) => {
+          if (!block || typeof block !== "object") return block;
+          const b = block as Record<string, unknown>;
+          if (b.type === "image" && ArrayBuffer.isView(b.image)) {
+            const buf = b.image as ArrayBufferView;
+            return {
+              type: "image",
+              mediaType: b.mediaType,
+              size: buf.byteLength,
+              data: "<omitted>",
+            };
+          }
+          return block;
+        }),
+      };
+    }),
+  };
 }
 
 export class JSONConsoleLogger implements Logger {
   private emitter: WebAgentEventEmitter | null = null;
   private handlers: [WebAgentEventType, (data: any) => void][] = [];
   private excludedEvents: Set<WebAgentEventType>;
+  private sanitizeGenerationImages: boolean;
 
   constructor(options: JSONConsoleLoggerOptions = {}) {
     // Build excluded events set
     this.excludedEvents = new Set(options.includeScreenshotImages ? [] : DEFAULT_EXCLUDED_EVENTS);
+    this.sanitizeGenerationImages = options.sanitizeGenerationImages !== false; // default: true
   }
 
   initialize(emitter: WebAgentEventEmitter): void {
@@ -55,7 +102,15 @@ export class JSONConsoleLogger implements Logger {
         return;
       }
 
-      const json = JSON.stringify({ event: type, data }, null, 0);
+      // Strip raw image bytes from AI generation messages to keep stdout.txt manageable.
+      // Screenshots are already saved separately as JPEG files; the binary arrays
+      // in the message history serve no purpose in the log and can reach 50-100MB.
+      const safeData =
+        this.sanitizeGenerationImages && type === WebAgentEventType.AI_GENERATION
+          ? sanitizeAiGenerationData(data)
+          : data;
+
+      const json = JSON.stringify({ event: type, data: safeData }, null, 0);
       console.log(json);
     };
   }


### PR DESCRIPTION
Did a few rounds with Claude and local eval runs to try improving prompts and scoring. Seems really promising:

<img width="1235" height="373" alt="image" src="https://github.com/user-attachments/assets/42d9df69-e16e-46a3-862d-77c46cf85bc4" />

Aiming to rework this as needed, once more dust has settled on renaming & reorgs

## Description

Improves the action loop system prompt based on analysis of recent eval runs. Changes are grouped into four themes:

**Interaction resilience:**
- Replaces the "no scrolling needed" assumption with a note that dynamic pages may require scroll/interaction to load content
- Adds click-interception fallback guidance: try `focus()` + keyboard navigation (Tab, Enter, arrow keys) or Escape to dismiss overlapping overlays
- Adds autocomplete/combobox guidance: use `focus()` + `enter()` on dropdown suggestions instead of `click()`, which often times out
- Adds date picker guidance: prefer `fill()` over calendar month navigation; fall back to keyboard input after two failed "next month" clicks

**Error recovery:**
- Adds stale-ref recovery guidance: after an "Invalid element reference" error, wait for a fresh snapshot and use new refs — don't retry old IDs
- Adds a recovery block to `stepErrorFeedbackTemplate`: don't repeat failing actions with the same arguments; try a different element or approach after 2 attempts

**Research and web search:**
- Proactively recommends `webSearch` for HTML versions (ACL Anthology, Semantic Scholar) before attempting PDFs that are often unscrollable/unreadable
- Adds a conditional hint (when `webSearch` is available) to use `webSearch()` directly rather than driving a browser search engine, avoiding CAPTCHA/bot-detection

**Output quality:**
- Shifts the `abort()` vs `done()` framing: prefer `done()` when core information is found; only `abort()` when the core task is fully blocked
- Adds a note to `taskValidationFeedbackTemplate`: use `done()` with the best available answer if genuine site limitations prevent addressing feedback
- Adds a criteria-confirmation requirement in `done()`: explicitly confirm each filter criterion (min rating, price range, ingredient count, etc.) was met

## PR Type

- Refactor

## Related issues

<!-- e.g. "Fixes #123" or "Related to #456" -->

## Checklist

- [ ] I understand the code I am submitting
- [ ] I have tested this code locally
- [ ] New and existing tests pass locally (`pnpm test`)
- [ ] I have added tests that prove my fix/feature works (if applicable)
- [ ] Documentation was updated where necessary
- [ ] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- Claude with Claude Code -->
