### PR TITLE
feat: add Tabstack API tools for cloud-based extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ try {
 - 🌐 **Multi-Browser Support**: Works with Firefox, Chrome, Safari, and Edge
 - 🛡️ **Safety First**: Provide guardrails to prevent unintended actions
 - 📝 **Rich Context**: Pass structured data to help with form filling and complex tasks
+- ☁️ **Tabstack API Integration**: Extract markdown, structured JSON, or AI-transformed data from any URL using [Tabstack](https://tabstack.ai) cloud tools — especially useful for PDFs which browsers cannot read directly
 
 ## Configuration
 
@@ -418,6 +419,7 @@ Results appear as commit status checks with links to detailed HTML reports. See 
 | `--pw-endpoint <url>`           | Playwright endpoint for remote browser                     | -                | `--pw-endpoint ws://localhost:9222`     |
 | `--pw-cdp-endpoint <url>`       | Chrome DevTools Protocol endpoint                          | -                | `--pw-cdp-endpoint ws://localhost:9222` |
 | `--bypass-csp`                  | Bypass Content Security Policy                             | false            | `--bypass-csp`                          |
+| `--tabstack-api-key <key>`      | Tabstack API key for cloud extraction tools                | -                | `--tabstack-api-key your-key`           |
 
 ### Environment Variables
 
@@ -463,6 +465,8 @@ All configuration options can be set via environment variables (dev mode only; n
 | `PILO_PW_ENDPOINT`                | Playwright endpoint URL                          | `--pw-endpoint`             |
 | `PILO_PW_CDP_ENDPOINT`            | CDP endpoint URL                                 | `--pw-cdp-endpoint`         |
 | `PILO_BYPASS_CSP`                 | Bypass CSP (true/false)                          | `--bypass-csp`              |
+| **Tabstack Configuration**        |                                                  |                             |
+| `TABSTACK_API_KEY`                | Tabstack API key for cloud extraction tools      | `--tabstack-api-key`        |
 
 ### Configuration Priority
 

--- a/README.md
+++ b/README.md
@@ -391,35 +391,36 @@ Results appear as commit status checks with links to detailed HTML reports. See 
 
 ### Complete CLI Options
 
-| Option                          | Description                                                | Default          | Example                                 |
-| ------------------------------- | ---------------------------------------------------------- | ---------------- | --------------------------------------- |
-| `--url <url>`                   | Starting URL for the task                                  | -                | `--url https://example.com`             |
-| `--data <json>`                 | JSON data to provide context                               | -                | `--data '{"name":"John"}'`              |
-| `--guardrails <text>`           | Safety constraints for execution                           | -                | `--guardrails "browse only"`            |
-| `--provider <provider>`         | AI provider (openai, openrouter, vertex, ollama)           | openrouter       | `--provider openai`                     |
-| `--model <model>`               | AI model to use                                            | Provider default | `--model gpt-4o`                        |
-| `--openai-api-key <key>`        | OpenAI API key                                             | -                | `--openai-api-key sk-...`               |
-| `--openrouter-api-key <key>`    | OpenRouter API key                                         | -                | `--openrouter-api-key sk-or-...`        |
-| `--browser <browser>`           | Browser (firefox, chrome, chromium, safari, webkit, edge)  | firefox          | `--browser chrome`                      |
-| `--channel <channel>`           | Browser channel (chrome, msedge, chrome-beta, moz-firefox) | -                | `--channel chrome-beta`                 |
-| `--executable-path <path>`      | Path to browser executable                                 | -                | `--executable-path /usr/bin/firefox`    |
-| `--headless`                    | Run browser in headless mode                               | false            | `--headless`                            |
-| `--debug`                       | Enable debug mode with snapshots                           | false            | `--debug`                               |
-| `--vision`                      | Enable vision capabilities                                 | false            | `--vision`                              |
-| `--no-block-ads`                | Disable ad blocking                                        | false            | `--no-block-ads`                        |
-| `--block-resources <list>`      | Resources to block (comma-separated)                       | media,manifest   | `--block-resources image,font`          |
-| `--max-iterations <n>`          | Maximum task iterations                                    | 50               | `--max-iterations 100`                  |
-| `--max-validation-attempts <n>` | Maximum validation attempts                                | 3                | `--max-validation-attempts 5`           |
-| `--max-repeated-actions <n>`    | Maximum action repetitions before warning/aborting         | 2                | `--max-repeated-actions 3`              |
-| `--reasoning-effort <level>`    | Reasoning effort (none, low, medium, high)                 | none             | `--reasoning-effort high`               |
-| `--proxy <url>`                 | Proxy server URL                                           | -                | `--proxy http://proxy:8080`             |
-| `--proxy-username <user>`       | Proxy authentication username                              | -                | `--proxy-username myuser`               |
-| `--proxy-password <pass>`       | Proxy authentication password                              | -                | `--proxy-password mypass`               |
-| `--logger <type>`               | Logger type (console, json)                                | console          | `--logger json`                         |
-| `--pw-endpoint <url>`           | Playwright endpoint for remote browser                     | -                | `--pw-endpoint ws://localhost:9222`     |
-| `--pw-cdp-endpoint <url>`       | Chrome DevTools Protocol endpoint                          | -                | `--pw-cdp-endpoint ws://localhost:9222` |
-| `--bypass-csp`                  | Bypass Content Security Policy                             | false            | `--bypass-csp`                          |
-| `--tabstack-api-key <key>`      | Tabstack API key for cloud extraction tools                | -                | `--tabstack-api-key your-key`           |
+| Option                          | Description                                                | Default                 | Example                                    |
+| ------------------------------- | ---------------------------------------------------------- | ----------------------- | ------------------------------------------ |
+| `--url <url>`                   | Starting URL for the task                                  | -                       | `--url https://example.com`                |
+| `--data <json>`                 | JSON data to provide context                               | -                       | `--data '{"name":"John"}'`                 |
+| `--guardrails <text>`           | Safety constraints for execution                           | -                       | `--guardrails "browse only"`               |
+| `--provider <provider>`         | AI provider (openai, openrouter, vertex, ollama)           | openrouter              | `--provider openai`                        |
+| `--model <model>`               | AI model to use                                            | Provider default        | `--model gpt-4o`                           |
+| `--openai-api-key <key>`        | OpenAI API key                                             | -                       | `--openai-api-key sk-...`                  |
+| `--openrouter-api-key <key>`    | OpenRouter API key                                         | -                       | `--openrouter-api-key sk-or-...`           |
+| `--browser <browser>`           | Browser (firefox, chrome, chromium, safari, webkit, edge)  | firefox                 | `--browser chrome`                         |
+| `--channel <channel>`           | Browser channel (chrome, msedge, chrome-beta, moz-firefox) | -                       | `--channel chrome-beta`                    |
+| `--executable-path <path>`      | Path to browser executable                                 | -                       | `--executable-path /usr/bin/firefox`       |
+| `--headless`                    | Run browser in headless mode                               | false                   | `--headless`                               |
+| `--debug`                       | Enable debug mode with snapshots                           | false                   | `--debug`                                  |
+| `--vision`                      | Enable vision capabilities                                 | false                   | `--vision`                                 |
+| `--no-block-ads`                | Disable ad blocking                                        | false                   | `--no-block-ads`                           |
+| `--block-resources <list>`      | Resources to block (comma-separated)                       | media,manifest          | `--block-resources image,font`             |
+| `--max-iterations <n>`          | Maximum task iterations                                    | 50                      | `--max-iterations 100`                     |
+| `--max-validation-attempts <n>` | Maximum validation attempts                                | 3                       | `--max-validation-attempts 5`              |
+| `--max-repeated-actions <n>`    | Maximum action repetitions before warning/aborting         | 2                       | `--max-repeated-actions 3`                 |
+| `--reasoning-effort <level>`    | Reasoning effort (none, low, medium, high)                 | none                    | `--reasoning-effort high`                  |
+| `--proxy <url>`                 | Proxy server URL                                           | -                       | `--proxy http://proxy:8080`                |
+| `--proxy-username <user>`       | Proxy authentication username                              | -                       | `--proxy-username myuser`                  |
+| `--proxy-password <pass>`       | Proxy authentication password                              | -                       | `--proxy-password mypass`                  |
+| `--logger <type>`               | Logger type (console, json)                                | console                 | `--logger json`                            |
+| `--pw-endpoint <url>`           | Playwright endpoint for remote browser                     | -                       | `--pw-endpoint ws://localhost:9222`        |
+| `--pw-cdp-endpoint <url>`       | Chrome DevTools Protocol endpoint                          | -                       | `--pw-cdp-endpoint ws://localhost:9222`    |
+| `--bypass-csp`                  | Bypass Content Security Policy                             | false                   | `--bypass-csp`                             |
+| `--tabstack-api-key <key>`      | Tabstack API key for cloud extraction tools                | -                       | `--tabstack-api-key your-key`              |
+| `--tabstack-api-url <url>`      | Tabstack API base URL                                      | https://api.tabstack.ai | `--tabstack-api-url http://localhost:8080` |
 
 ### Environment Variables
 
@@ -467,6 +468,7 @@ All configuration options can be set via environment variables (dev mode only; n
 | `PILO_BYPASS_CSP`                 | Bypass CSP (true/false)                          | `--bypass-csp`              |
 | **Tabstack Configuration**        |                                                  |                             |
 | `TABSTACK_API_KEY`                | Tabstack API key for cloud extraction tools      | `--tabstack-api-key`        |
+| `TABSTACK_API_URL`                | Tabstack API base URL                            | `--tabstack-api-url`        |
 
 ### Configuration Priority
 

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -221,6 +221,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       searchProvider: options.searchProvider ?? cfg.search_provider,
       searchApiKey: cfg.parallel_api_key,
       tabstackApiKey: options.tabstackApiKey ?? cfg.tabstack_api_key,
+      tabstackApiUrl: options.tabstackApiUrl ?? cfg.tabstack_api_url,
       providerConfig,
       logger,
       eventEmitter,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -220,6 +220,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       maxTotalErrors: options.maxTotalErrors ?? cfg.max_total_errors,
       searchProvider: options.searchProvider ?? cfg.search_provider,
       searchApiKey: cfg.parallel_api_key,
+      tabstackApiKey: options.tabstackApiKey ?? cfg.tabstack_api_key,
       providerConfig,
       logger,
       eventEmitter,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,7 @@
     "@ai-sdk/openai-compatible": "^2.0.31",
     "@ghostery/adblocker-playwright": "^2.14.1",
     "@openrouter/ai-sdk-provider": "^2.1.1",
+    "@tabstack/sdk": "^2.2.0",
     "ai": "^6.0.105",
     "chalk": "^5.6.2",
     "commander": "^14.0.3",

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -119,6 +119,7 @@ export interface PiloConfig {
 
   // Tabstack Configuration
   tabstack_api_key?: string;
+  tabstack_api_url?: string;
 }
 
 /** PiloConfigResolved type - output type (defaults applied) */
@@ -187,6 +188,7 @@ export interface PiloConfigResolved {
 
   // Tabstack Configuration
   tabstack_api_key?: string;
+  tabstack_api_url?: string;
 }
 
 export type ConfigKey = keyof PiloConfigResolved;
@@ -613,6 +615,14 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     placeholder: "key",
     env: ["TABSTACK_API_KEY"],
     description: "Tabstack API key for cloud extraction tools",
+    category: "tabstack",
+  },
+  tabstack_api_url: {
+    type: "string",
+    cli: "--tabstack-api-url",
+    placeholder: "url",
+    env: ["TABSTACK_API_URL"],
+    description: "Tabstack API base URL (default: https://api.tabstack.ai)",
     category: "tabstack",
   },
 };

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -46,7 +46,8 @@ export type ConfigCategory =
   | "playwright"
   | "navigation"
   | "action"
-  | "search";
+  | "search"
+  | "tabstack";
 
 // =============================================================================
 // PiloConfig Interface (Manual for Readability)
@@ -115,6 +116,9 @@ export interface PiloConfig {
   // Search Configuration
   search_provider?: SearchProviderName;
   parallel_api_key?: string;
+
+  // Tabstack Configuration
+  tabstack_api_key?: string;
 }
 
 /** PiloConfigResolved type - output type (defaults applied) */
@@ -180,6 +184,9 @@ export interface PiloConfigResolved {
   // Search Configuration
   search_provider: SearchProviderName;
   parallel_api_key?: string;
+
+  // Tabstack Configuration
+  tabstack_api_key?: string;
 }
 
 export type ConfigKey = keyof PiloConfigResolved;
@@ -597,6 +604,16 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     env: ["PARALLEL_API_KEY"],
     description: "Parallel API key for search",
     category: "search",
+  },
+
+  // Tabstack Configuration
+  tabstack_api_key: {
+    type: "string",
+    cli: "--tabstack-api-key",
+    placeholder: "key",
+    env: ["TABSTACK_API_KEY"],
+    description: "Tabstack API key for cloud extraction tools",
+    category: "tabstack",
   },
 };
 

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -111,6 +111,31 @@ export const TOOL_STRINGS = {
       feedback: "Specific feedback on what needs improvement (if not complete/excellent)",
     },
   },
