### PR TITLE
fix(server): skip lifecycle scripts during Docker install

### DIFF
--- a/packages/server/Dockerfile
+++ b/packages/server/Dockerfile
@@ -20,7 +20,7 @@ COPY packages/server/package.json ./packages/server/package.json
 COPY packages/extension/package.json ./packages/extension/package.json
 
 # Install all workspace dependencies
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy core source and build it (server depends on pilo-core)
 COPY packages/core/ ./packages/core/


### PR DESCRIPTION
## Description

Docker build fails because pnpm install triggers the root prepare script, which tries to build pilo-core. At that stage only package.json manifests are copied — source files aren't there yet. Adding --ignore-scripts fixes it since the core build already runs explicitly in the next Dockerfile step. 

## PR Type

<!-- Delete the types that don't apply -->
- Bug Fix
- Infrastructure

## Related issues



## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`)
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

<!-- We welcome the use of AI to aid in contribution! Please indicate your AI usage below. -->

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [X] This is fully AI-generated

<!-- Optional: What LLM and tooling did you use? (e.g., Claude with Claude Code, GPT-4 with Copilot) -->
