### PR TITLE
Gate GAR image push on Build & Test workflow success

### DIFF
--- a/.github/workflows/gar_image_push.yml
+++ b/.github/workflows/gar_image_push.yml
@@ -7,11 +7,14 @@ env:
   GAR_REPOSITORY: tabs-prod
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Build & Test"]
+    types: [completed]
     branches: [main]
 
 jobs:
   build:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     permissions:
       contents: read
       deployments: write


### PR DESCRIPTION
## Summary
- Changed the GAR image push workflow trigger from `on: push` to `on: workflow_run`, making it dependent on the "Build & Test" workflow completing on `main`
- Added a guard condition (`workflow_run.conclusion == 'success'`) so the image is only built and pushed when Build & Test passes

## Test plan
- [ ] Verify the image push workflow triggers after a successful Build & Test run on `main`
- [ ] Verify the image push workflow is skipped when Build & Test fails