### PR TITLE
build(extension): fix build sequencing so both browser artifacts survive

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabstack/pilo",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "AI-powered web automation library and CLI tool",
   "type": "module",
   "engines": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -9,9 +9,10 @@
   },
   "scripts": {
     "dev": "tsx scripts/dev.ts",
-    "build:chrome": "pnpm run clean && wxt build -b chrome",
-    "build:firefox": "pnpm run clean && wxt build -b firefox",
-    "build:publish": "pnpm run build:chrome && pnpm run build:firefox",
+    "prebuild": "pnpm run clean",
+    "build:chrome": "wxt build -b chrome",
+    "build:firefox": "wxt build -b firefox",
+    "build:publish": "pnpm run prebuild && pnpm run build:chrome && pnpm run build:firefox",
     "clean": "rm -rf dist .output && rm -f public/pilo.config.json",
     "pretest": "wxt prepare",
     "typecheck": "wxt prepare && tsc --noEmit",


### PR DESCRIPTION
## Summary
- Restructured extension build scripts so `clean` runs once via a new `prebuild` step, not before each individual browser build
- Previously, `build:publish` chained `build:chrome && build:firefox`, and each called `clean` first, so the firefox clean wiped the chrome output from `dist/`
- Now `build:publish` runs `prebuild` (clean) once, then both `wxt build` calls run without cleaning, preserving both browser artifacts