### PR TITLE
fix: align package.json license fields with Apache-2.0 LICENSE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "cli"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "dependencies": {
     "@ai-sdk/google": "^3.0.30",
     "@ai-sdk/google-vertex": "^4.0.61",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -21,7 +21,7 @@
     "pilo"
   ],
   "author": "",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@types/node": "^25.3.0",
     "tsx": "^4.21.0",


### PR DESCRIPTION
## Summary

- The repository `LICENSE` file declares Apache-2.0 (copyright 2026 Mozilla Corporation)
- The root `package.json` and `packages/server/package.json` both declared `"license": "MIT"`
- This mismatch can block downstream adoption, especially for enterprises with automated compliance gates

This PR updates both `package.json` files to `"license": "Apache-2.0"` to match the LICENSE file.

## Test plan

- [ ] Verify `package.json` license field reads `"Apache-2.0"`
- [ ] Verify `packages/server/package.json` license field reads `"Apache-2.0"`
- [ ] No functional code changes — metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)