+  /**
+   * Tabstack tools - cloud-based extraction and generation via Tabstack API
+   */
+  tabstack: {
+    tabstack_extract_markdown: {
+      description:
+        "Extract clean markdown content from a URL (web page or PDF). Especially useful for PDFs, which browsers cannot read directly. Returns the page content as markdown with metadata (title, description, author, etc.).",
+      url: "The URL to extract content from (web page or PDF URL)",
+    },
+    tabstack_extract_json: {
+      description:
+        "Extract structured JSON data from a URL according to a JSON Schema you provide. The schema defines the exact shape of the data you want extracted from the page.",
+      url: "The URL to extract data from",
+      json_schema:
+        "A JSON Schema object defining the desired output structure. Must include type, properties, and optionally required fields. Use description fields on properties to guide extraction.",
+    },
+    tabstack_generate_json: {
+      description:
+        "Fetch a URL and transform its content into structured JSON using AI, guided by your natural language instructions and a JSON Schema for the output format.",
+      url: "The URL to process",
+      json_schema: "A JSON Schema object defining the desired output structure",
+      instructions:
+        "Natural language instructions describing how to transform or generate the data from the page content",
+    },
+  },
 } as const;
 
 /** Base AI persona for web automation tasks. */
@@ -127,7 +152,7 @@ IMPORTANT:
 `.trim();
 
 /** Build available browser action tools with JSON syntax examples. */
-function buildToolExamples(hasWebSearch: boolean): string {
+function buildToolExamples(hasWebSearch: boolean, hasTabstack: boolean = false): string {
   const lines = [
     `- click({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.click.description}`,
     `- fill({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "text"}) - ${TOOL_STRINGS.webActions.fill.description}`,
@@ -147,6 +172,14 @@ function buildToolExamples(hasWebSearch: boolean): string {
   if (hasWebSearch) {
     lines.push(
       `- webSearch({"query": "search terms"}) - ${TOOL_STRINGS.webActions.webSearch.description}`,
+    );
+  }
+
+  if (hasTabstack) {
+    lines.push(
+      `- tabstack_extract_markdown({"url": "https://example.com"}) - ${TOOL_STRINGS.tabstack.tabstack_extract_markdown.description}`,
+      `- tabstack_extract_json({"url": "https://example.com", "json_schema": {"type": "object", "properties": {"field": {"type": "string"}}}}) - ${TOOL_STRINGS.tabstack.tabstack_extract_json.description}`,
+      `- tabstack_generate_json({"url": "https://example.com", "json_schema": {"type": "object", "properties": {"field": {"type": "string"}}}, "instructions": "..."}) - ${TOOL_STRINGS.tabstack.tabstack_generate_json.description}`,
     );
   }
 
@@ -298,8 +331,13 @@ Analyze the current page state and determine your next action based on previous 
 - If you don't find relevant links or buttons, and the site has a search form, prioritize using it for navigation
 - If you have found the core information requested but cannot access supplementary details due to site limitations, use done() with what you have — only use abort() when the core task cannot be completed at all
 - For research: Use extract() immediately when finding relevant data
-- For academic papers or documents that require reading, counting, or extracting content (e.g., counting figures/tables, reading body text): PDFs are often unscrollable and unreadable — use webSearch to find an HTML version (e.g., ACL Anthology, Semantic Scholar) or the abstract page before attempting the PDF
+- For academic papers or documents that require reading, counting, or extracting content (e.g., counting figures/tables, reading body text): PDFs are often unscrollable and unreadable{% if hasTabstack %} — use tabstack_extract_markdown to read PDF content directly{% endif %}{% if not hasTabstack %} — use webSearch to find an HTML version (e.g., ACL Anthology, Semantic Scholar) or the abstract page before attempting the PDF{% endif %}
 {% if hasWebSearch %}- If you need to search the web, use webSearch({query}) directly rather than filling in a browser search engine (DuckDuckGo, Google, Bing, etc.) — webSearch avoids CAPTCHA and bot detection that will block browser-based searches{% endif %}
+{% if hasTabstack %}- **Tabstack cloud tools are available — prefer them over manual browsing when they fit:**
+  - tabstack_extract_markdown: Use this for PDFs (browsers render PDFs in a viewer you cannot read) and whenever you need clean text from a page without navigating to it
+  - tabstack_extract_json: Use when you need structured data from a page and can define the desired shape as a JSON Schema
+  - tabstack_generate_json: Use when you need AI-transformed content (summaries, categorization, restructured data){% endif %}
+{% if hasStartingUrl and hasWebSearch %}- A starting URL was provided — **focus on that site first**. Use webSearch only if you need supplementary information beyond what the site provides{% endif %}
 {% if hasGuardrails %}- Verify guardrail compliance before each action{% endif %}
 
 **When using done():**
@@ -320,12 +358,19 @@ ${toolCallInstruction}
 `.trim(),
 );
 
-/** Build action system prompt with optional guardrails and web search. */
-const buildActionLoopSystemPrompt = (hasGuardrails: boolean, hasWebSearch: boolean = false) =>
+/** Build action system prompt with optional guardrails, web search, and Tabstack tools. */
+const buildActionLoopSystemPrompt = (
+  hasGuardrails: boolean,
+  hasWebSearch: boolean = false,
+  hasTabstack: boolean = false,
+  hasStartingUrl: boolean = false,
+) =>
   actionLoopSystemPromptTemplate({
     hasGuardrails,
     hasWebSearch,
-    toolExamples: buildToolExamples(hasWebSearch),
+    hasTabstack,
+    hasStartingUrl,
+    toolExamples: buildToolExamples(hasWebSearch, hasTabstack),
     currentDate: getCurrentFormattedDate(),
   });
 
@@ -452,11 +497,12 @@ export const buildStepErrorFeedbackPrompt = (
   error: string,
   hasGuardrails: boolean = false,
   hasWebSearch: boolean = false,
+  hasTabstack: boolean = false,
 ) =>
   stepErrorFeedbackTemplate({
     error,
     hasGuardrails,
-    toolExamples: buildToolExamples(hasWebSearch),
+    toolExamples: buildToolExamples(hasWebSearch, hasTabstack),
   });
 
 /**

--- a/packages/core/src/tabstack/client.ts
+++ b/packages/core/src/tabstack/client.ts
@@ -9,6 +9,6 @@ import Tabstack from "@tabstack/sdk";
 
 export type { default as Tabstack } from "@tabstack/sdk";
 
-export function createTabstackClient(apiKey: string): Tabstack {
-  return new Tabstack({ apiKey });
+export function createTabstackClient(apiKey: string, baseURL?: string): Tabstack {
+  return new Tabstack({ apiKey, baseURL: baseURL ?? null });
 }

--- a/packages/core/src/tabstack/client.ts
+++ b/packages/core/src/tabstack/client.ts
@@ -1,0 +1,14 @@
+/**
+ * Tabstack SDK client factory.
+ *
+ * Thin wrapper around the @tabstack/sdk to create client instances
+ * from an API key. The caller manages the client lifecycle.
+ */
+
+import Tabstack from "@tabstack/sdk";
+
+export type { default as Tabstack } from "@tabstack/sdk";
+
+export function createTabstackClient(apiKey: string): Tabstack {
+  return new Tabstack({ apiKey });
+}

--- a/packages/core/src/tools/tabstackTools.ts
+++ b/packages/core/src/tools/tabstackTools.ts
@@ -1,0 +1,171 @@
+/**
+ * Tabstack Tools
+ *
+ * Cloud-based extraction and generation tools using the Tabstack API.
+ * These tools give the agent access to Tabstack's content extraction
+ * capabilities, which are especially useful for PDFs and structured
+ * data extraction.
+ */
+
+import { tool } from "ai";
+import { z } from "zod";
+import type Tabstack from "@tabstack/sdk";
+import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
+import { TOOL_STRINGS } from "../prompts.js";
+
+export interface TabstackToolContext {
+  client: Tabstack;
+  eventEmitter: WebAgentEventEmitter;
+}
+
+export function createTabstackTools(context: TabstackToolContext) {
+  return {
+    tabstack_extract_markdown: tool({
+      description: TOOL_STRINGS.tabstack.tabstack_extract_markdown.description,
+      inputSchema: z.object({
+        url: z.string().url().describe(TOOL_STRINGS.tabstack.tabstack_extract_markdown.url),
+      }),
+      execute: async ({ url }) => {
+        context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
+          action: "tabstack_extract_markdown",
+          value: url,
+        });
+
+        try {
+          const result = await context.client.extract.markdown({ url, metadata: true });
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: true,
+            action: "tabstack_extract_markdown",
+          });
+
+          return {
+            success: true,
+            action: "tabstack_extract_markdown",
+            url: result.url,
+            content: result.content,
+            metadata: result.metadata,
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: false,
+            action: "tabstack_extract_markdown",
+            error: errorMessage,
+            isRecoverable: true,
+          });
+
+          return {
+            success: false,
+            action: "tabstack_extract_markdown",
+            url,
+            error: errorMessage,
+            isRecoverable: true,
+          };
+        }
+      },
+    }),
+
+    tabstack_extract_json: tool({
+      description: TOOL_STRINGS.tabstack.tabstack_extract_json.description,
+      inputSchema: z.object({
+        url: z.string().url().describe(TOOL_STRINGS.tabstack.tabstack_extract_json.url),
+        json_schema: z
+          .record(z.string(), z.unknown())
+          .describe(TOOL_STRINGS.tabstack.tabstack_extract_json.json_schema),
+      }),
+      execute: async ({ url, json_schema }) => {
+        context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
+          action: "tabstack_extract_json",
+          value: url,
+        });
+
+        try {
+          const data = await context.client.extract.json({ url, json_schema });
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: true,
+            action: "tabstack_extract_json",
+          });
+
+          return {
+            success: true,
+            action: "tabstack_extract_json",
+            url,
+            data,
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: false,
+            action: "tabstack_extract_json",
+            error: errorMessage,
+            isRecoverable: true,
+          });
+
+          return {
+            success: false,
+            action: "tabstack_extract_json",
+            url,
+            error: errorMessage,
+            isRecoverable: true,
+          };
+        }
+      },
+    }),
+
+    tabstack_generate_json: tool({
+      description: TOOL_STRINGS.tabstack.tabstack_generate_json.description,
+      inputSchema: z.object({
+        url: z.string().url().describe(TOOL_STRINGS.tabstack.tabstack_generate_json.url),
+        json_schema: z
+          .record(z.string(), z.unknown())
+          .describe(TOOL_STRINGS.tabstack.tabstack_generate_json.json_schema),
+        instructions: z
+          .string()
+          .describe(TOOL_STRINGS.tabstack.tabstack_generate_json.instructions),
+      }),
+      execute: async ({ url, json_schema, instructions }) => {
+        context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
+          action: "tabstack_generate_json",
+          value: url,
+        });
+
+        try {
+          const data = await context.client.generate.json({ url, json_schema, instructions });
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: true,
+            action: "tabstack_generate_json",
+          });
+
+          return {
+            success: true,
+            action: "tabstack_generate_json",
+            url,
+            data,
+          };
+        } catch (error) {
+          const errorMessage = error instanceof Error ? error.message : String(error);
+
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: false,
+            action: "tabstack_generate_json",
+            error: errorMessage,
+            isRecoverable: true,
+          });
+
+          return {
+            success: false,
+            action: "tabstack_generate_json",
+            url,
+            error: errorMessage,
+            isRecoverable: true,
+          };
+        }
+      },
+    }),
+  };
+}

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -80,6 +80,8 @@ export interface WebAgentOptions {
   searchApiKey?: string;
   /** Tabstack API key for cloud extraction tools (when set, Tabstack tools are available) */
   tabstackApiKey?: string;
+  /** Tabstack API base URL (default: https://api.tabstack.ai) */
+  tabstackApiUrl?: string;
 }
 
 export interface ExecuteOptions {
@@ -199,6 +201,7 @@ export class WebAgent {
   private readonly searchProvider: SearchProviderName;
   private readonly searchApiKey: string | undefined;
   private readonly tabstackApiKey: string | undefined;
+  private readonly tabstackApiUrl: string | undefined;
 
   constructor(
     private browser: AriaBrowser,
@@ -220,6 +223,7 @@ export class WebAgent {
     this.searchProvider = options.searchProvider ?? defaults.search_provider;
     this.searchApiKey = options.searchApiKey;
     this.tabstackApiKey = options.tabstackApiKey;
+    this.tabstackApiUrl = options.tabstackApiUrl;
 
     if (this.searchProvider === "parallel-api" && !this.searchApiKey) {
       throw new Error("parallel_api_key is required when search_provider is 'parallel-api'");
@@ -346,7 +350,7 @@ export class WebAgent {
     // Only include Tabstack tools if an API key is configured
     const tabstackTools = this.tabstackApiKey
       ? createTabstackTools({
-          client: createTabstackClient(this.tabstackApiKey),
+          client: createTabstackClient(this.tabstackApiKey, this.tabstackApiUrl),
           eventEmitter: this.eventEmitter,
         })
       : {};

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -37,6 +37,8 @@ import { createSearchTools } from "./tools/searchTools.js";
 import { SearchService } from "./search/searchService.js";
 import { createPlanningTools } from "./tools/planningTools.js";
 import { createValidationTools } from "./tools/validationTools.js";
+import { createTabstackTools } from "./tools/tabstackTools.js";
+import { createTabstackClient } from "./tabstack/client.js";
 import { nanoid } from "nanoid";
 import { getConfigDefaults, type SearchProviderName } from "./config/defaults.js";
 import {
@@ -76,6 +78,8 @@ export interface WebAgentOptions {
   searchProvider?: SearchProviderName;
   /** API key for search providers that require authentication (e.g., Parallel) */
   searchApiKey?: string;
+  /** Tabstack API key for cloud extraction tools (when set, Tabstack tools are available) */
+  tabstackApiKey?: string;
 }
 
 export interface ExecuteOptions {
@@ -194,6 +198,7 @@ export class WebAgent {
   private readonly guardrails: string | null;
   private readonly searchProvider: SearchProviderName;
   private readonly searchApiKey: string | undefined;
+  private readonly tabstackApiKey: string | undefined;
 
   constructor(
     private browser: AriaBrowser,
@@ -214,6 +219,7 @@ export class WebAgent {
     this.guardrails = options.guardrails ?? null;
     this.searchProvider = options.searchProvider ?? defaults.search_provider;
     this.searchApiKey = options.searchApiKey;
+    this.tabstackApiKey = options.tabstackApiKey;
 
     if (this.searchProvider === "parallel-api" && !this.searchApiKey) {
       throw new Error("parallel_api_key is required when search_provider is 'parallel-api'");
@@ -337,8 +343,16 @@ export class WebAgent {
       ? createSearchTools({ searchService: this.searchService, eventEmitter: this.eventEmitter })
       : {};
 
+    // Only include Tabstack tools if an API key is configured
+    const tabstackTools = this.tabstackApiKey
+      ? createTabstackTools({
+          client: createTabstackClient(this.tabstackApiKey),
+          eventEmitter: this.eventEmitter,
+        })
+      : {};
+
     // Merge all tools
-    const allTools = { ...webActionTools, ...searchTools };
+    const allTools = { ...webActionTools, ...searchTools, ...tabstackTools };
 
     // Skip the first page snapshot when starting on about:blank (e.g., search-first flow).
     // The empty page has no useful elements and the snapshot prompt causes the model
@@ -555,6 +569,7 @@ export class WebAgent {
       errorMessage,
       Boolean(this.guardrails),
       this.searchProvider !== "none",
+      Boolean(this.tabstackApiKey),
     );
     this.messages.push({ role: "user", content: errorFeedback });
   }
@@ -1389,6 +1404,8 @@ export class WebAgent {
   private initializeSystemPromptAndTask(task: string): void {
     const hasGuardrails = Boolean(this.guardrails);
     const hasWebSearch = this.searchProvider !== "none";
+    const hasTabstack = Boolean(this.tabstackApiKey);
+    const hasStartingUrl = Boolean(this.url && this.url !== "about:blank");
 
     const taskPromptContent = buildTaskAndPlanPrompt(
       task,
@@ -1401,7 +1418,12 @@ export class WebAgent {
     this.messages = [
       {
         role: "system",
-        content: buildActionLoopSystemPrompt(hasGuardrails, hasWebSearch),
+        content: buildActionLoopSystemPrompt(
+          hasGuardrails,
+          hasWebSearch,
+          hasTabstack,
+          hasStartingUrl,
+        ),
       },
       {
         role: "user",

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -189,6 +189,7 @@ describe("ConfigManager", () => {
         "action_timeout_ms",
         "search_provider",
         "parallel_api_key",
+        "tabstack_api_key",
       ];
 
       // Check that schema has all PiloConfig keys

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -190,6 +190,7 @@ describe("ConfigManager", () => {
         "search_provider",
         "parallel_api_key",
         "tabstack_api_key",
+        "tabstack_api_url",
       ];
 
       // Check that schema has all PiloConfig keys

--- a/packages/core/test/tabstack/client.test.ts
+++ b/packages/core/test/tabstack/client.test.ts
@@ -11,7 +11,19 @@ describe("createTabstackClient", () => {
   it("should create a Tabstack instance with the provided API key", () => {
     createTabstackClient("test-api-key-123");
 
-    expect(Tabstack).toHaveBeenCalledWith({ apiKey: "test-api-key-123" });
+    expect(Tabstack).toHaveBeenCalledWith({
+      apiKey: "test-api-key-123",
+      baseURL: null,
+    });
+  });
+
+  it("should pass baseURL when provided", () => {
+    createTabstackClient("test-api-key-123", "http://127.0.0.1:8080");
+
+    expect(Tabstack).toHaveBeenCalledWith({
+      apiKey: "test-api-key-123",
+      baseURL: "http://127.0.0.1:8080",
+    });
   });
 
   it("should return the created instance", () => {

--- a/packages/core/test/tabstack/client.test.ts
+++ b/packages/core/test/tabstack/client.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi } from "vitest";
+import { createTabstackClient } from "../../src/tabstack/client.js";
+import Tabstack from "@tabstack/sdk";
+
+vi.mock("@tabstack/sdk", () => {
+  const MockTabstack = vi.fn();
+  return { default: MockTabstack };
+});
+
+describe("createTabstackClient", () => {
+  it("should create a Tabstack instance with the provided API key", () => {
+    createTabstackClient("test-api-key-123");
+
+    expect(Tabstack).toHaveBeenCalledWith({ apiKey: "test-api-key-123" });
+  });
+
+  it("should return the created instance", () => {
+    const instance = createTabstackClient("key-456");
+    expect(instance).toBeDefined();
+  });
+});

--- a/packages/core/test/tools/tabstackTools.test.ts
+++ b/packages/core/test/tools/tabstackTools.test.ts
@@ -1,0 +1,282 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createTabstackTools } from "../../src/tools/tabstackTools.js";
+import { WebAgentEventEmitter, WebAgentEventType } from "../../src/events.js";
+import type Tabstack from "@tabstack/sdk";
+
+// Mock the ai module
+vi.mock("ai", () => ({
+  tool: vi.fn((config: unknown) => {
+    const typedConfig = config as {
+      description: string;
+      inputSchema: unknown;
+      execute: (args: unknown, options?: unknown) => Promise<unknown>;
+    };
+    return {
+      ...typedConfig,
+      description: typedConfig.description,
+      inputSchema: typedConfig.inputSchema,
+      execute: typedConfig.execute,
+    };
+  }),
+}));
+
+function createMockClient() {
+  return {
+    extract: {
+      markdown: vi.fn(),
+      json: vi.fn(),
+    },
+    generate: {
+      json: vi.fn(),
+    },
+  } as unknown as Tabstack;
+}
+
+const toolCallOptions = { toolCallId: "test", messages: [] } as any;
+
+describe("Tabstack Tools", () => {
+  let mockClient: Tabstack;
+  let eventEmitter: WebAgentEventEmitter;
+  let tools: ReturnType<typeof createTabstackTools>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockClient = createMockClient();
+    eventEmitter = new WebAgentEventEmitter();
+    tools = createTabstackTools({ client: mockClient, eventEmitter });
+  });
+
+  describe("Tool Structure", () => {
+    it("should create all three tools", () => {
+      expect(tools.tabstack_extract_markdown).toBeDefined();
+      expect(tools.tabstack_extract_json).toBeDefined();
+      expect(tools.tabstack_generate_json).toBeDefined();
+    });
+
+    it("should have descriptions mentioning key features", () => {
+      expect(tools.tabstack_extract_markdown.description).toContain("PDF");
+      expect(tools.tabstack_extract_json.description).toContain("JSON Schema");
+      expect(tools.tabstack_generate_json.description).toContain("instructions");
+    });
+  });
+
+  describe("tabstack_extract_markdown", () => {
+    it("should call SDK with metadata: true and return result", async () => {
+      const sdkResult = {
+        url: "https://example.com",
+        content: "# Hello",
+        metadata: { title: "Hello" },
+      };
+      vi.mocked(mockClient.extract.markdown).mockResolvedValue(sdkResult);
+
+      const result = await tools.tabstack_extract_markdown.execute!(
+        { url: "https://example.com" },
+        toolCallOptions,
+      );
+
+      expect(mockClient.extract.markdown).toHaveBeenCalledWith({
+        url: "https://example.com",
+        metadata: true,
+      });
+      expect(result).toEqual({
+        success: true,
+        action: "tabstack_extract_markdown",
+        url: "https://example.com",
+        content: "# Hello",
+        metadata: { title: "Hello" },
+      });
+    });
+
+    it("should emit events on success", async () => {
+      vi.mocked(mockClient.extract.markdown).mockResolvedValue({
+        url: "https://example.com",
+        content: "# Hello",
+      });
+      const emitSpy = vi.spyOn(eventEmitter, "emit");
+
+      await tools.tabstack_extract_markdown.execute!(
+        { url: "https://example.com" },
+        toolCallOptions,
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.AGENT_ACTION, {
+        action: "tabstack_extract_markdown",
+        value: "https://example.com",
+      });
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+        success: true,
+        action: "tabstack_extract_markdown",
+      });
+    });
+
+    it("should handle errors gracefully", async () => {
+      vi.mocked(mockClient.extract.markdown).mockRejectedValue(new Error("Fetch failed"));
+
+      const result = await tools.tabstack_extract_markdown.execute!(
+        { url: "https://example.com" },
+        toolCallOptions,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        action: "tabstack_extract_markdown",
+        url: "https://example.com",
+        error: "Fetch failed",
+        isRecoverable: true,
+      });
+    });
+
+    it("should emit failure event on error", async () => {
+      vi.mocked(mockClient.extract.markdown).mockRejectedValue(new Error("Timeout"));
+      const emitSpy = vi.spyOn(eventEmitter, "emit");
+
+      await tools.tabstack_extract_markdown.execute!(
+        { url: "https://example.com" },
+        toolCallOptions,
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+        success: false,
+        action: "tabstack_extract_markdown",
+        error: "Timeout",
+        isRecoverable: true,
+      });
+    });
+
+    it("should handle non-Error exceptions", async () => {
+      vi.mocked(mockClient.extract.markdown).mockRejectedValue("string error");
+
+      const result = await tools.tabstack_extract_markdown.execute!(
+        { url: "https://example.com" },
+        toolCallOptions,
+      );
+
+      expect(result).toMatchObject({
+        success: false,
+        error: "string error",
+      });
+    });
+  });
+
+  describe("tabstack_extract_json", () => {
+    const schema = {
+      type: "object",
+      properties: { title: { type: "string" } },
+    };
+
+    it("should call SDK with url and json_schema and return data", async () => {
+      const sdkResult = { title: "Hello World" };
+      vi.mocked(mockClient.extract.json).mockResolvedValue(sdkResult);
+
+      const result = await tools.tabstack_extract_json.execute!(
+        { url: "https://example.com", json_schema: schema },
+        toolCallOptions,
+      );
+
+      expect(mockClient.extract.json).toHaveBeenCalledWith({
+        url: "https://example.com",
+        json_schema: schema,
+      });
+      expect(result).toEqual({
+        success: true,
+        action: "tabstack_extract_json",
+        url: "https://example.com",
+        data: { title: "Hello World" },
+      });
+    });
+
+    it("should handle errors gracefully", async () => {
+      vi.mocked(mockClient.extract.json).mockRejectedValue(new Error("Invalid schema"));
+
+      const result = await tools.tabstack_extract_json.execute!(
+        { url: "https://example.com", json_schema: schema },
+        toolCallOptions,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        action: "tabstack_extract_json",
+        url: "https://example.com",
+        error: "Invalid schema",
+        isRecoverable: true,
+      });
+    });
+  });
+
+  describe("tabstack_generate_json", () => {
+    const schema = {
+      type: "object",
+      properties: { summary: { type: "string" } },
+    };
+
+    it("should call SDK with url, json_schema, and instructions", async () => {
+      const sdkResult = { summary: "A brief summary" };
+      vi.mocked(mockClient.generate.json).mockResolvedValue(sdkResult);
+
+      const result = await tools.tabstack_generate_json.execute!(
+        {
+          url: "https://example.com",
+          json_schema: schema,
+          instructions: "Summarize the page",
+        },
+        toolCallOptions,
+      );
+
+      expect(mockClient.generate.json).toHaveBeenCalledWith({
+        url: "https://example.com",
+        json_schema: schema,
+        instructions: "Summarize the page",
+      });
+      expect(result).toEqual({
+        success: true,
+        action: "tabstack_generate_json",
+        url: "https://example.com",
+        data: { summary: "A brief summary" },
+      });
+    });
+
+    it("should handle errors gracefully", async () => {
+      vi.mocked(mockClient.generate.json).mockRejectedValue(new Error("Transform failed"));
+
+      const result = await tools.tabstack_generate_json.execute!(
+        {
+          url: "https://example.com",
+          json_schema: schema,
+          instructions: "Summarize",
+        },
+        toolCallOptions,
+      );
+
+      expect(result).toEqual({
+        success: false,
+        action: "tabstack_generate_json",
+        url: "https://example.com",
+        error: "Transform failed",
+        isRecoverable: true,
+      });
+    });
+
+    it("should emit events on success", async () => {
+      vi.mocked(mockClient.generate.json).mockResolvedValue({ summary: "test" });
+      const emitSpy = vi.spyOn(eventEmitter, "emit");
+
+      await tools.tabstack_generate_json.execute!(
+        {
+          url: "https://example.com",
+          json_schema: schema,
+          instructions: "Summarize",
+        },
+        toolCallOptions,
+      );
+
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.AGENT_ACTION, {
+        action: "tabstack_generate_json",
+        value: "https://example.com",
+      });
+      expect(emitSpy).toHaveBeenCalledWith(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+        success: true,
+        action: "tabstack_generate_json",
+      });
+    });
+  });
+});

--- a/packages/server/src/routes/pilo.test.ts
+++ b/packages/server/src/routes/pilo.test.ts
@@ -153,6 +153,20 @@ describe("Pilo Routes", () => {
       expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     });
 
+    it("should accept tabstackApiKey override", async () => {
+      const res = await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: "test task",
+          tabstackApiKey: "user-tabstack-key-123",
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    });
+
     it("should handle malformed JSON", async () => {
       const res = await app.request("/pilo/run", {
         method: "POST",

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -216,6 +216,7 @@ pilo.post("/run", async (c) => {
           guardrails: body.guardrails,
           searchProvider: body.searchProvider ?? serverConfig.search_provider,
           searchApiKey: serverConfig.parallel_api_key,
+          tabstackApiKey: serverConfig.tabstack_api_key,
         };
 
         // Create browser and agent instances

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -99,6 +99,9 @@ interface PiloTaskRequest {
   // Search configuration overrides
   searchProvider?: "none" | "duckduckgo" | "google" | "bing" | "parallel-api";
 
+  // Tabstack configuration overrides
+  tabstackApiKey?: string;
+
   // Enable full screenshot events (default: false)
   includeScreenshotImages?: boolean;
 }
@@ -216,7 +219,7 @@ pilo.post("/run", async (c) => {
           guardrails: body.guardrails,
           searchProvider: body.searchProvider ?? serverConfig.search_provider,
           searchApiKey: serverConfig.parallel_api_key,
-          tabstackApiKey: serverConfig.tabstack_api_key,
+          tabstackApiKey: body.tabstackApiKey ?? serverConfig.tabstack_api_key,
           tabstackApiUrl: serverConfig.tabstack_api_url,
         };
 

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -217,6 +217,7 @@ pilo.post("/run", async (c) => {
           searchProvider: body.searchProvider ?? serverConfig.search_provider,
           searchApiKey: serverConfig.parallel_api_key,
           tabstackApiKey: serverConfig.tabstack_api_key,
+          tabstackApiUrl: serverConfig.tabstack_api_url,
         };
 
         // Create browser and agent instances

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,13 +10,13 @@ importers:
     dependencies:
       '@ai-sdk/google':
         specifier: ^3.0.34
-        version: 3.0.34(zod@4.3.6)
+        version: 3.0.43(zod@4.3.6)
       '@ai-sdk/google-vertex':
         specifier: ^4.0.68
-        version: 4.0.68(zod@4.3.6)
+        version: 4.0.80(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.37
-        version: 3.0.37(zod@4.3.6)
+        version: 3.0.41(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.31
         version: 2.0.31(zod@4.3.6)
@@ -25,10 +25,10 @@ importers:
         version: 2.14.1(playwright@1.58.2)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.1.1
-        version: 2.2.3(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 2.2.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       ai:
         specifier: ^6.0.105
-        version: 6.0.105(zod@4.3.6)
+        version: 6.0.116(zod@4.3.6)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -52,7 +52,7 @@ importers:
         version: 5.1.6
       ollama-ai-provider-v2:
         specifier: ^3.0.3
-        version: 3.3.1(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 3.3.1(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       playwright:
         specifier: 1.58.2
         version: 1.58.2
@@ -74,7 +74,7 @@ importers:
         version: 3.8.1
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -99,25 +99,25 @@ importers:
     devDependencies:
       '@ai-sdk/google':
         specifier: ^3.0.34
-        version: 3.0.34(zod@4.3.6)
+        version: 3.0.43(zod@4.3.6)
       '@ai-sdk/google-vertex':
         specifier: ^4.0.68
-        version: 4.0.68(zod@4.3.6)
+        version: 4.0.80(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.37
-        version: 3.0.37(zod@4.3.6)
+        version: 3.0.41(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.31
         version: 2.0.31(zod@4.3.6)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.1.1
-        version: 2.2.3(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 2.2.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       '@types/node':
         specifier: ^25.3.0
-        version: 25.3.5
+        version: 25.3.0
       ollama-ai-provider-v2:
         specifier: ^3.0.3
-        version: 3.3.1(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 3.3.1(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -126,19 +126,19 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/core:
     dependencies:
       '@ai-sdk/google':
         specifier: ^3.0.34
-        version: 3.0.34(zod@4.3.6)
+        version: 3.0.43(zod@4.3.6)
       '@ai-sdk/google-vertex':
         specifier: ^4.0.68
-        version: 4.0.68(zod@4.3.6)
+        version: 4.0.80(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.37
-        version: 3.0.37(zod@4.3.6)
+        version: 3.0.41(zod@4.3.6)
       '@ai-sdk/openai-compatible':
         specifier: ^2.0.31
         version: 2.0.31(zod@4.3.6)
@@ -147,10 +147,13 @@ importers:
         version: 2.14.1(playwright@1.58.2)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.1.1
-        version: 2.2.3(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 2.2.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
+      '@tabstack/sdk':
+        specifier: ^2.2.0
+        version: 2.2.0
       ai:
         specifier: ^6.0.105
-        version: 6.0.105(zod@4.3.6)
+        version: 6.0.116(zod@4.3.6)
       chalk:
         specifier: ^5.6.2
         version: 5.6.2
@@ -174,7 +177,7 @@ importers:
         version: 5.1.6
       ollama-ai-provider-v2:
         specifier: ^3.0.3
-        version: 3.3.1(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 3.3.1(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       playwright:
         specifier: 1.58.2
         version: 1.58.2
@@ -190,13 +193,13 @@ importers:
         version: 28.0.0
       '@types/node':
         specifier: ^25.3.0
-        version: 25.3.5
+        version: 25.3.0
       '@types/turndown':
         specifier: ^5.0.6
         version: 5.0.6
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       esbuild:
         specifier: ^0.27.3
         version: 0.27.3
@@ -211,19 +214,19 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/extension:
     dependencies:
       '@ai-sdk/google':
         specifier: ^3.0.34
-        version: 3.0.34(zod@4.3.6)
+        version: 3.0.43(zod@4.3.6)
       '@ai-sdk/openai':
         specifier: ^3.0.37
-        version: 3.0.37(zod@4.3.6)
+        version: 3.0.41(zod@4.3.6)
       '@openrouter/ai-sdk-provider':
         specifier: ^2.1.1
-        version: 2.2.3(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 2.2.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.15
         version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -241,13 +244,13 @@ importers:
         version: 1.2.4(@types/react@19.2.14)(react@19.2.4)
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+        version: 4.2.1(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@types/webextension-polyfill':
         specifier: ^0.12.5
         version: 0.12.5
       '@wxt-dev/webextension-polyfill':
         specifier: ^1.0.0
-        version: 1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -262,7 +265,7 @@ importers:
         version: 3.0.2(react@19.2.4)
       ollama-ai-provider-v2:
         specifier: ^3.0.3
-        version: 3.3.1(ai@6.0.105(zod@4.3.6))(zod@4.3.6)
+        version: 3.3.1(ai@6.0.116(zod@4.3.6))(zod@4.3.6)
       pilo-core:
         specifier: workspace:*
         version: link:../core
@@ -320,10 +323,10 @@ importers:
         version: 5.0.6
       '@wxt-dev/module-react':
         specifier: ^1.1.5
-        version: 1.1.5(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(wxt@0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 1.1.5(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(wxt@0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))
       happy-dom:
         specifier: ^20.7.0
-        version: 20.7.0
+        version: 20.8.3
       tw-animate-css:
         specifier: ^1.3.4
         version: 1.4.0
@@ -332,16 +335,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       wxt:
         specifier: 0.20.18
-        version: 0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
+        version: 0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/server:
     dependencies:
       '@hono/node-server':
         specifier: ^1.19.10
-        version: 1.19.10(hono@4.12.7)
+        version: 1.19.11(hono@4.12.7)
       '@hono/sentry':
         specifier: ^1.2.2
         version: 1.2.2(hono@4.12.7)
@@ -357,7 +360,7 @@ importers:
     devDependencies:
       '@types/node':
         specifier: ^25.3.0
-        version: 25.3.5
+        version: 25.3.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -366,7 +369,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
 
@@ -379,26 +382,26 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/anthropic@3.0.50':
-    resolution: {integrity: sha512-BkCUgGTp/iZJuuFBF1wv7GGnrEJg7X7hqbaa+/t4HTBt9dZn3e6NFn5NhPUvo2p5SreUeHEl0As0r2uaVn3K9Q==}
+  '@ai-sdk/anthropic@3.0.58':
+    resolution: {integrity: sha512-/53SACgmVukO4bkms4dpxpRlYhW8Ct6QZRe6sj1Pi5H00hYhxIrqfiLbZBGxkdRvjsBQeP/4TVGsXgH5rQeb8Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.59':
-    resolution: {integrity: sha512-MbtheWHgEFV/8HL1Z6E3hOAsmP73zZlNFg0F0nJAD0Adnjp4J/plqNK00Y896d+dWTw+r0OXzyov9/2wCFjH0Q==}
+  '@ai-sdk/gateway@3.0.66':
+    resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google-vertex@4.0.68':
-    resolution: {integrity: sha512-jzSgEDiq2F+6JrqVQd5XKUJIBrBlgy1ZQXx62gZk3clJTUVj2QW9nPij/i30exeN2RNb+O6b/y+DlJtpHx9nOw==}
+  '@ai-sdk/google-vertex@4.0.80':
+    resolution: {integrity: sha512-CZbiI3AEZQjVYUI2duLFH3ONYkUbsoi0AiTEYNaNKC+ZVnteXwmzJB0W7miaDViV66pWh2VpjNgIJnYXCtNgfw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/google@3.0.34':
-    resolution: {integrity: sha512-1tXUr1W5YACXPgtHYWIU3raqMsayp6cMI8NUT4EEzzZSpvHzkkiNWHEr+bGxEGurSUukfo+pE1RKpLwBFOZtJg==}
+  '@ai-sdk/google@3.0.43':
+    resolution: {integrity: sha512-NGCgP5g8HBxrNdxvF8Dhww+UKfqAkZAmyYBvbu9YLoBkzAmGKDBGhVptN/oXPB5Vm0jggMdoLycZ8JReQM8Zqg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -409,8 +412,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/openai@3.0.37':
-    resolution: {integrity: sha512-bcYjT3/58i/C0DN3AnrjiGsAb0kYivZLWWUtgTjsBurHSht/LTEy+w3dw5XQe3FmZwX7Z/mUQCiA3wB/5Kf7ow==}
+  '@ai-sdk/openai@3.0.41':
+    resolution: {integrity: sha512-IZ42A+FO+vuEQCVNqlnAPYQnnUpUfdJIwn1BEDOBywiEHa23fw7PahxVtlX9zm3/zMvTW4JKPzWyvAgDu+SQ2A==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -423,6 +426,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.16':
     resolution: {integrity: sha512-kBvDqNkt5EwlzF9FujmNhhtl8FYg3e8FO8P5uneKliqfRThWemzBj+wfYr7ZCymAQhTRnwSSz1/SOqhOAwmx9g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.19':
+    resolution: {integrity: sha512-3eG55CrSWCu2SXlqq2QCsFjo3+E7+Gmg7i/oRVoSZzIodTuDSfLb3MRje67xE9RFea73Zao7Lm4mADIfUETKGg==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -788,8 +797,8 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@exodus/bytes@1.15.0':
-    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+  '@exodus/bytes@1.14.1':
+    resolution: {integrity: sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
     peerDependencies:
       '@noble/hashes': ^1.8.0 || ^2.0.0
@@ -843,8 +852,8 @@ packages:
   '@ghostery/url-parser@1.3.1':
     resolution: {integrity: sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==}
 
-  '@hono/node-server@1.19.10':
-    resolution: {integrity: sha512-hZ7nOssGqRgyV3FVVQdfi+U4q02uB23bpnYpdvNXkYTRRyWx84b7yf1ans+dnJ/7h41sGL3CeQTfO+ZGxuO+Iw==}
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
@@ -1581,6 +1590,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@tabstack/sdk@2.2.0':
+    resolution: {integrity: sha512-/0YCjfou0Qtd8hAXQUzlBWPZEeqpo3Ngv4RBJhJPBYmr8PJy31gFWUc1Ly/WsHoFSw6U7GrsSUHC90HWXoJCTg==}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -1742,11 +1754,8 @@ packages:
   '@types/minimatch@3.0.5':
     resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
-  '@types/node@25.3.5':
-    resolution: {integrity: sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==}
-
-  '@types/node@25.4.0':
-    resolution: {integrity: sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw==}
+  '@types/node@25.3.0':
+    resolution: {integrity: sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1891,8 +1900,8 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
-  ai@6.0.105:
-    resolution: {integrity: sha512-rp+exWtZS3J0DDvZIfetpKCIg7D3cCsvBPoFN3I67IDTs9aoBZDbpecoIkmNLT+U9RBkoEial3OGHRvme23HCw==}
+  ai@6.0.116:
+    resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2008,11 +2017,8 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -2123,8 +2129,8 @@ packages:
     resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
     engines: {node: '>=18.20'}
 
-  cli-truncate@5.2.0:
-    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+  cli-truncate@5.1.1:
+    resolution: {integrity: sha512-SroPvNHxUnk+vIW/dOSfNqdy1sPEFkrTk6TUtqLCnBlo3N7TNYYkzzN7uSD6+jVjrdO4+p8nH7JzH6cIvUem6A==}
     engines: {node: '>=20'}
 
   cliui@8.0.1:
@@ -2145,6 +2151,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
   columnify@1.6.0:
     resolution: {integrity: sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q==}
@@ -2214,8 +2223,8 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
-  css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+  css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   css-what@6.2.2:
@@ -2604,10 +2613,6 @@ packages:
     resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
     engines: {node: '>=14.14'}
 
-  fs-extra@11.3.4:
-    resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
-    engines: {node: '>=14.14'}
-
   fsevents@2.3.2:
     resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2684,8 +2689,8 @@ packages:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
-  google-auth-library@10.6.1:
-    resolution: {integrity: sha512-5awwuLrzNol+pFDmKJd0dKtZ0fPLAtoA5p7YO4ODsDu6ONJUVqbYwvv8y2ZBO5MBNp9TJXigB19710kYpBPdtA==}
+  google-auth-library@10.5.0:
+    resolution: {integrity: sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==}
     engines: {node: '>=18'}
 
   google-logging-utils@1.1.3:
@@ -2704,8 +2709,12 @@ packages:
   growly@1.3.0:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
 
-  happy-dom@20.7.0:
-    resolution: {integrity: sha512-hR/uLYQdngTyEfxnOoa+e6KTcfBFyc1hgFj/Cc144A5JJUuHFYqIEBDcD4FeGqUeKLRZqJ9eN9u7/GDjYEgS1g==}
+  gtoken@8.0.0:
+    resolution: {integrity: sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==}
+    engines: {node: '>=18'}
+
+  happy-dom@20.8.3:
+    resolution: {integrity: sha512-lMHQRRwIPyJ70HV0kkFT7jH/gXzSI7yDkQFe07E2flwmNDFoWUTRMKpW2sglsnpeA7b6S2TJPp98EbQxai8eaQ==}
     engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
@@ -3118,9 +3127,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
-  listr2@10.2.1:
-    resolution: {integrity: sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q==}
-    engines: {node: '>=22.13.0'}
+  listr2@10.1.1:
+    resolution: {integrity: sha512-4oogpJzRRGtq41B0GKZIldzYCnQTgX2DPM/XvcfNu7g2E7sxaast009150RKFZBnrHAnfMOUaedIqdIOLCCRxQ==}
+    engines: {node: '>=22.0.0'}
 
   load-tsconfig@0.2.5:
     resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
@@ -3162,9 +3171,9 @@ packages:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
+  log-update@7.1.0:
+    resolution: {integrity: sha512-y9pi/ZOQQVvTgfRDEHV1Cj4zQUkJZPipEUNOxhn1R6KgmdMs7LKvXWCd9eMVPGJgvYzFLCenecWr0Ps8ChVv2A==}
+    engines: {node: '>=20'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3214,8 +3223,8 @@ packages:
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
 
-  mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+  mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
 
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -3233,32 +3242,26 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
-  minimatch@10.2.4:
-    resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
+  minimatch@10.2.3:
+    resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.3:
     resolution: {integrity: sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@9.0.9:
-    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+  minimatch@9.0.7:
+    resolution: {integrity: sha512-MOwgjc8tfrpn5QQEvjijjmDVtMw2oL88ugTevzxQnzRLm6l3fVEF2gzU0kYeYYKD8C66+IdGX6peJ4MyUlUnPg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@7.1.3:
-    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
-
-  mlly@1.8.1:
-    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3513,10 +3516,6 @@ packages:
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3782,10 +3781,6 @@ packages:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
 
-  slice-ansi@8.0.0:
-    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
-    engines: {node: '>=20'}
-
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -3849,10 +3844,6 @@ packages:
 
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
-    engines: {node: '>=12'}
-
-  strip-ansi@7.2.0:
-    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
   strip-bom-buf@2.0.0:
@@ -3953,14 +3944,17 @@ packages:
     resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.23:
+    resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
   tldts-core@7.0.25:
     resolution: {integrity: sha512-ZjCZK0rppSBu7rjHYDYsEaMOIbbT+nWF57hKkv4IUmZWBNrBWBOjIElc0mKRgLM8bm7x/BBlof6t2gi/Oq/Asw==}
 
   tldts-experimental@7.0.25:
     resolution: {integrity: sha512-rFB8lPWHAf4II9+Zdlc6dwcJLIe6sqEzndcjfbcv9PdsFTlNYBgRI4y9aJzo7VMHvg/GRaUlFK+qZUyKpcE6zA==}
 
-  tldts@7.0.25:
-    resolution: {integrity: sha512-keinCnPbwXEUG3ilrWQZU+CqcTTzHq9m2HhoUP2l7Xmi8l1LuijAXLpAJ5zRW+ifKTNscs4NdCkfkDCBYm352w==}
+  tldts@7.0.23:
+    resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
     hasBin: true
 
   tmp@0.2.5:
@@ -4061,8 +4055,8 @@ packages:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
     engines: {node: '>=20.18.1'}
 
-  unimport@5.7.0:
-    resolution: {integrity: sha512-njnL6sp8lEA8QQbZrt+52p/g4X0rw3bnGGmUcJnt1jeG8+iiqO779aGz0PirCtydAIVcuTBRlJ52F0u46z309Q==}
+  unimport@5.6.0:
+    resolution: {integrity: sha512-8rqAmtJV8o60x46kBAJKtHpJDJWkA2xcBqWKPI14MgUb05o1pnpnCnXSxedUXyeq7p8fR5g3pTo2BaswZ9lD9A==}
     engines: {node: '>=18.12.0'}
 
   universalify@2.0.1:
@@ -4263,8 +4257,8 @@ packages:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
     engines: {node: '>=20'}
 
-  whatwg-url@16.0.1:
-    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+  whatwg-url@16.0.0:
+    resolution: {integrity: sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   whatwg-url@5.0.0:
@@ -4427,34 +4421,34 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/anthropic@3.0.50(zod@4.3.6)':
+  '@ai-sdk/anthropic@3.0.58(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/gateway@3.0.59(zod@4.3.6)':
+  '@ai-sdk/gateway@3.0.66(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       '@vercel/oidc': 3.1.0
       zod: 4.3.6
 
-  '@ai-sdk/google-vertex@4.0.68(zod@4.3.6)':
+  '@ai-sdk/google-vertex@4.0.80(zod@4.3.6)':
     dependencies:
-      '@ai-sdk/anthropic': 3.0.50(zod@4.3.6)
-      '@ai-sdk/google': 3.0.34(zod@4.3.6)
+      '@ai-sdk/anthropic': 3.0.58(zod@4.3.6)
+      '@ai-sdk/google': 3.0.43(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
-      google-auth-library: 10.6.1
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
+      google-auth-library: 10.5.0
       zod: 4.3.6
     transitivePeerDependencies:
       - supports-color
 
-  '@ai-sdk/google@3.0.34(zod@4.3.6)':
+  '@ai-sdk/google@3.0.43(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/openai-compatible@2.0.31(zod@4.3.6)':
@@ -4463,10 +4457,10 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
       zod: 4.3.6
 
-  '@ai-sdk/openai@3.0.37(zod@4.3.6)':
+  '@ai-sdk/openai@3.0.41(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.15(zod@4.3.6)':
@@ -4477,6 +4471,13 @@ snapshots:
       zod: 4.3.6
 
   '@ai-sdk/provider-utils@4.0.16(zod@4.3.6)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 4.3.6
+
+  '@ai-sdk/provider-utils@4.0.19(zod@4.3.6)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
@@ -4508,7 +4509,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/nwsapi': 2.3.9
       bidi-js: 1.0.3
-      css-tree: 3.2.1
+      css-tree: 3.1.0
       is-potential-custom-element-name: 1.0.1
       lru-cache: 11.2.6
 
@@ -4634,7 +4635,7 @@ snapshots:
 
   '@bramus/specificity@2.4.2':
     dependencies:
-      css-tree: 3.2.1
+      css-tree: 3.1.0
 
   '@csstools/color-helpers@6.0.2': {}
 
@@ -4763,7 +4764,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 3.1.3
     transitivePeerDependencies:
       - supports-color
 
@@ -4784,7 +4785,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.5
+      minimatch: 3.1.3
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -4798,7 +4799,7 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
-  '@exodus/bytes@1.15.0': {}
+  '@exodus/bytes@1.14.1': {}
 
   '@floating-ui/core@1.7.4':
     dependencies:
@@ -4852,7 +4853,7 @@ snapshots:
     dependencies:
       tldts-experimental: 7.0.25
 
-  '@hono/node-server@1.19.10(hono@4.12.7)':
+  '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
       hono: 4.12.7
 
@@ -4876,7 +4877,7 @@ snapshots:
     dependencies:
       string-width: 5.1.2
       string-width-cjs: string-width@4.2.3
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       strip-ansi-cjs: strip-ansi@6.0.1
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
@@ -4916,9 +4917,9 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
-  '@openrouter/ai-sdk-provider@2.2.3(ai@6.0.105(zod@4.3.6))(zod@4.3.6)':
+  '@openrouter/ai-sdk-provider@2.2.3(ai@6.0.116(zod@4.3.6))(zod@4.3.6)':
     dependencies:
-      ai: 6.0.105(zod@4.3.6)
+      ai: 6.0.116(zod@4.3.6)
       zod: 4.3.6
 
   '@opentelemetry/api@1.9.0': {}
@@ -5454,6 +5455,8 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@tabstack/sdk@2.2.0': {}
+
   '@tailwindcss/node@4.2.1':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -5515,12 +5518,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.1
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5598,7 +5601,7 @@ snapshots:
 
   '@types/jsdom@28.0.0':
     dependencies:
-      '@types/node': 25.3.5
+      '@types/node': 25.3.0
       '@types/tough-cookie': 4.0.5
       parse5: 7.3.0
       undici-types: 7.22.0
@@ -5607,11 +5610,7 @@ snapshots:
 
   '@types/minimatch@3.0.5': {}
 
-  '@types/node@25.3.5':
-    dependencies:
-      undici-types: 7.18.2
-
-  '@types/node@25.4.0':
+  '@types/node@25.3.0':
     dependencies:
       undici-types: 7.18.2
 
@@ -5633,15 +5632,15 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.3.0
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 25.4.0
+      '@types/node': 25.3.0
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.6)
@@ -5649,11 +5648,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -5665,7 +5664,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -5676,21 +5675,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -5729,10 +5720,10 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.1.5(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(wxt@0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@wxt-dev/module-react@1.1.5(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))(wxt@0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@vitejs/plugin-react': 5.1.2(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      wxt: 0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
+      '@vitejs/plugin-react': 5.1.2(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      wxt: 0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
       - vite
@@ -5743,10 +5734,10 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
-  '@wxt-dev/webextension-polyfill@1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@wxt-dev/webextension-polyfill@1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       webextension-polyfill: 0.12.0
-      wxt: 0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
+      wxt: 0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2)
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -5806,11 +5797,11 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai@6.0.105(zod@4.3.6):
+  ai@6.0.116(zod@4.3.6):
     dependencies:
-      '@ai-sdk/gateway': 3.0.59(zod@4.3.6)
+      '@ai-sdk/gateway': 3.0.66(zod@4.3.6)
       '@ai-sdk/provider': 3.0.8
-      '@ai-sdk/provider-utils': 4.0.16(zod@4.3.6)
+      '@ai-sdk/provider-utils': 4.0.19(zod@4.3.6)
       '@opentelemetry/api': 1.9.0
       zod: 4.3.6
 
@@ -5921,11 +5912,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.3:
     dependencies:
       balanced-match: 4.0.4
 
@@ -6023,7 +6010,7 @@ snapshots:
 
   chrome-launcher@1.2.0:
     dependencies:
-      '@types/node': 25.3.5
+      '@types/node': 25.3.0
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -6050,9 +6037,9 @@ snapshots:
 
   cli-spinners@3.4.0: {}
 
-  cli-truncate@5.2.0:
+  cli-truncate@5.1.1:
     dependencies:
-      slice-ansi: 8.0.0
+      slice-ansi: 7.1.2
       string-width: 8.2.0
 
   cliui@8.0.1:
@@ -6070,6 +6057,8 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  colorette@2.0.20: {}
 
   columnify@1.6.0:
     dependencies:
@@ -6141,9 +6130,9 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
-  css-tree@3.2.1:
+  css-tree@3.1.0:
     dependencies:
-      mdn-data: 2.27.1
+      mdn-data: 2.12.2
       source-map-js: 1.2.1
 
   css-what@6.2.2: {}
@@ -6156,7 +6145,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
       '@csstools/css-syntax-patches-for-csstree': 1.1.0
-      css-tree: 3.2.1
+      css-tree: 3.1.0
       lru-cache: 11.2.6
 
   csstype@3.2.3: {}
@@ -6166,7 +6155,7 @@ snapshots:
   data-urls@7.0.0:
     dependencies:
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -6376,7 +6365,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 3.1.3
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -6518,12 +6507,6 @@ snapshots:
       jsonfile: 6.2.0
       universalify: 2.0.1
 
-  fs-extra@11.3.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.2.0
-      universalify: 2.0.1
-
   fsevents@2.3.2:
     optional: true
 
@@ -6595,8 +6578,8 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.9
-      minipass: 7.1.3
+      minimatch: 9.0.7
+      minipass: 7.1.2
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
 
@@ -6606,13 +6589,14 @@ snapshots:
 
   globals@14.0.0: {}
 
-  google-auth-library@10.6.1:
+  google-auth-library@10.5.0:
     dependencies:
       base64-js: 1.5.1
       ecdsa-sig-formatter: 1.0.11
       gaxios: 7.1.3
       gcp-metadata: 8.1.2
       google-logging-utils: 1.1.3
+      gtoken: 8.0.0
       jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
@@ -6627,9 +6611,16 @@ snapshots:
 
   growly@1.3.0: {}
 
-  happy-dom@20.7.0:
+  gtoken@8.0.0:
     dependencies:
-      '@types/node': 25.4.0
+      gaxios: 7.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  happy-dom@20.8.3:
+    dependencies:
+      '@types/node': 25.3.0
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       entities: 7.0.1
@@ -6647,7 +6638,7 @@ snapshots:
 
   html-encoding-sniffer@6.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.14.1
     transitivePeerDependencies:
       - '@noble/hashes'
 
@@ -6820,7 +6811,7 @@ snapshots:
       '@acemir/cssom': 0.9.31
       '@asamuzakjp/dom-selector': 6.8.1
       '@bramus/specificity': 2.4.2
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.14.1
       cssstyle: 6.2.0
       data-urls: 7.0.0
       decimal.js: 10.6.0
@@ -6836,7 +6827,7 @@ snapshots:
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
-      whatwg-url: 16.0.1
+      whatwg-url: 16.0.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - '@noble/hashes'
@@ -6998,11 +6989,12 @@ snapshots:
     dependencies:
       commander: 10.0.1
 
-  listr2@10.2.1:
+  listr2@10.1.1:
     dependencies:
-      cli-truncate: 5.2.0
+      cli-truncate: 5.1.1
+      colorette: 2.0.20
       eventemitter3: 5.0.4
-      log-update: 6.1.0
+      log-update: 7.1.0
       rfdc: 1.4.1
       wrap-ansi: 10.0.0
 
@@ -7010,7 +7002,7 @@ snapshots:
 
   local-pkg@1.1.2:
     dependencies:
-      mlly: 1.8.1
+      mlly: 1.8.0
       pkg-types: 2.3.0
       quansync: 0.2.11
 
@@ -7039,12 +7031,12 @@ snapshots:
       is-unicode-supported: 2.1.0
       yoctocolors: 2.1.2
 
-  log-update@6.1.0:
+  log-update@7.1.0:
     dependencies:
       ansi-escapes: 7.3.0
       cli-cursor: 5.0.0
       slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
   lru-cache@10.4.3: {}
@@ -7088,7 +7080,7 @@ snapshots:
 
   marky@1.3.0: {}
 
-  mdn-data@2.27.1: {}
+  mdn-data@2.12.2: {}
 
   merge2@1.4.1: {}
 
@@ -7101,34 +7093,23 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.4:
+  minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.3
 
   minimatch@3.1.3:
     dependencies:
       brace-expansion: 1.1.12
 
-  minimatch@3.1.5:
+  minimatch@9.0.7:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@9.0.9:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.3
 
   minimist@1.2.8: {}
 
-  minipass@7.1.3: {}
+  minipass@7.1.2: {}
 
   mlly@1.8.0:
-    dependencies:
-      acorn: 8.16.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.3
-
-  mlly@1.8.1:
     dependencies:
       acorn: 8.16.0
       pathe: 2.0.3
@@ -7209,11 +7190,11 @@ snapshots:
 
   ohash@2.0.11: {}
 
-  ollama-ai-provider-v2@3.3.1(ai@6.0.105(zod@4.3.6))(zod@4.3.6):
+  ollama-ai-provider-v2@3.3.1(ai@6.0.116(zod@4.3.6))(zod@4.3.6):
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@ai-sdk/provider-utils': 4.0.15(zod@4.3.6)
-      ai: 6.0.105(zod@4.3.6)
+      ai: 6.0.116(zod@4.3.6)
       zod: 4.3.6
 
   on-exit-leak-free@2.1.2: {}
@@ -7320,7 +7301,7 @@ snapshots:
   path-scurry@1.11.1:
     dependencies:
       lru-cache: 10.4.3
-      minipass: 7.1.3
+      minipass: 7.1.2
 
   pathe@2.0.3: {}
 
@@ -7391,7 +7372,7 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.1
+      mlly: 1.8.0
       pathe: 2.0.3
 
   pkg-types@2.3.0:
@@ -7408,12 +7389,12 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.8
+      postcss: 8.5.6
       tsx: 4.21.0
       yaml: 2.8.2
 
@@ -7422,13 +7403,6 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-
-  postcss@8.5.8:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-    optional: true
 
   powershell-utils@0.1.0: {}
 
@@ -7465,7 +7439,7 @@ snapshots:
       form-data-encoder: 4.1.0
       formdata-node: 6.0.3
       jsonwebtoken: 9.0.3
-      listr2: 10.2.1
+      listr2: 10.1.1
       ofetch: 1.5.1
       zod: 4.3.6
 
@@ -7704,11 +7678,6 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -7751,7 +7720,7 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   string-width@7.2.0:
     dependencies:
@@ -7762,7 +7731,7 @@ snapshots:
   string-width@8.2.0:
     dependencies:
       get-east-asian-width: 1.5.0
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   string_decoder@1.1.1:
     dependencies:
@@ -7773,10 +7742,6 @@ snapshots:
       ansi-regex: 5.0.1
 
   strip-ansi@7.1.2:
-    dependencies:
-      ansi-regex: 6.2.2
-
-  strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
 
@@ -7866,15 +7831,17 @@ snapshots:
 
   tinyrainbow@3.0.3: {}
 
+  tldts-core@7.0.23: {}
+
   tldts-core@7.0.25: {}
 
   tldts-experimental@7.0.25:
     dependencies:
       tldts-core: 7.0.25
 
-  tldts@7.0.25:
+  tldts@7.0.23:
     dependencies:
-      tldts-core: 7.0.25
+      tldts-core: 7.0.23
 
   tmp@0.2.5: {}
 
@@ -7890,7 +7857,7 @@ snapshots:
 
   tough-cookie@6.0.0:
     dependencies:
-      tldts: 7.0.25
+      tldts: 7.0.23
 
   tr46@0.0.3: {}
 
@@ -7904,7 +7871,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -7915,7 +7882,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -7924,7 +7891,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      postcss: 8.5.8
+      postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -7967,14 +7934,14 @@ snapshots:
 
   undici@7.22.0: {}
 
-  unimport@5.7.0:
+  unimport@5.6.0:
     dependencies:
       acorn: 8.16.0
       escape-string-regexp: 5.0.0
       estree-walker: 3.0.3
       local-pkg: 1.1.2
       magic-string: 0.30.21
-      mlly: 1.8.1
+      mlly: 1.8.0
       pathe: 2.0.3
       picomatch: 4.0.3
       pkg-types: 2.3.0
@@ -8047,13 +8014,13 @@ snapshots:
 
   uuid@8.3.2: {}
 
-  vite-node@5.3.0(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite-node@5.3.0(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       es-module-lexer: 2.0.0
       obug: 2.1.1
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8067,7 +8034,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+  vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8076,33 +8043,17 @@ snapshots:
       rollup: 4.57.1
       tinyglobby: 0.2.15
     optionalDependencies:
-      '@types/node': 25.3.5
+      '@types/node': 25.3.0
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.31.1
       tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      esbuild: 0.27.3
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.57.1
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 25.4.0
-      fsevents: 2.3.3
-      jiti: 2.6.1
-      lightningcss: 1.31.1
-      tsx: 4.21.0
-      yaml: 2.8.2
-
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.5)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.3.0)(happy-dom@20.8.3)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -8119,52 +8070,12 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
-      '@types/node': 25.3.5
-      happy-dom: 20.7.0
-      jsdom: 28.1.0
-    transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
-
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@25.4.0)(happy-dom@20.7.0)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2):
-    dependencies:
-      '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2))
-      '@vitest/pretty-format': 4.0.18
-      '@vitest/runner': 4.0.18
-      '@vitest/snapshot': 4.0.18
-      '@vitest/spy': 4.0.18
-      '@vitest/utils': 4.0.18
-      es-module-lexer: 1.7.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.3
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 25.4.0
-      happy-dom: 20.7.0
+      '@types/node': 25.3.0
+      happy-dom: 20.8.3
       jsdom: 28.1.0
     transitivePeerDependencies:
       - jiti
@@ -8279,9 +8190,9 @@ snapshots:
 
   whatwg-mimetype@5.0.0: {}
 
-  whatwg-url@16.0.1:
+  whatwg-url@16.0.0:
     dependencies:
-      '@exodus/bytes': 1.15.0
+      '@exodus/bytes': 1.14.1
       tr46: 6.0.0
       webidl-conversions: 8.0.1
     transitivePeerDependencies:
@@ -8322,7 +8233,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 8.2.0
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -8334,7 +8245,7 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.2.0
+      strip-ansi: 7.1.2
 
   wrap-ansi@9.0.2:
     dependencies:
@@ -8349,7 +8260,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.18(@types/node@25.4.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2):
+  wxt@0.20.18(@types/node@25.3.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@1natsu/wait-element': 4.1.2
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.59.0)
@@ -8370,7 +8281,7 @@ snapshots:
       esbuild: 0.27.3
       fast-glob: 3.3.3
       filesize: 11.0.13
-      fs-extra: 11.3.4
+      fs-extra: 11.3.3
       get-port-please: 3.2.0
       giget: 3.1.2
       hookable: 6.0.1
@@ -8380,7 +8291,7 @@ snapshots:
       jszip: 3.10.1
       linkedom: 0.18.12
       magicast: 0.5.2
-      minimatch: 10.2.4
+      minimatch: 10.2.3
       nano-spawn: 2.0.0
       normalize-path: 3.0.0
       nypm: 0.6.5
@@ -8392,9 +8303,9 @@ snapshots:
       prompts: 2.4.2
       publish-browser-extension: 4.0.4
       scule: 1.3.0
-      unimport: 5.7.0
-      vite: 7.3.1(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 5.3.0(@types/node@25.4.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      unimport: 5.6.0
+      vite: 7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 5.3.0(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.2)
       web-ext-run: 0.2.4
     optionalDependencies:
       eslint: 9.39.2(jiti@2.6.1)


### PR DESCRIPTION
Add three new tools that leverage the Tabstack API when a TABSTACK_API_KEY is configured:

- tabstack_extract_markdown: extract clean markdown from web pages and PDFs (especially useful for PDFs which browsers can't read)
- tabstack_extract_json: extract structured data per a JSON Schema
- tabstack_generate_json: AI-transform page content via instructions

Tools are conditionally available (same pattern as search tools) and use the @tabstack/sdk TypeScript client.

## Description

<!-- What does this PR do? -->

## PR Type

<!-- Delete the types that don't apply -->

- New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`)
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

<!-- We welcome the use of AI to aid in contribution! Please indicate your AI usage below. -->

- [x] AI was used for drafting/refactoring

<!-- Optional: What LLM and tooling did you use? (e.g., Claude with Claude Code, GPT-4 with Copilot) -->
