### PR TITLE
feat: add OpenTelemetry tracing with context propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ coverage
 
 # Auto-generated files
 packages/core/src/browser/ariaTree/bundle.ts
+
+# Worktrees
+.worktrees

--- a/docs/opentelemetry.md
+++ b/docs/opentelemetry.md
@@ -1,0 +1,151 @@
+# OpenTelemetry Support
+
+Pilo has built-in OpenTelemetry (OTel) support for distributed tracing. Telemetry is opt-in and zero-overhead when disabled — if the `@opentelemetry/api` package is not installed or no exporter endpoint is configured, all instrumentation becomes no-op.
+
+## Quick Start
+
+### 1. Install OTel dependencies
+
+The `pilo-core` package declares `@opentelemetry/api` as an **optional peer dependency**. To enable telemetry, install it along with an SDK and exporters:
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-node \
+  @opentelemetry/exporter-trace-otlp-proto \
+  @opentelemetry/resources @opentelemetry/semantic-conventions
+```
+
+### 2. Set environment variables
+
+| Variable                      | Required          | Default | Description                                            |
+| ----------------------------- | ----------------- | ------- | ------------------------------------------------------ |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Yes (to activate) | —       | OTLP collector endpoint (e.g. `http://localhost:4318`) |
+| `OTEL_SERVICE_NAME`           | No                | `pilo`  | Service name in traces                                 |
+
+If `OTEL_EXPORTER_OTLP_ENDPOINT` is not set, telemetry is completely disabled.
+
+### 3. Initialize the SDK (server usage)
+
+If you are using `pilo-server`, telemetry is initialized automatically at startup — no code changes needed. Just set the environment variables above.
+
+For custom Node.js applications, initialize the SDK **before** importing Pilo:
+
+```typescript
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+const sdk = new NodeSDK({
+  resource: resourceFromAttributes({
+    [ATTR_SERVICE_NAME]: "my-pilo-app",
+  }),
+  traceExporter: new OTLPTraceExporter(),
+});
+
+sdk.start();
+
+// Now import and use Pilo — spans will be collected
+import { WebAgent, PlaywrightBrowser } from "@tabstack/pilo";
+```
+
+## What Gets Instrumented
+
+### Traces (Spans)
+
+All spans use the `pilo-core` tracer and form a connected hierarchy via automatic context propagation:
+
+```
+pilo.task.execute (root)
+├── pilo.task.plan
+│   └── pilo.ai.generate
+├── pilo.browser.navigate
+├── pilo.agent.step (per iteration)
+│   ├── pilo.browser.snapshot
+│   ├── pilo.ai.generate
+│   │   ├── pilo.browser.action
+│   │   │   └── pilo.browser.perform
+│   │   └── pilo.search.execute
+│   └── pilo.task.validate
+│       └── pilo.ai.generate
+└── pilo.browser.reconnect (on error recovery)
+```
+
+| Span Name                 | Location          | Key Attributes                                                                               |
+| ------------------------- | ----------------- | -------------------------------------------------------------------------------------------- |
+| `pilo.task.execute`       | WebAgent          | `pilo.task`, `pilo.url`, `pilo.task.success`                                                 |
+| `pilo.task.plan`          | WebAgent          | `pilo.task`, `pilo.url`, `pilo.plan.has_url`                                                 |
+| `pilo.agent.step`         | WebAgent          | `pilo.step.number`, `pilo.step.iteration_id`                                                 |
+| `pilo.ai.generate`        | WebAgent / retry  | `pilo.ai.finish_reason`, `pilo.ai.attempts`, `pilo.ai.input_tokens`, `pilo.ai.output_tokens` |
+| `pilo.task.validate`      | WebAgent          | `pilo.validation.attempt`, `pilo.validation.quality`, `pilo.validation.accepted`             |
+| `pilo.browser.reconnect`  | WebAgent          | `pilo.cdp.endpoint_index`, `pilo.cdp.total`                                                  |
+| `pilo.browser.action`     | webActionTools    | `pilo.browser.action_type`, `pilo.browser.element_ref`, `pilo.browser.success`               |
+| `pilo.browser.perform`    | PlaywrightBrowser | `pilo.browser.action_type`, `pilo.browser.element_ref`                                       |
+| `pilo.browser.navigate`   | PlaywrightBrowser | `pilo.browser.url`                                                                           |
+| `pilo.browser.screenshot` | PlaywrightBrowser | —                                                                                            |
+| `pilo.browser.snapshot`   | PlaywrightBrowser | —                                                                                            |
+| `pilo.search.execute`     | searchTools       | `pilo.search.query`, `pilo.search.success`                                                   |
+
+Error handling: all spans call `span.setStatus(ERROR)` and `span.recordException()` for non-recoverable errors. Recoverable errors (e.g., browser element not found, search failures) are recorded for observability but do not set the span status to ERROR, since the LLM handles retries.
+
+### Distributed Tracing
+
+When pilo-server receives requests with W3C Trace Context headers (`traceparent`, `tracestate`), it automatically joins the caller's trace. This enables end-to-end tracing across services — e.g., an upstream API server → pilo-server → browser operations all appear as one connected trace.
+
+## Local Development with Jaeger
+
+[Jaeger](https://www.jaegertracing.io/) is an open-source tracing backend that works well for local development.
+
+### docker-compose.yml
+
+```yaml
+services:
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686" # Jaeger UI
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+```
+
+```bash
+docker compose up -d
+```
+
+Then run Pilo with:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 pnpm run dev:server
+```
+
+Open http://localhost:16686 to view traces in the Jaeger UI.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────┐
+│  pilo-core                                          │
+│                                                     │
+│  WebAgent / Browser / Tools                         │
+│    │                                                │
+│    └── withSpan() ──► spans (trace API)             │
+│          ├── automatic parent-child context          │
+│          └── no-op if @opentelemetry/api missing    │
+│                                                     │
+│  @opentelemetry/api is an optional peer dep         │
+└─────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────┐
+│  pilo-server                                        │
+│                                                     │
+│  initTelemetry()                                    │
+│    └── NodeSDK + OTLP trace exporter                │
+│         (activates only if OTEL_EXPORTER_OTLP_      │
+│          ENDPOINT is set)                           │
+│                                                     │
+│  withRemoteContext()                                │
+│    └── Extracts W3C traceparent from incoming       │
+│         requests for distributed tracing            │
+└─────────────────────────────────────────────────────┘
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,16 @@
     "turndown": "^7.2.2",
     "zod": "^4.3.6"
   },
+  "peerDependencies": {
+    "@opentelemetry/api": "^1.9.0"
+  },
+  "peerDependenciesMeta": {
+    "@opentelemetry/api": {
+      "optional": true
+    }
+  },
   "devDependencies": {
+    "@opentelemetry/api": "^1.9.0",
     "@types/jsdom": "^28.0.0",
     "@types/node": "^25.5.0",
     "@types/turndown": "^5.0.6",

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -26,7 +26,7 @@ import { NavigationRetryConfig, calculateTimeout } from "./navigationRetry.js";
 import { getConfigDefaults } from "../config/defaults.js";
 import { createNavigationRetryConfig } from "../utils/configMerge.js";
 import { ARIA_TREE_SCRIPT } from "./ariaTree/bundle.js";
-import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
+import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
 
 export interface PlaywrightBrowserOptions {
   /** Browser type to use (defaults to 'firefox') */
@@ -340,7 +340,7 @@ export class PlaywrightBrowser implements AriaBrowser {
   async goto(url: string): Promise<void> {
     if (!this.page) throw new Error("Browser not started");
     return withSpan(
-      "pilo.browser.navigate",
+      SpanName.BROWSER_NAVIGATE,
       { attributes: { "pilo.browser.url": url } },
       async (span) => {
         try {
@@ -570,7 +570,7 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   async getTreeWithRefs(): Promise<string> {
     if (!this.page) throw new Error("Browser not started");
-    return withSpan("pilo.browser.snapshot", {}, async (span) => {
+    return withSpan(SpanName.BROWSER_SNAPSHOT, {}, async (span) => {
       try {
         return await this.getTreeWithRefsImpl();
       } catch (error) {
@@ -697,7 +697,7 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   async getScreenshot(options?: { withMarks?: boolean }): Promise<Buffer> {
     if (!this.page) throw new Error("Browser not started");
-    return withSpan("pilo.browser.screenshot", {}, async (span) => {
+    return withSpan(SpanName.BROWSER_SCREENSHOT, {}, async (span) => {
       try {
         // Apply SoM overlay before screenshot if requested.
         // Failures are non-fatal — a plain screenshot is still useful.
@@ -786,7 +786,7 @@ export class PlaywrightBrowser implements AriaBrowser {
   async performAction(ref: string, action: PageAction, value?: string): Promise<void> {
     if (!this.page) throw new Error("Browser not started");
     return withSpan(
-      "pilo.browser.perform",
+      SpanName.BROWSER_PERFORM,
       {
         attributes: {
           "pilo.browser.action_type": String(action),

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -26,6 +26,7 @@ import { NavigationRetryConfig, calculateTimeout } from "./navigationRetry.js";
 import { getConfigDefaults } from "../config/defaults.js";
 import { createNavigationRetryConfig } from "../utils/configMerge.js";
 import { ARIA_TREE_SCRIPT } from "./ariaTree/bundle.js";
+import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
 
 export interface PlaywrightBrowserOptions {
   /** Browser type to use (defaults to 'firefox') */
@@ -338,7 +339,25 @@ export class PlaywrightBrowser implements AriaBrowser {
    */
   async goto(url: string): Promise<void> {
     if (!this.page) throw new Error("Browser not started");
-    await this.executeNavigationWithRetry((timeoutMs) => this.performGoto(url, timeoutMs), url);
+    return withSpan(
+      "pilo.browser.navigate",
+      { attributes: { "pilo.browser.url": url } },
+      async (span) => {
+        try {
+          await this.executeNavigationWithRetry(
+            (timeoutMs) => this.performGoto(url, timeoutMs),
+            url,
+          );
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+        }
+      },
+    );
   }
 
   /**
@@ -551,15 +570,24 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   async getTreeWithRefs(): Promise<string> {
     if (!this.page) throw new Error("Browser not started");
-
-    try {
-      return await this.getTreeWithRefsImpl();
-    } catch (error) {
-      if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
-        throw new BrowserDisconnectedError(error.message);
+    return withSpan("pilo.browser.snapshot", {}, async (span) => {
+      try {
+        return await this.getTreeWithRefsImpl();
+      } catch (error) {
+        if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
+          const disconnectError = new BrowserDisconnectedError(error.message);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+          span.recordException(disconnectError);
+          throw disconnectError;
+        }
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        throw error;
       }
-      throw error;
-    }
+    });
   }
 
   private async getTreeWithRefsImpl(): Promise<string> {
@@ -669,44 +697,54 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   async getScreenshot(options?: { withMarks?: boolean }): Promise<Buffer> {
     if (!this.page) throw new Error("Browser not started");
-
-    // Apply SoM overlay before screenshot if requested.
-    // Failures are non-fatal — a plain screenshot is still useful.
-    if (options?.withMarks) {
+    return withSpan("pilo.browser.screenshot", {}, async (span) => {
       try {
-        await this.page.evaluate(() => {
-          const win = window as any;
-          win.__piloAriaTree?.applySetOfMarks?.();
-        });
-      } catch {
-        // Can fail if page navigated or ariaTree bundle wasn't injected yet
-      }
-    }
-
-    try {
-      return await this.page.screenshot({
-        fullPage: true,
-        type: "jpeg",
-        quality: 80,
-        scale: "css",
-      });
-    } catch (error) {
-      if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
-        throw new BrowserDisconnectedError(error.message);
-      }
-      throw error;
-    } finally {
-      if (options?.withMarks) {
-        try {
-          await this.page.evaluate(() => {
-            const win = window as any;
-            win.__piloAriaTree?.removeSetOfMarks?.();
-          });
-        } catch {
-          // Page may have navigated between screenshot and cleanup
+        // Apply SoM overlay before screenshot if requested.
+        // Failures are non-fatal — a plain screenshot is still useful.
+        if (options?.withMarks) {
+          try {
+            await this.page!.evaluate(() => {
+              const win = window as any;
+              win.__piloAriaTree?.applySetOfMarks?.();
+            });
+          } catch {
+            // Can fail if page navigated or ariaTree bundle wasn't injected yet
+          }
         }
+
+        try {
+          return await this.page!.screenshot({
+            fullPage: true,
+            type: "jpeg",
+            quality: 80,
+            scale: "css",
+          });
+        } catch (error) {
+          if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
+            throw new BrowserDisconnectedError(error.message);
+          }
+          throw error;
+        } finally {
+          if (options?.withMarks) {
+            try {
+              await this.page!.evaluate(() => {
+                const win = window as any;
+                win.__piloAriaTree?.removeSetOfMarks?.();
+              });
+            } catch {
+              // Page may have navigated between screenshot and cleanup
+            }
+          }
+        }
+      } catch (error) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        throw error;
       }
-    }
+    });
   }
 
   async waitForLoadState(state: LoadState, options?: { timeout?: number }): Promise<void> {
@@ -747,133 +785,155 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   async performAction(ref: string, action: PageAction, value?: string): Promise<void> {
     if (!this.page) throw new Error("Browser not started");
+    return withSpan(
+      "pilo.browser.perform",
+      {
+        attributes: {
+          "pilo.browser.action_type": String(action),
+          ...(ref && { "pilo.browser.element_ref": ref }),
+        },
+      },
+      async (span) => {
+        try {
+          try {
+            // Always validate ref for any action that uses it
+            // This ensures consistent error messages and early validation
+            let locator: Locator | null = null;
 
-    try {
-      // Always validate ref for any action that uses it
-      // This ensures consistent error messages and early validation
-      let locator: Locator | null = null;
+            // Check if this action requires an element ref
+            const requiresElement = this.actionRequiresElement(action);
 
-      // Check if this action requires an element ref
-      const requiresElement = this.actionRequiresElement(action);
+            if (requiresElement) {
+              // Validate and get the locator
+              locator = await this.validateElementRef(ref);
+              // Scroll element into view so developers can follow along in headed mode
+              await locator.scrollIntoViewIfNeeded({ timeout: this.actionTimeoutMs });
+            }
 
-      if (requiresElement) {
-        // Validate and get the locator
-        locator = await this.validateElementRef(ref);
-        // Scroll element into view so developers can follow along in headed mode
-        await locator.scrollIntoViewIfNeeded({ timeout: this.actionTimeoutMs });
-      }
+            switch (action) {
+              // Element interactions
+              case PageAction.Click:
+                await locator!.click({ timeout: this.actionTimeoutMs });
+                // Ensure page is usable after click that may cause navigation
+                await this.ensureOptimizedPageLoad();
+                break;
 
-      switch (action) {
-        // Element interactions
-        case PageAction.Click:
-          await locator!.click({ timeout: this.actionTimeoutMs });
-          // Ensure page is usable after click that may cause navigation
-          await this.ensureOptimizedPageLoad();
-          break;
+              case PageAction.Hover:
+                await locator!.hover({ timeout: this.actionTimeoutMs });
+                break;
 
-        case PageAction.Hover:
-          await locator!.hover({ timeout: this.actionTimeoutMs });
-          break;
+              case PageAction.Fill:
+                if (!value)
+                  throw new BrowserActionException("fill", "Value required for fill action");
+                await locator!.fill(value, { timeout: this.actionTimeoutMs });
+                break;
 
-        case PageAction.Fill:
-          if (!value) throw new BrowserActionException("fill", "Value required for fill action");
-          await locator!.fill(value, { timeout: this.actionTimeoutMs });
-          break;
+              case PageAction.Focus:
+                await locator!.focus({ timeout: this.actionTimeoutMs });
+                break;
 
-        case PageAction.Focus:
-          await locator!.focus({ timeout: this.actionTimeoutMs });
-          break;
+              case PageAction.Check:
+                await locator!.check({ timeout: this.actionTimeoutMs });
+                break;
 
-        case PageAction.Check:
-          await locator!.check({ timeout: this.actionTimeoutMs });
-          break;
+              case PageAction.Uncheck:
+                await locator!.uncheck({ timeout: this.actionTimeoutMs });
+                break;
 
-        case PageAction.Uncheck:
-          await locator!.uncheck({ timeout: this.actionTimeoutMs });
-          break;
+              case PageAction.Select:
+                if (!value)
+                  throw new BrowserActionException("select", "Value required for select action");
+                await locator!.selectOption(value, {
+                  timeout: this.actionTimeoutMs,
+                });
+                // Forms might trigger page reloads on select
+                await this.ensureOptimizedPageLoad();
+                break;
 
-        case PageAction.Select:
-          if (!value)
-            throw new BrowserActionException("select", "Value required for select action");
-          await locator!.selectOption(value, {
-            timeout: this.actionTimeoutMs,
-          });
-          // Forms might trigger page reloads on select
-          await this.ensureOptimizedPageLoad();
-          break;
+              case PageAction.Enter:
+                await locator!.press("Enter", { timeout: this.actionTimeoutMs });
+                // Forms might trigger page reloads on enter
+                await this.ensureOptimizedPageLoad();
+                break;
 
-        case PageAction.Enter:
-          await locator!.press("Enter", { timeout: this.actionTimeoutMs });
-          // Forms might trigger page reloads on enter
-          await this.ensureOptimizedPageLoad();
-          break;
+              // Navigation and workflow (these don't need element refs)
+              case PageAction.Wait:
+                if (!value)
+                  throw new BrowserActionException("wait", "Value required for wait action");
+                const seconds = parseInt(value, 10);
+                if (isNaN(seconds) || seconds < 0) {
+                  throw new BrowserActionException(
+                    "wait",
+                    `Invalid wait time: ${value}. Must be a positive number.`,
+                  );
+                }
+                await this.page!.waitForTimeout(seconds * 1000);
+                break;
 
-        // Navigation and workflow (these don't need element refs)
-        case PageAction.Wait:
-          if (!value) throw new BrowserActionException("wait", "Value required for wait action");
-          const seconds = parseInt(value, 10);
-          if (isNaN(seconds) || seconds < 0) {
+              case PageAction.Goto:
+                if (!value)
+                  throw new BrowserActionException("goto", "URL required for goto action");
+                if (!value.trim()) throw new BrowserActionException("goto", "URL cannot be empty");
+                await this.goto(value.trim());
+                // Note: goto already calls ensureOptimizedPageLoad internally
+                break;
+
+              case PageAction.Back:
+                await this.goBack();
+                // Note: goBack already calls ensureOptimizedPageLoad internally
+                break;
+
+              case PageAction.Forward:
+                await this.goForward();
+                // Note: goForward already calls ensureOptimizedPageLoad internally
+                break;
+
+              case PageAction.Extract:
+                // Extract is handled at a higher level in the automation flow
+                // The browser implementation doesn't need to do anything
+                break;
+
+              case PageAction.Abort:
+                // Abort is handled at a higher level in the automation flow
+                // The browser implementation doesn't need to do anything
+                break;
+
+              case PageAction.Done:
+                // This is a no-op in the browser implementation
+                // It's handled at a higher level in the automation flow
+                break;
+
+              default:
+                throw new BrowserActionException(String(action), `Unsupported action: ${action}`);
+            }
+          } catch (error) {
+            // Re-throw browser exceptions as-is
+            if (error instanceof InvalidRefException || error instanceof BrowserActionException) {
+              throw error;
+            }
+
+            // Surface browser disconnects distinctly so WebAgent can trigger a restart
+            if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
+              throw new BrowserDisconnectedError(error.message);
+            }
+
+            // Wrap other errors
             throw new BrowserActionException(
-              "wait",
-              `Invalid wait time: ${value}. Must be a positive number.`,
+              String(action),
+              `Failed to perform action: ${error instanceof Error ? error.message : String(error)}`,
+              { originalError: error },
             );
           }
-          await this.page.waitForTimeout(seconds * 1000);
-          break;
-
-        case PageAction.Goto:
-          if (!value) throw new BrowserActionException("goto", "URL required for goto action");
-          if (!value.trim()) throw new BrowserActionException("goto", "URL cannot be empty");
-          await this.goto(value.trim());
-          // Note: goto already calls ensureOptimizedPageLoad internally
-          break;
-
-        case PageAction.Back:
-          await this.goBack();
-          // Note: goBack already calls ensureOptimizedPageLoad internally
-          break;
-
-        case PageAction.Forward:
-          await this.goForward();
-          // Note: goForward already calls ensureOptimizedPageLoad internally
-          break;
-
-        case PageAction.Extract:
-          // Extract is handled at a higher level in the automation flow
-          // The browser implementation doesn't need to do anything
-          break;
-
-        case PageAction.Abort:
-          // Abort is handled at a higher level in the automation flow
-          // The browser implementation doesn't need to do anything
-          break;
-
-        case PageAction.Done:
-          // This is a no-op in the browser implementation
-          // It's handled at a higher level in the automation flow
-          break;
-
-        default:
-          throw new BrowserActionException(String(action), `Unsupported action: ${action}`);
-      }
-    } catch (error) {
-      // Re-throw browser exceptions as-is
-      if (error instanceof InvalidRefException || error instanceof BrowserActionException) {
-        throw error;
-      }
-
-      // Surface browser disconnects distinctly so WebAgent can trigger a restart
-      if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
-        throw new BrowserDisconnectedError(error.message);
-      }
-
-      // Wrap other errors
-      throw new BrowserActionException(
-        String(action),
-        `Failed to perform action: ${error instanceof Error ? error.message : String(error)}`,
-        { originalError: error },
-      );
-    }
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+        }
+      },
+    );
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export {
   getTracer,
   getOTelApi,
   SpanStatusCode,
+  SpanName,
   withSpan,
   withRemoteContext,
 } from "./telemetry/tracing.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,6 +20,15 @@ export { ChalkConsoleLogger } from "./loggers/chalkConsole.js";
 export { MetricsCollector } from "./loggers/metricsCollector.js";
 export { SecretsRedactor } from "./loggers/secretsRedactor.js";
 
+// Telemetry
+export {
+  getTracer,
+  getOTelApi,
+  SpanStatusCode,
+  withSpan,
+  withRemoteContext,
+} from "./telemetry/tracing.js";
+
 // Configuration and Provider System
 export {
   config,

--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -30,6 +30,25 @@ export const SpanStatusCode = {
   ERROR: 2,
 } as const;
 
+/**
+ * Span name constants for all instrumented operations.
+ * Use these with `withSpan` to ensure consistent, typo-free span names.
+ */
+export const SpanName = {
+  TASK_EXECUTE: "pilo.task.execute",
+  TASK_PLAN: "pilo.task.plan",
+  TASK_VALIDATE: "pilo.task.validate",
+  AGENT_STEP: "pilo.agent.step",
+  AI_GENERATE: "pilo.ai.generate",
+  BROWSER_NAVIGATE: "pilo.browser.navigate",
+  BROWSER_SNAPSHOT: "pilo.browser.snapshot",
+  BROWSER_SCREENSHOT: "pilo.browser.screenshot",
+  BROWSER_PERFORM: "pilo.browser.perform",
+  BROWSER_ACTION: "pilo.browser.action",
+  BROWSER_RECONNECT: "pilo.browser.reconnect",
+  SEARCH_EXECUTE: "pilo.search.execute",
+} as const;
+
 // --- Internal cache ---
 
 type OTelApiModule = typeof import("@opentelemetry/api");

--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -120,7 +120,16 @@ export async function getTracer(name = "pilo-core", version?: string): Promise<T
  * When @opentelemetry/api is not installed or the headers are empty,
  * the function runs directly with zero overhead.
  */
-export async function withRemoteContext<T>(
+export function withRemoteContext<T>(
+  headers: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  // Synchronous fast-path: if already resolved to null, skip async entirely
+  if (resolvedApi === null) return fn();
+  return withRemoteContextAsync(headers, fn);
+}
+
+async function withRemoteContextAsync<T>(
   headers: Record<string, string | undefined>,
   fn: () => Promise<T>,
 ): Promise<T> {
@@ -146,7 +155,22 @@ export async function withRemoteContext<T>(
  * The callback receives the span for setting attributes or recording errors.
  * withSpan does NOT automatically record errors — the callback manages that.
  */
-export async function withSpan<T>(
+export function withSpan<T>(
+  name: string,
+  options: { attributes?: Record<string, string | number | boolean> },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  // Synchronous fast-path: if already resolved to null, skip async entirely.
+  // After the first call, this avoids a microtask tick on every withSpan
+  // invocation in the common case where OTel is not installed.
+  if (resolvedApi === null) {
+    const span = makeNoOpSpan();
+    return fn(span).finally(() => span.end());
+  }
+  return withSpanAsync(name, options, fn);
+}
+
+async function withSpanAsync<T>(
   name: string,
   options: { attributes?: Record<string, string | number | boolean> },
   fn: (span: Span) => Promise<T>,

--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -1,0 +1,181 @@
+/**
+ * Thin wrapper that safely resolves @opentelemetry/api at runtime.
+ * Falls back to a no-op implementation if the package is not installed.
+ */
+
+interface Span {
+  setAttribute(key: string, value: string | number | boolean): this;
+  setStatus(status: { code: number; message?: string }): this;
+  recordException(error: Error | string): void;
+  end(): void;
+}
+
+interface Tracer {
+  startSpan(
+    name: string,
+    options?: { attributes?: Record<string, string | number | boolean> },
+  ): Span;
+}
+
+/**
+ * SpanStatusCode constants compatible with @opentelemetry/api SpanStatusCode enum.
+ * These work even when OTel is not installed.
+ */
+export const SpanStatusCode = {
+  /** The default status. */
+  UNSET: 0,
+  /** The operation completed successfully. */
+  OK: 1,
+  /** The operation contains an error. */
+  ERROR: 2,
+} as const;
+
+// --- Internal cache ---
+
+type OTelApiModule = typeof import("@opentelemetry/api");
+
+let resolvedApi: OTelApiModule | null | undefined = undefined;
+const cachedTracers = new Map<string, Tracer>();
+
+// --- No-op implementations ---
+
+function makeNoOpSpan(): Span {
+  const span: Span = {
+    setAttribute(_key: string, _value: string | number | boolean): Span {
+      return span;
+    },
+    setStatus(_status: { code: number; message?: string }): Span {
+      return span;
+    },
+    recordException(_error: Error | string): void {
+      // no-op
+    },
+    end(): void {
+      // no-op
+    },
+  };
+  return span;
+}
+
+function makeNoOpTracer(): Tracer {
+  return {
+    startSpan(
+      _name: string,
+      _options?: { attributes?: Record<string, string | number | boolean> },
+    ): Span {
+      return makeNoOpSpan();
+    },
+  };
+}
+
+// --- Resolution ---
+
+async function resolveOTelApi(): Promise<OTelApiModule | null> {
+  if (resolvedApi !== undefined) {
+    return resolvedApi;
+  }
+
+  try {
+    const api = await import("@opentelemetry/api");
+    resolvedApi = api;
+    return resolvedApi;
+  } catch {
+    resolvedApi = null;
+    return null;
+  }
+}
+
+// --- Public API ---
+
+/**
+ * Returns the full @opentelemetry/api module, or undefined if not installed.
+ * Result is cached after the first call.
+ */
+export async function getOTelApi(): Promise<OTelApiModule | undefined> {
+  const api = await resolveOTelApi();
+  return api ?? undefined;
+}
+
+/**
+ * Returns a Tracer for the given name and version.
+ * If @opentelemetry/api is not installed, returns a no-op tracer.
+ * The same tracer instance is returned on subsequent calls with the same arguments.
+ */
+export async function getTracer(name = "pilo-core", version?: string): Promise<Tracer> {
+  const key = `${name}:${version ?? ""}`;
+  const existing = cachedTracers.get(key);
+  if (existing) return existing;
+
+  const api = await resolveOTelApi();
+  const tracer = api ? api.trace.getTracer(name, version) : makeNoOpTracer();
+  cachedTracers.set(key, tracer);
+  return tracer;
+}
+
+/**
+ * Run a function within a trace context extracted from incoming HTTP headers
+ * (e.g. a WebSocket upgrade request). Any spans created inside `fn` via
+ * `withSpan` will automatically become children of the remote parent.
+ *
+ * When @opentelemetry/api is not installed or the headers are empty,
+ * the function runs directly with zero overhead.
+ */
+export async function withRemoteContext<T>(
+  headers: Record<string, string | undefined>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const api = await resolveOTelApi();
+  if (!api) return fn();
+
+  // Build a carrier with only defined values for the propagator.
+  const carrier: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    if (v) carrier[k] = v;
+  }
+
+  const ctx = api.propagation.extract(api.context.active(), carrier);
+  return api.context.with(ctx, fn);
+}
+
+/**
+ * Execute a function within a traced span. The span is automatically:
+ * - Created as a child of the currently active span (if any)
+ * - Set as the active span so nested withSpan calls become children
+ * - Ended when the function completes (success or error)
+ *
+ * The callback receives the span for setting attributes or recording errors.
+ * withSpan does NOT automatically record errors — the callback manages that.
+ */
+export async function withSpan<T>(
+  name: string,
+  options: { attributes?: Record<string, string | number | boolean> },
+  fn: (span: Span) => Promise<T>,
+): Promise<T> {
+  const api = await resolveOTelApi();
+
+  if (!api) {
+    // No OTel — run callback with no-op span, zero overhead
+    const span = makeNoOpSpan();
+    try {
+      return await fn(span);
+    } finally {
+      span.end();
+    }
+  }
+
+  const tracer = await getTracer();
+  // startSpan automatically uses context.active() to find the parent
+  const span = tracer.startSpan(name, options);
+  // Set this span as active so children created inside fn() become our children.
+  // Cast: tracer.startSpan() returns a full OTel Span at runtime; the local
+  // Span interface is an intentionally narrow subset.
+  const ctx = api.trace.setSpan(api.context.active(), span as any);
+
+  return api.context.with(ctx, async () => {
+    try {
+      return await fn(span);
+    } finally {
+      span.end();
+    }
+  });
+}

--- a/packages/core/src/tools/searchTools.ts
+++ b/packages/core/src/tools/searchTools.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import type { SearchService } from "../search/searchService.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
 import { TOOL_STRINGS } from "../prompts.js";
-import { withSpan } from "../telemetry/tracing.js";
+import { withSpan, SpanName } from "../telemetry/tracing.js";
 
 interface SearchToolContext {
   searchService: SearchService;
@@ -26,7 +26,7 @@ export function createSearchTools(context: SearchToolContext) {
       }),
       execute: async ({ query }) => {
         return withSpan(
-          "pilo.search.execute",
+          SpanName.SEARCH_EXECUTE,
           { attributes: { "pilo.search.query": query } },
           async (span) => {
             context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {

--- a/packages/core/src/tools/searchTools.ts
+++ b/packages/core/src/tools/searchTools.ts
@@ -10,6 +10,7 @@ import { z } from "zod";
 import type { SearchService } from "../search/searchService.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
 import { TOOL_STRINGS } from "../prompts.js";
+import { withSpan } from "../telemetry/tracing.js";
 
 interface SearchToolContext {
   searchService: SearchService;
@@ -24,43 +25,56 @@ export function createSearchTools(context: SearchToolContext) {
         query: z.string().describe(TOOL_STRINGS.webActions.webSearch.query),
       }),
       execute: async ({ query }) => {
-        context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
-          action: "webSearch",
-          value: query,
-        });
+        return withSpan(
+          "pilo.search.execute",
+          { attributes: { "pilo.search.query": query } },
+          async (span) => {
+            context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
+              action: "webSearch",
+              value: query,
+            });
 
-        try {
-          const markdown = await context.searchService.search(query);
+            try {
+              const markdown = await context.searchService.search(query);
 
-          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-            success: true,
-            action: "webSearch",
-          });
+              context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+                success: true,
+                action: "webSearch",
+              });
 
-          return {
-            success: true,
-            action: "webSearch",
-            query,
-            markdown,
-          };
-        } catch (error) {
-          const errorMessage = error instanceof Error ? error.message : String(error);
+              span.setAttribute("pilo.search.success", true);
+              return {
+                success: true,
+                action: "webSearch",
+                query,
+                markdown,
+              };
+            } catch (error) {
+              const errorMessage = error instanceof Error ? error.message : String(error);
 
-          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-            success: false,
-            action: "webSearch",
-            error: errorMessage,
-            isRecoverable: true,
-          });
+              context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+                success: false,
+                action: "webSearch",
+                error: errorMessage,
+                isRecoverable: true,
+              });
 
-          return {
-            success: false,
-            action: "webSearch",
-            query,
-            error: errorMessage,
-            isRecoverable: true,
-          };
-        }
+              span.setAttribute("pilo.search.success", false);
+              // Record the exception for observability even though search errors are
+              // recoverable (the LLM sees the error and can retry or move on).
+              // We do NOT set span status to ERROR — matching the webActionTools
+              // pattern for recoverable failures.
+              span.recordException(error instanceof Error ? error : new Error(errorMessage));
+              return {
+                success: false,
+                action: "webSearch",
+                query,
+                error: errorMessage,
+                isRecoverable: true,
+              };
+            }
+          },
+        );
       },
     }),
   };

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -13,6 +13,7 @@ import { buildExtractionPrompt, TOOL_STRINGS } from "../prompts.js";
 import type { ProviderConfig } from "../provider.js";
 import { BrowserException } from "../errors.js";
 import { generateTextWithRetry } from "../utils/retry.js";
+import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
 
 interface WebActionContext {
   browser: AriaBrowser;
@@ -53,58 +54,83 @@ async function performActionWithValidation(
   ref?: string,
   value?: string,
 ): Promise<ActionResult> {
-  try {
-    // Emit action started events
-    context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
-      action,
-      ref,
-      value,
-    });
+  return withSpan(
+    "pilo.browser.action",
+    {
+      attributes: {
+        "pilo.browser.action_type": String(action),
+        ...(ref && { "pilo.browser.element_ref": ref }),
+      },
+    },
+    async (span) => {
+      try {
+        // Emit action started events
+        context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
+          action,
+          ref,
+          value,
+        });
 
-    context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_STARTED, {
-      action,
-      ref,
-      value,
-    });
+        context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_STARTED, {
+          action,
+          ref,
+          value,
+        });
 
-    // Perform the action
-    await context.browser.performAction(ref || "", action, value);
+        // Perform the action
+        await context.browser.performAction(ref || "", action, value);
 
-    // Emit success
-    context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-      success: true,
-      action,
-    });
+        // Emit success
+        context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+          success: true,
+          action,
+        });
 
-    return { success: true, action, ...(ref && { ref }), ...(value !== undefined && { value }) };
-  } catch (error) {
-    // For browser exceptions, emit failure with error details and return error info
-    if (error instanceof BrowserException) {
-      context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-        success: false,
-        action,
-        error: error.message,
-        isRecoverable: true,
-      });
+        span.setAttribute("pilo.browser.success", true);
+        return {
+          success: true,
+          action,
+          ...(ref && { ref }),
+          ...(value !== undefined && { value }),
+        };
+      } catch (error) {
+        // For browser exceptions, emit failure with error details and return error info
+        if (error instanceof BrowserException) {
+          context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+            success: false,
+            action,
+            error: error.message,
+            isRecoverable: true,
+          });
 
-      return {
-        success: false,
-        action,
-        ...(ref && { ref }),
-        ...(value !== undefined && { value }),
-        error: error.message,
-        isRecoverable: true,
-      };
-    }
+          span.setAttribute("pilo.browser.success", false);
+          span.setAttribute("pilo.browser.recoverable", true);
+          // Do NOT set span status ERROR for recoverable browser exceptions
+          return {
+            success: false,
+            action,
+            ...(ref && { ref }),
+            ...(value !== undefined && { value }),
+            error: error.message,
+            isRecoverable: true,
+          };
+        }
 
-    // For non-browser errors, emit failure without recoverable flag and re-throw
-    context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
-      success: false,
-      action,
-    });
+        // For non-browser errors, emit failure without recoverable flag and re-throw
+        context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+          success: false,
+          action,
+        });
 
-    throw error;
-  }
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: error instanceof Error ? error.message : String(error),
+        });
+        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        throw error;
+      }
+    },
+  );
 }
 
 export function createWebActionTools(context: WebActionContext) {

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -13,7 +13,7 @@ import { buildExtractionPrompt, TOOL_STRINGS } from "../prompts.js";
 import type { ProviderConfig } from "../provider.js";
 import { BrowserException } from "../errors.js";
 import { generateTextWithRetry } from "../utils/retry.js";
-import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
+import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
 
 interface WebActionContext {
   browser: AriaBrowser;
@@ -55,7 +55,7 @@ async function performActionWithValidation(
   value?: string,
 ): Promise<ActionResult> {
   return withSpan(
-    "pilo.browser.action",
+    SpanName.BROWSER_ACTION,
     {
       attributes: {
         "pilo.browser.action_type": String(action),

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_RETRY_MAX_DELAY_MS,
   DEFAULT_RETRY_BACKOFF_FACTOR,
 } from "../constants.js";
+import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
 
 /**
  * Check if an error is retryable
@@ -79,85 +80,93 @@ export async function generateTextWithRetry<TOOLS extends Record<string, any> = 
   params: Parameters<typeof generateText<TOOLS>>[0],
   retryOptions?: RetryOptions,
 ): Promise<Awaited<ReturnType<typeof generateText<TOOLS>>>> {
-  const {
-    maxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS,
-    initialDelay = DEFAULT_RETRY_INITIAL_DELAY_MS,
-    maxDelay = DEFAULT_RETRY_MAX_DELAY_MS,
-    backoffFactor = DEFAULT_RETRY_BACKOFF_FACTOR,
-    onRetry,
-  } = retryOptions || {};
+  return withSpan("pilo.ai.generate", {}, async (span) => {
+    const {
+      maxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS,
+      initialDelay = DEFAULT_RETRY_INITIAL_DELAY_MS,
+      maxDelay = DEFAULT_RETRY_MAX_DELAY_MS,
+      backoffFactor = DEFAULT_RETRY_BACKOFF_FACTOR,
+      onRetry,
+    } = retryOptions || {};
 
-  let lastError: unknown;
-  let delay = initialDelay;
+    let lastError: unknown;
+    let delay = initialDelay;
 
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      // Attempt the generateText call
-      const result = await generateText(params);
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        const result = await generateText(params);
 
-      // Simple validation: if toolChoice is "required", we must have tool results
-      if (params.toolChoice === "required" && !result.toolResults?.length) {
-        throw new Error("Tool call was required but model did not call any tools");
-      }
+        if (params.toolChoice === "required" && !result.toolResults?.length) {
+          throw new Error("Tool call was required but model did not call any tools");
+        }
 
-      return result;
-    } catch (error) {
-      lastError = error;
+        // Record success attributes
+        span.setAttribute("pilo.ai.attempts", attempt);
+        span.setAttribute("pilo.ai.finish_reason", String(result.finishReason));
+        return result;
+      } catch (error) {
+        lastError = error;
 
-      // Extract error details for logging
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      const errorAny = error as any;
-      const statusCode = errorAny.statusCode || errorAny.status || errorAny.response?.status;
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const errorAny = error as any;
+        const statusCode = errorAny.statusCode || errorAny.status || errorAny.response?.status;
 
-      // Check if error is retryable
-      if (!isRetryableError(error)) {
-        console.error(`[Retry] Non-retryable error encountered:`, {
+        if (!isRetryableError(error)) {
+          console.error(`[Retry] Non-retryable error encountered:`, {
+            message: errorMessage,
+            statusCode,
+            attempt,
+          });
+          span.setAttribute("pilo.ai.attempts", attempt);
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: errorMessage,
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+        }
+
+        if (attempt === maxAttempts) {
+          console.error(`[Retry] Max attempts (${maxAttempts}) reached`);
+          break;
+        }
+
+        console.warn(`⚠️ [Retry] AI call failed (attempt ${attempt}/${maxAttempts}):`, {
           message: errorMessage,
           statusCode,
-          attempt,
+          retrying: true,
         });
-        throw error;
+
+        if (onRetry) {
+          onRetry(attempt, error);
+        }
+
+        const waitTime = Math.min(addJitter(delay), maxDelay);
+        console.log(`[Retry] Waiting ${Math.round(waitTime)}ms before retry...`);
+        await sleep(waitTime);
+
+        delay = Math.min(delay * backoffFactor, maxDelay);
+        console.log(`[Retry] Retrying (attempt ${attempt + 1}/${maxAttempts})...`);
       }
-
-      // Check if we have more attempts
-      if (attempt === maxAttempts) {
-        console.error(`[Retry] Max attempts (${maxAttempts}) reached`);
-        break;
-      }
-
-      // Log the retry attempt
-      console.warn(`⚠️ [Retry] AI call failed (attempt ${attempt}/${maxAttempts}):`, {
-        message: errorMessage,
-        statusCode,
-        retrying: true,
-      });
-
-      // Call retry callback if provided
-      if (onRetry) {
-        onRetry(attempt, error);
-      }
-
-      // Wait with exponential backoff and jitter
-      const waitTime = Math.min(addJitter(delay), maxDelay);
-      console.log(`[Retry] Waiting ${Math.round(waitTime)}ms before retry...`);
-      await sleep(waitTime);
-
-      // Increase delay for next attempt
-      delay = Math.min(delay * backoffFactor, maxDelay);
-      console.log(`[Retry] Retrying (attempt ${attempt + 1}/${maxAttempts})...`);
     }
-  }
 
-  // All retries exhausted
-  const errorMessage = lastError instanceof Error ? lastError.message : String(lastError);
-  const errorAny = lastError as any;
-  const statusCode = errorAny.statusCode || errorAny.status || errorAny.response?.status;
+    // All retries exhausted
+    const errorMessage = lastError instanceof Error ? lastError.message : String(lastError);
+    const errorAny = lastError as any;
+    const statusCode = errorAny.statusCode || errorAny.status || errorAny.response?.status;
 
-  console.error(`❌ [Retry] AI call failed after ${maxAttempts} attempts:`, {
-    message: errorMessage,
-    statusCode,
-    willThrow: true,
+    console.error(`❌ [Retry] AI call failed after ${maxAttempts} attempts:`, {
+      message: errorMessage,
+      statusCode,
+      willThrow: true,
+    });
+
+    span.setAttribute("pilo.ai.attempts", maxAttempts);
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: errorMessage,
+    });
+    span.recordException(lastError instanceof Error ? lastError : new Error(String(lastError)));
+    throw lastError;
   });
-
-  throw lastError;
 }

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_RETRY_MAX_DELAY_MS,
   DEFAULT_RETRY_BACKOFF_FACTOR,
 } from "../constants.js";
-import { withSpan, SpanStatusCode } from "../telemetry/tracing.js";
+import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
 
 /**
  * Check if an error is retryable
@@ -80,7 +80,7 @@ export async function generateTextWithRetry<TOOLS extends Record<string, any> = 
   params: Parameters<typeof generateText<TOOLS>>[0],
   retryOptions?: RetryOptions,
 ): Promise<Awaited<ReturnType<typeof generateText<TOOLS>>>> {
-  return withSpan("pilo.ai.generate", {}, async (span) => {
+  return withSpan(SpanName.AI_GENERATE, {}, async (span) => {
     const {
       maxAttempts = DEFAULT_RETRY_MAX_ATTEMPTS,
       initialDelay = DEFAULT_RETRY_INITIAL_DELAY_MS,

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -48,7 +48,7 @@ import {
   DEFAULT_PLANNING_MAX_TOKENS,
   DEFAULT_VALIDATION_MAX_TOKENS,
 } from "./constants.js";
-import { withSpan, SpanStatusCode } from "./telemetry/tracing.js";
+import { withSpan, SpanStatusCode, SpanName } from "./telemetry/tracing.js";
 
 // === Type Definitions ===
 
@@ -281,7 +281,7 @@ export class WebAgent {
    */
   async execute(task: string, options: ExecuteOptions = {}): Promise<TaskExecutionResult> {
     return withSpan(
-      "pilo.task.execute",
+      SpanName.TASK_EXECUTE,
       {
         attributes: {
           "pilo.task": task,
@@ -472,7 +472,7 @@ export class WebAgent {
       this.currentIterationId = nanoid(8);
 
       const outcome: StepOutcome = await withSpan(
-        "pilo.agent.step",
+        SpanName.AGENT_STEP,
         {
           attributes: {
             "pilo.step.number": executionState.currentIteration,
@@ -838,7 +838,7 @@ export class WebAgent {
     let generationError: Error | null = null;
 
     const aiResponse: ProcessedAIResponse | null = await withSpan(
-      "pilo.ai.generate",
+      SpanName.AI_GENERATE,
       {},
       async (aiSpan) => {
         try {
@@ -1152,7 +1152,7 @@ export class WebAgent {
     executionState.validationAttempts++;
 
     return withSpan(
-      "pilo.task.validate",
+      SpanName.TASK_VALIDATE,
       {
         attributes: { "pilo.validation.attempt": executionState.validationAttempts },
       },
@@ -1318,7 +1318,7 @@ export class WebAgent {
    */
   private async planTask(task: string, startingUrl?: string): Promise<void> {
     return withSpan(
-      "pilo.task.plan",
+      SpanName.TASK_PLAN,
       {
         attributes: {
           "pilo.task": task,
@@ -1723,7 +1723,7 @@ export class WebAgent {
     error: BrowserDisconnectedError,
     executionState: ExecutionState,
   ): Promise<void> {
-    return withSpan("pilo.browser.reconnect", {}, async (span) => {
+    return withSpan(SpanName.BROWSER_RECONNECT, {}, async (span) => {
       try {
         console.warn(`[WebAgent] Browser disconnected mid-task: ${error.message}`);
         console.warn(`[WebAgent] Restarting on next CDP endpoint...`);

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -48,6 +48,7 @@ import {
   DEFAULT_PLANNING_MAX_TOKENS,
   DEFAULT_VALIDATION_MAX_TOKENS,
 } from "./constants.js";
+import { withSpan, SpanStatusCode } from "./telemetry/tracing.js";
 
 // === Type Definitions ===
 
@@ -161,6 +162,12 @@ interface PlanningResponse {
   toolResults: PlanningToolResult[];
 }
 
+type StepOutcome =
+  | { flow: "break" }
+  | { flow: "continue" }
+  | { flow: "return"; value: { success: boolean; finalAnswer: string; error?: TaskError } }
+  | { flow: "next"; needsPageSnapshot: boolean };
+
 type StreamTextResultGeneric = StreamTextResult<any, never>;
 // HACK: cobble together a type from StreamTextResult with promises resolved
 type ProcessedAIResponse = AwaitedProperties<
@@ -273,64 +280,88 @@ export class WebAgent {
    * Main entry point - keep this simple and clear
    */
   async execute(task: string, options: ExecuteOptions = {}): Promise<TaskExecutionResult> {
-    // 1. Validate input parameters (let validation errors throw)
-    this.validateTaskAndOptions(task, options);
-
-    // 2. Initialize browser and internal state
-    await this.initializeBrowserAndState(task, options);
-
-    // 3. Eagerly create search service so provider errors surface before the main loop
-    if (this.searchProvider !== "none") {
-      this.searchService = await SearchService.create(this.searchProvider, this.browser, {
-        apiKey: this.searchApiKey,
-      });
-    }
-
-    const executionState = this.initializeExecutionState();
-
-    try {
-      // 4. Planning phase
-      await this.planTask(task, options.startingUrl);
-
-      // 5. Navigation phase (with retry on recoverable errors)
-      await this.navigateToStartWithRetry(task);
-
-      this.initializeSystemPromptAndTask(task);
-
-      // 6. Main execution loop
-      const loopOutcome = await this.runMainLoop(task, executionState);
-
-      // 7. Return results
-      return this.buildResult(loopOutcome, executionState);
-    } catch (error) {
-      // Check if aborted
-      if (this.abortSignal?.aborted) {
-        return this.buildResult(
-          {
-            success: false,
-            finalAnswer: "Task aborted by user",
-            error: { code: TaskErrorCode.TASK_ABORTED, message: "Task aborted by user" },
-          },
-          executionState,
-        );
-      }
-
-      // Re-throw setup/planning errors (they indicate configuration issues)
-      if (this.isSetupError(error)) {
-        throw error;
-      }
-
-      // Convert runtime errors to results
-      const message = `Task failed: ${this.extractErrorMessage(error)}`;
-      return this.buildResult(
-        {
-          success: false,
-          finalAnswer: message,
-          error: { code: TaskErrorCode.TASK_FAILED, message },
+    return withSpan(
+      "pilo.task.execute",
+      {
+        attributes: {
+          "pilo.task": task,
+          ...(options.startingUrl && { "pilo.url": options.startingUrl }),
         },
-        executionState,
-      );
-    }
+      },
+      async (span) => {
+        try {
+          // 1. Validate input parameters (let validation errors throw)
+          this.validateTaskAndOptions(task, options);
+
+          // 2. Initialize browser and internal state
+          await this.initializeBrowserAndState(task, options);
+
+          // 3. Eagerly create search service so provider errors surface before the main loop
+          if (this.searchProvider !== "none") {
+            this.searchService = await SearchService.create(this.searchProvider, this.browser, {
+              apiKey: this.searchApiKey,
+            });
+          }
+
+          const executionState = this.initializeExecutionState();
+
+          try {
+            // 4. Planning phase
+            await this.planTask(task, options.startingUrl);
+
+            // 5. Navigation phase (with retry on recoverable errors)
+            await this.navigateToStartWithRetry(task);
+
+            this.initializeSystemPromptAndTask(task);
+
+            // 6. Main execution loop
+            const loopOutcome = await this.runMainLoop(task, executionState);
+
+            // 7. Return results
+            const result = this.buildResult(loopOutcome, executionState);
+            span.setAttribute("pilo.task.success", result.success);
+            return result;
+          } catch (error) {
+            // Check if aborted
+            if (this.abortSignal?.aborted) {
+              span.setAttribute("pilo.task.success", false);
+              return this.buildResult(
+                {
+                  success: false,
+                  finalAnswer: "Task aborted by user",
+                  error: { code: TaskErrorCode.TASK_ABORTED, message: "Task aborted by user" },
+                },
+                executionState,
+              );
+            }
+
+            // Re-throw setup/planning errors (they indicate configuration issues)
+            if (this.isSetupError(error)) {
+              throw error;
+            }
+
+            // Convert runtime errors to results
+            const message = `Task failed: ${this.extractErrorMessage(error)}`;
+            span.setAttribute("pilo.task.success", false);
+            return this.buildResult(
+              {
+                success: false,
+                finalAnswer: message,
+                error: { code: TaskErrorCode.TASK_FAILED, message },
+              },
+              executionState,
+            );
+          }
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          throw error;
+        }
+      },
+    );
   }
 
   /**
@@ -440,88 +471,116 @@ export class WebAgent {
       // Generate unique iteration ID
       this.currentIterationId = nanoid(8);
 
-      // Emit step event for this iteration
-      this.emit(WebAgentEventType.AGENT_STEP, {
-        iterationId: this.currentIterationId,
-        currentIteration: executionState.currentIteration,
-      });
+      const outcome: StepOutcome = await withSpan(
+        "pilo.agent.step",
+        {
+          attributes: {
+            "pilo.step.number": executionState.currentIteration,
+            "pilo.step.iteration_id": this.currentIterationId,
+          },
+        },
+        async (stepSpan) => {
+          // Emit step event for this iteration
+          this.emit(WebAgentEventType.AGENT_STEP, {
+            iterationId: this.currentIterationId,
+            currentIteration: executionState.currentIteration,
+          });
 
-      // Add page snapshot if needed
-      if (needsPageSnapshot) {
-        // Clear approved refs when page changes: ARIA refs reset on each snapshot,
-        // so old ref strings may now point to different DOM elements.
-        if (approvedRefs) {
-          approvedRefs.clear();
-        }
-        await this.addPageSnapshot();
-      }
-
-      // Single try-catch for ALL iteration logic
-      try {
-        const result = await this.generateAndProcessAction(task, allTools, executionState);
-
-        // Reset error counter on success
-        consecutiveErrors = 0;
-
-        // Handle terminal actions
-        if (result.isTerminal) {
-          executionState.success = result.success;
-          executionState.finalAnswer = result.finalAnswer;
-          executionState.error = result.error;
-          break;
-        }
-
-        // Update state for successful action
-        if (result.actionExecuted) {
-          executionState.actionCount++;
-        }
-
-        needsPageSnapshot = result.pageChanged;
-      } catch (error) {
-        // Browser disconnects are handled specially: restart on next CDP endpoint,
-        // reset execution state, and continue — not counted as an agent error.
-        if (error instanceof BrowserDisconnectedError) {
-          // May throw if all endpoints exhausted — propagates as hard error
-          await this.handleBrowserDisconnect(task, error, executionState);
-          consecutiveErrors = 0;
-          needsPageSnapshot = true;
-          executionState.currentIteration++;
-          continue;
-        }
-
-        trackError();
-
-        // Check if we should continue
-        if (!this.shouldContinueAfterError(consecutiveErrors, totalErrors, error)) {
-          const isNonRecoverable = this.isNonRecoverableError(error);
-          const errorMessage = this.extractErrorMessage(error);
-
-          if (isNonRecoverable) {
-            console.error(`[WebAgent] Non-recoverable error, stopping execution:`, errorMessage);
-          } else {
-            console.error(
-              `[WebAgent] Too many errors (${consecutiveErrors} consecutive, ${totalErrors} total), stopping:`,
-              errorMessage,
-            );
+          // Add page snapshot if needed
+          if (needsPageSnapshot) {
+            // Clear approved refs when page changes: ARIA refs reset on each snapshot,
+            // so old ref strings may now point to different DOM elements.
+            if (approvedRefs) {
+              approvedRefs.clear();
+            }
+            await this.addPageSnapshot();
           }
 
-          const message = isNonRecoverable
-            ? `Task failed: ${errorMessage}`
-            : `Task failed after ${consecutiveErrors} consecutive errors (${totalErrors} total): ${errorMessage}`;
-          return {
-            success: false,
-            finalAnswer: message,
-            error: {
-              code: isNonRecoverable ? TaskErrorCode.TASK_FAILED : TaskErrorCode.MAX_ERRORS,
-              message,
-            },
-          };
-        }
+          // Single try-catch for ALL iteration logic
+          try {
+            const result = await this.generateAndProcessAction(task, allTools, executionState);
 
-        // Add error feedback and retry
-        this.addErrorFeedback(error);
-        needsPageSnapshot = false; // Nothing changed, don't snapshot
-      }
+            // Reset error counter on success
+            consecutiveErrors = 0;
+
+            // Handle terminal actions
+            if (result.isTerminal) {
+              executionState.success = result.success;
+              executionState.finalAnswer = result.finalAnswer;
+              executionState.error = result.error;
+              return { flow: "break" as const };
+            }
+
+            // Update state for successful action
+            if (result.actionExecuted) {
+              executionState.actionCount++;
+            }
+
+            return { flow: "next" as const, needsPageSnapshot: result.pageChanged };
+          } catch (error) {
+            // Browser disconnects handled specially — don't mark span as error when recovery succeeds
+            if (error instanceof BrowserDisconnectedError) {
+              // May throw if all endpoints exhausted — propagates as hard error
+              await this.handleBrowserDisconnect(task, error, executionState);
+              consecutiveErrors = 0;
+              executionState.currentIteration++;
+              return { flow: "continue" as const };
+            }
+
+            // Only mark non-disconnect errors as span failures
+            stepSpan.setStatus({
+              code: SpanStatusCode.ERROR,
+              message: error instanceof Error ? error.message : String(error),
+            });
+            stepSpan.recordException(error instanceof Error ? error : new Error(String(error)));
+
+            trackError();
+
+            // Check if we should continue
+            if (!this.shouldContinueAfterError(consecutiveErrors, totalErrors, error)) {
+              const isNonRecoverable = this.isNonRecoverableError(error);
+              const errorMessage = this.extractErrorMessage(error);
+
+              if (isNonRecoverable) {
+                console.error(
+                  `[WebAgent] Non-recoverable error, stopping execution:`,
+                  errorMessage,
+                );
+              } else {
+                console.error(
+                  `[WebAgent] Too many errors (${consecutiveErrors} consecutive, ${totalErrors} total), stopping:`,
+                  errorMessage,
+                );
+              }
+
+              const message = isNonRecoverable
+                ? `Task failed: ${errorMessage}`
+                : `Task failed after ${consecutiveErrors} consecutive errors (${totalErrors} total): ${errorMessage}`;
+              return {
+                flow: "return" as const,
+                value: {
+                  success: false,
+                  finalAnswer: message,
+                  error: {
+                    code: isNonRecoverable ? TaskErrorCode.TASK_FAILED : TaskErrorCode.MAX_ERRORS,
+                    message,
+                  },
+                },
+              };
+            }
+
+            // Add error feedback and retry
+            this.addErrorFeedback(error);
+            return { flow: "next" as const, needsPageSnapshot: false };
+          }
+        },
+      );
+
+      // Handle control flow after withSpan
+      if (outcome.flow === "break") break;
+      if (outcome.flow === "continue") continue;
+      if (outcome.flow === "return") return outcome.value;
+      needsPageSnapshot = outcome.needsPageSnapshot;
 
       executionState.currentIteration++;
     }
@@ -776,77 +835,93 @@ export class WebAgent {
       iterationId: this.currentIterationId,
     });
 
-    let aiResponse: ProcessedAIResponse | null = null;
     let generationError: Error | null = null;
 
-    try {
-      // Generate AI response using streamText
-      const streamResult = streamText({
-        ...this.providerConfig,
-        messages: this.messages,
-        tools: webActionTools,
-        toolChoice: "required",
-        maxOutputTokens: DEFAULT_GENERATION_MAX_TOKENS,
-        abortSignal: this.abortSignal,
-      });
+    const aiResponse: ProcessedAIResponse | null = await withSpan(
+      "pilo.ai.generate",
+      {},
+      async (aiSpan) => {
+        try {
+          // Generate AI response using streamText
+          const streamResult = streamText({
+            ...this.providerConfig,
+            messages: this.messages,
+            tools: webActionTools,
+            toolChoice: "required",
+            maxOutputTokens: DEFAULT_GENERATION_MAX_TOKENS,
+            abortSignal: this.abortSignal,
+          });
 
-      // Process the full stream to capture reasoning before tool execution
-      let reasoningText = "";
-      let reasoningEmitted = false;
+          // Process the full stream to capture reasoning before tool execution
+          let reasoningText = "";
+          let reasoningEmitted = false;
 
-      for await (const part of streamResult.fullStream) {
-        switch (part.type) {
-          case "reasoning-start":
-            // Start accumulating reasoning
-            reasoningText = "";
-            reasoningEmitted = false;
-            break;
+          for await (const part of streamResult.fullStream) {
+            switch (part.type) {
+              case "reasoning-start":
+                // Start accumulating reasoning
+                reasoningText = "";
+                reasoningEmitted = false;
+                break;
 
-          case "reasoning-delta":
-            // Accumulate reasoning text
-            if ("text" in part) {
-              reasoningText += part.text;
+              case "reasoning-delta":
+                // Accumulate reasoning text
+                if ("text" in part) {
+                  reasoningText += part.text;
+                }
+                break;
+
+              case "tool-input-start":
+              case "tool-call":
+              case "reasoning-end":
+                // Emit reasoning when we're about to execute a tool or when reasoning ends
+                if (reasoningText && !reasoningEmitted) {
+                  this.emit(WebAgentEventType.AGENT_REASONED, {
+                    reasoning: reasoningText.trim(),
+                    iterationId: this.currentIterationId,
+                  });
+                  reasoningEmitted = true;
+                }
+                break;
             }
-            break;
+          }
 
-          case "tool-input-start":
-          case "tool-call":
-          case "reasoning-end":
-            // Emit reasoning when we're about to execute a tool or when reasoning ends
-            if (reasoningText && !reasoningEmitted) {
-              this.emit(WebAgentEventType.AGENT_REASONED, {
-                reasoning: reasoningText.trim(),
-                iterationId: this.currentIterationId,
-              });
-              reasoningEmitted = true;
-            }
-            break;
+          // Await only the properties we actually need
+          const [toolResults, response, finishReason, usage, warnings, providerMetadata] =
+            await Promise.all([
+              streamResult.toolResults,
+              streamResult.response,
+              streamResult.finishReason,
+              streamResult.usage,
+              streamResult.warnings,
+              streamResult.providerMetadata,
+            ]);
+
+          const result: ProcessedAIResponse = {
+            toolResults,
+            response,
+            finishReason,
+            usage,
+            warnings,
+            providerMetadata,
+          };
+
+          aiSpan.setAttribute("pilo.ai.finish_reason", String(finishReason));
+          if (usage) {
+            aiSpan.setAttribute("pilo.ai.input_tokens", usage.inputTokens || 0);
+            aiSpan.setAttribute("pilo.ai.output_tokens", usage.outputTokens || 0);
+          }
+
+          return result;
+        } catch (error) {
+          // Preserve original error
+          generationError = error instanceof Error ? error : new Error(String(error));
+          aiSpan.setStatus({ code: SpanStatusCode.ERROR, message: generationError.message });
+          aiSpan.recordException(generationError);
+          return null;
         }
-      }
-
-      // Await only the properties we actually need
-      const [toolResults, response, finishReason, usage, warnings, providerMetadata] =
-        await Promise.all([
-          streamResult.toolResults,
-          streamResult.response,
-          streamResult.finishReason,
-          streamResult.usage,
-          streamResult.warnings,
-          streamResult.providerMetadata,
-        ]);
-
-      aiResponse = {
-        toolResults,
-        response,
-        finishReason,
-        usage,
-        warnings,
-        providerMetadata,
-      };
-    } catch (error) {
-      // Preserve original error
-      generationError = error instanceof Error ? error : new Error(String(error));
-    }
+      },
+    );
 
     // Always append messages if they exist (even on error)
     if (aiResponse?.response?.messages) {
@@ -1074,119 +1149,136 @@ export class WebAgent {
     finalAnswer: string,
     executionState: ExecutionState,
   ): Promise<{ isAccepted: boolean }> {
-    // Increment validation attempts
     executionState.validationAttempts++;
 
-    // Emit processing event with attempt number
-    this.emit(WebAgentEventType.AGENT_PROCESSING, {
-      operation: `Validating task completion (attempt ${executionState.validationAttempts})`,
-      hasScreenshot: false,
-      iterationId: this.currentIterationId,
-    });
+    return withSpan(
+      "pilo.task.validate",
+      {
+        attributes: { "pilo.validation.attempt": executionState.validationAttempts },
+      },
+      async (span) => {
+        // Emit processing event with attempt number
+        this.emit(WebAgentEventType.AGENT_PROCESSING, {
+          operation: `Validating task completion (attempt ${executionState.validationAttempts})`,
+          hasScreenshot: false,
+          iterationId: this.currentIterationId,
+        });
 
-    try {
-      // Format conversation history for validation context
-      const conversationHistory = this.formatConversationHistory();
+        try {
+          // Format conversation history for validation context
+          const conversationHistory = this.formatConversationHistory();
 
-      // Build validation prompt
-      const validationPrompt = buildTaskValidationPrompt(
-        task,
-        this.successCriteria,
-        finalAnswer,
-        conversationHistory,
-      );
+          // Build validation prompt
+          const validationPrompt = buildTaskValidationPrompt(
+            task,
+            this.successCriteria,
+            finalAnswer,
+            conversationHistory,
+          );
 
-      // Call validation tool
-      const validationTools = createValidationTools();
-      const validationResponse = await generateTextWithRetry(
-        {
-          ...this.providerConfig,
-          prompt: validationPrompt,
-          tools: validationTools,
-          toolChoice: "required", // Use "required" for compatibility with providers that don't support specific tool selection
-          maxOutputTokens: DEFAULT_VALIDATION_MAX_TOKENS,
-          abortSignal: this.abortSignal,
-        },
-        {
-          maxAttempts: 2,
-          onRetry: (attempt, error) => {
-            this.emit(WebAgentEventType.AGENT_STATUS, {
-              message: `Validation retry attempt ${attempt} after error: ${this.extractErrorMessage(error)}`,
+          // Call validation tool
+          const validationTools = createValidationTools();
+          const validationResponse = await generateTextWithRetry(
+            {
+              ...this.providerConfig,
+              prompt: validationPrompt,
+              tools: validationTools,
+              toolChoice: "required", // Use "required" for compatibility with providers that don't support specific tool selection
+              maxOutputTokens: DEFAULT_VALIDATION_MAX_TOKENS,
+              abortSignal: this.abortSignal,
+            },
+            {
+              maxAttempts: 2,
+              onRetry: (attempt, error) => {
+                this.emit(WebAgentEventType.AGENT_STATUS, {
+                  message: `Validation retry attempt ${attempt} after error: ${this.extractErrorMessage(error)}`,
+                  iterationId: this.currentIterationId,
+                });
+              },
+            },
+          );
+
+          if (!validationResponse.toolResults?.[0]) {
+            throw new Error("Failed to validate task completion");
+          }
+
+          const validationResult = validationResponse.toolResults[0].output as any;
+          const { taskAssessment, completionQuality, feedback } = validationResult;
+
+          // Emit validation event
+          this.emit(WebAgentEventType.TASK_VALIDATED, {
+            observation: taskAssessment,
+            completionQuality,
+            feedback,
+            finalAnswer,
+            iterationId: this.currentIterationId,
+          });
+
+          span.setAttribute("pilo.validation.quality", completionQuality);
+
+          // Check if quality is acceptable
+          const isAccepted = completionQuality === "complete" || completionQuality === "excellent";
+
+          // If not accepted and we haven't hit max attempts, add feedback to conversation
+          if (!isAccepted && executionState.validationAttempts < this.maxValidationAttempts) {
+            // Build feedback message using the prompt function
+            const feedbackMessage = buildValidationFeedbackPrompt(
+              executionState.validationAttempts,
+              taskAssessment,
+              feedback,
+            );
+
+            this.messages.push({ role: "user", content: feedbackMessage });
+
+            // Emit event for debugging
+            this.emit(WebAgentEventType.TASK_VALIDATION_ERROR, {
+              errors: [`Validation failed: ${completionQuality}`],
+              retryCount: executionState.validationAttempts,
+              feedback: feedbackMessage,
               iterationId: this.currentIterationId,
             });
-          },
-        },
-      );
+          }
 
-      if (!validationResponse.toolResults?.[0]) {
-        throw new Error("Failed to validate task completion");
-      }
+          // Accept if quality is good OR we've hit max validation attempts
+          const forceAccept = executionState.validationAttempts >= this.maxValidationAttempts;
+          if (forceAccept && !isAccepted) {
+            // Log warning that we're accepting due to max attempts
+            this.emit(WebAgentEventType.AGENT_STATUS, {
+              message: `Accepting answer after ${executionState.validationAttempts} validation attempts`,
+              finalAnswer,
+              iterationId: this.currentIterationId,
+            });
+          }
 
-      const validationResult = validationResponse.toolResults[0].output as any;
-      const { taskAssessment, completionQuality, feedback } = validationResult;
+          span.setAttribute("pilo.validation.accepted", isAccepted || forceAccept);
 
-      // Emit validation event
-      this.emit(WebAgentEventType.TASK_VALIDATED, {
-        observation: taskAssessment,
-        completionQuality,
-        feedback,
-        finalAnswer,
-        iterationId: this.currentIterationId,
-      });
+          return {
+            isAccepted: isAccepted || forceAccept,
+          };
+        } catch (error) {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
 
-      // Check if quality is acceptable
-      const isAccepted = completionQuality === "complete" || completionQuality === "excellent";
+          // On validation error, accept the result if we've hit max attempts
+          if (executionState.validationAttempts >= this.maxValidationAttempts) {
+            return { isAccepted: true };
+          }
 
-      // If not accepted and we haven't hit max attempts, add feedback to conversation
-      if (!isAccepted && executionState.validationAttempts < this.maxValidationAttempts) {
-        // Build feedback message using the prompt function
-        const feedbackMessage = buildValidationFeedbackPrompt(
-          executionState.validationAttempts,
-          taskAssessment,
-          feedback,
-        );
+          // Otherwise, continue execution
+          this.emit(WebAgentEventType.TASK_VALIDATION_ERROR, {
+            errors: [this.extractErrorMessage(error)],
+            retryCount: executionState.validationAttempts,
+            rawResponse: null,
+            iterationId: this.currentIterationId,
+          });
 
-        this.messages.push({ role: "user", content: feedbackMessage });
-
-        // Emit event for debugging
-        this.emit(WebAgentEventType.TASK_VALIDATION_ERROR, {
-          errors: [`Validation failed: ${completionQuality}`],
-          retryCount: executionState.validationAttempts,
-          feedback: feedbackMessage,
-          iterationId: this.currentIterationId,
-        });
-      }
-
-      // Accept if quality is good OR we've hit max validation attempts
-      const forceAccept = executionState.validationAttempts >= this.maxValidationAttempts;
-      if (forceAccept && !isAccepted) {
-        // Log warning that we're accepting due to max attempts
-        this.emit(WebAgentEventType.AGENT_STATUS, {
-          message: `Accepting answer after ${executionState.validationAttempts} validation attempts`,
-          finalAnswer,
-          iterationId: this.currentIterationId,
-        });
-      }
-
-      return {
-        isAccepted: isAccepted || forceAccept,
-      };
-    } catch (error) {
-      // On validation error, accept the result if we've hit max attempts
-      if (executionState.validationAttempts >= this.maxValidationAttempts) {
-        return { isAccepted: true };
-      }
-
-      // Otherwise, continue execution
-      this.emit(WebAgentEventType.TASK_VALIDATION_ERROR, {
-        errors: [this.extractErrorMessage(error)],
-        retryCount: executionState.validationAttempts,
-        rawResponse: null,
-        iterationId: this.currentIterationId,
-      });
-
-      return { isAccepted: false };
-    }
+          return { isAccepted: false };
+        }
+      },
+    );
   }
 
   /**
@@ -1225,78 +1317,105 @@ export class WebAgent {
    * When no startingUrl, the prompt instructs the planner to determine a url.
    */
   private async planTask(task: string, startingUrl?: string): Promise<void> {
-    const webSearchEnabled = this.searchProvider !== "none";
-    const planningPrompt = buildPlanPrompt(task, startingUrl, this.guardrails, webSearchEnabled);
-    const planningTools = createPlanningTools();
-
-    // Emit processing event before planning - planning doesn't use screenshots
-    this.emit(WebAgentEventType.AGENT_PROCESSING, {
-      operation: "Creating task plan",
-      hasScreenshot: false,
-      iterationId: this.currentIterationId || "planning",
-    });
-
-    // Also emit as status so extension ChatView shows it to user
-    this.emit(WebAgentEventType.AGENT_STATUS, {
-      message: "Creating task plan",
-      iterationId: this.currentIterationId || "planning",
-    });
-
-    try {
-      const planningResponse = await generateTextWithRetry(
-        {
-          ...this.providerConfig,
-          prompt: planningPrompt,
-          tools: planningTools,
-          toolChoice: "required", // Use "required" for compatibility with providers that don't support specific tool selection
-          maxOutputTokens: DEFAULT_PLANNING_MAX_TOKENS,
+    return withSpan(
+      "pilo.task.plan",
+      {
+        attributes: {
+          "pilo.task": task,
+          ...(startingUrl && { "pilo.url": startingUrl }),
         },
-        {
-          maxAttempts: 3,
-          onRetry: (attempt, error) => {
-            const errorMsg = this.extractErrorMessage(error);
-            console.warn(`[WebAgent] Planning retry attempt ${attempt}/3 after error:`, errorMsg);
-            this.emit(WebAgentEventType.AGENT_STATUS, {
-              message: `Planning retry attempt ${attempt} after error: ${errorMsg}`,
-              iterationId: this.currentIterationId || "planning",
-            });
-          },
-        },
-      );
+      },
+      async (span) => {
+        const webSearchEnabled = this.searchProvider !== "none";
+        const planningPrompt = buildPlanPrompt(
+          task,
+          startingUrl,
+          this.guardrails,
+          webSearchEnabled,
+        );
+        const planningTools = createPlanningTools();
 
-      if (!planningResponse.toolResults?.[0]) {
-        throw new Error("No tool results returned from planning");
-      }
+        // Emit processing event before planning - planning doesn't use screenshots
+        this.emit(WebAgentEventType.AGENT_PROCESSING, {
+          operation: "Creating task plan",
+          hasScreenshot: false,
+          iterationId: this.currentIterationId || "planning",
+        });
 
-      // Cast to PlanningResponse - we've validated toolResults[0] exists above
-      const { plan, successCriteria, url, actionItems } = this.extractPlanOutput(
-        planningResponse as unknown as PlanningResponse,
-      );
+        // Also emit as status so extension ChatView shows it to user
+        this.emit(WebAgentEventType.AGENT_STATUS, {
+          message: "Creating task plan",
+          iterationId: this.currentIterationId || "planning",
+        });
 
-      this.plan = plan;
-      this.successCriteria = successCriteria;
-      this.actionItems = actionItems;
+        try {
+          const planningResponse = await generateTextWithRetry(
+            {
+              ...this.providerConfig,
+              prompt: planningPrompt,
+              tools: planningTools,
+              toolChoice: "required", // Use "required" for compatibility with providers that don't support specific tool selection
+              maxOutputTokens: DEFAULT_PLANNING_MAX_TOKENS,
+            },
+            {
+              maxAttempts: 3,
+              onRetry: (attempt, error) => {
+                const errorMsg = this.extractErrorMessage(error);
+                console.warn(
+                  `[WebAgent] Planning retry attempt ${attempt}/3 after error:`,
+                  errorMsg,
+                );
+                this.emit(WebAgentEventType.AGENT_STATUS, {
+                  message: `Planning retry attempt ${attempt} after error: ${errorMsg}`,
+                  iterationId: this.currentIterationId || "planning",
+                });
+              },
+            },
+          );
 
-      // Determine starting point: user-provided URL > planner URL > blank
-      this.url = startingUrl || url || "about:blank";
+          if (!planningResponse.toolResults?.[0]) {
+            throw new Error("No tool results returned from planning");
+          }
 
-      this.emit(WebAgentEventType.AGENT_STATUS, {
-        message: "Task plan created",
-        plan: this.plan,
-        successCriteria: this.successCriteria,
-        url: this.url,
-      });
-    } catch (error) {
-      const errorMsg = this.extractErrorMessage(error);
-      console.error(`[WebAgent] Failed to generate plan:`, errorMsg);
+          // Cast to PlanningResponse - we've validated toolResults[0] exists above
+          const { plan, successCriteria, url, actionItems } = this.extractPlanOutput(
+            planningResponse as unknown as PlanningResponse,
+          );
 
-      // Check if the error message already contains "Failed to generate plan" to avoid double-wrapping
-      if (errorMsg.includes("Failed to generate plan")) {
-        throw new Error(errorMsg);
-      } else {
-        throw new Error(`Failed to generate plan: ${errorMsg}`);
-      }
-    }
+          this.plan = plan;
+          this.successCriteria = successCriteria;
+          this.actionItems = actionItems;
+
+          // Determine starting point: user-provided URL > planner URL > blank
+          this.url = startingUrl || url || "about:blank";
+
+          this.emit(WebAgentEventType.AGENT_STATUS, {
+            message: "Task plan created",
+            plan: this.plan,
+            successCriteria: this.successCriteria,
+            url: this.url,
+          });
+
+          span.setAttribute("pilo.plan.has_url", !!this.url && this.url !== "about:blank");
+        } catch (error) {
+          const errorMsg = this.extractErrorMessage(error);
+          console.error(`[WebAgent] Failed to generate plan:`, errorMsg);
+
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: error instanceof Error ? error.message : String(error),
+          });
+          span.recordException(error instanceof Error ? error : new Error(String(error)));
+
+          // Check if the error message already contains "Failed to generate plan" to avoid double-wrapping
+          if (errorMsg.includes("Failed to generate plan")) {
+            throw new Error(errorMsg);
+          } else {
+            throw new Error(`Failed to generate plan: ${errorMsg}`);
+          }
+        }
+      },
+    );
   }
 
   // === Helper Methods ===
@@ -1604,41 +1723,58 @@ export class WebAgent {
     error: BrowserDisconnectedError,
     executionState: ExecutionState,
   ): Promise<void> {
-    console.warn(`[WebAgent] Browser disconnected mid-task: ${error.message}`);
-    console.warn(`[WebAgent] Restarting on next CDP endpoint...`);
+    return withSpan("pilo.browser.reconnect", {}, async (span) => {
+      try {
+        console.warn(`[WebAgent] Browser disconnected mid-task: ${error.message}`);
+        console.warn(`[WebAgent] Restarting on next CDP endpoint...`);
 
-    await this.browser.shutdown();
+        await this.browser.shutdown();
 
-    // Throws a hard (non-RecoverableError) if all endpoints are exhausted
-    await this.browser.start();
+        // Throws a hard (non-RecoverableError) if all endpoints are exhausted
+        await this.browser.start();
 
-    // Navigate to the original starting URL — not currentPage.url.
-    // The new browser has no prior session state; we need a coherent starting point.
-    if (this.url && this.url !== "about:blank") {
-      await this.browser.goto(this.url);
-    }
+        // Navigate to the original starting URL — not currentPage.url.
+        // The new browser has no prior session state; we need a coherent starting point.
+        if (this.url && this.url !== "about:blank") {
+          await this.browser.goto(this.url);
+        }
 
-    // Re-initialize messages: stale DOM snapshots from the old browser would
-    // confuse the agent and may trigger false repetition-abort logic.
-    this.initializeSystemPromptAndTask(task);
+        // Re-initialize messages: stale DOM snapshots from the old browser would
+        // confuse the agent and may trigger false repetition-abort logic.
+        this.initializeSystemPromptAndTask(task);
 
-    // Reset repetition tracking to avoid false "stuck in loop" detection.
-    executionState.actionRepeatCount = 0;
-    executionState.lastAction = undefined;
+        // Reset repetition tracking to avoid false "stuck in loop" detection.
+        executionState.actionRepeatCount = 0;
+        executionState.lastAction = undefined;
 
-    // Refresh page state from the newly navigated browser.
-    await this.updatePageState();
+        // Refresh page state from the newly navigated browser.
+        await this.updatePageState();
 
-    const browserAny = this.browser as any;
-    const endpointIndex: number = browserAny.nextStartIndex ?? 0;
-    const total: number = browserAny.pwCdpEndpoints?.length ?? 0;
+        const browserAny = this.browser as any;
+        const endpointIndex: number = browserAny.nextStartIndex ?? 0;
+        const total: number = browserAny.pwCdpEndpoints?.length ?? 0;
 
-    const data: Omit<BrowserReconnectedEventData, "timestamp" | "iterationId"> = {
-      startingUrl: this.url ?? "",
-      endpointIndex,
-      total,
-    };
-    this.emit(WebAgentEventType.BROWSER_RECONNECTED, data);
+        span.setAttribute("pilo.cdp.endpoint_index", endpointIndex);
+        span.setAttribute("pilo.cdp.total", total);
+
+        const data: Omit<BrowserReconnectedEventData, "timestamp" | "iterationId"> = {
+          startingUrl: this.url ?? "",
+          endpointIndex,
+          total,
+        };
+        this.emit(WebAgentEventType.BROWSER_RECONNECTED, data);
+      } catch (reconnectError) {
+        span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message:
+            reconnectError instanceof Error ? reconnectError.message : String(reconnectError),
+        });
+        span.recordException(
+          reconnectError instanceof Error ? reconnectError : new Error(String(reconnectError)),
+        );
+        throw reconnectError;
+      }
+    });
   }
 
   private emit(type: WebAgentEventType, data: any): void {

--- a/packages/core/test/telemetry/tracing.test.ts
+++ b/packages/core/test/telemetry/tracing.test.ts
@@ -229,4 +229,82 @@ describe("tracing helpers", () => {
       });
     });
   });
+
+  describe("withRemoteContext", () => {
+    describe("when @opentelemetry/api is NOT installed", () => {
+      beforeEach(() => {
+        vi.doMock("@opentelemetry/api", () => {
+          throw new Error("Cannot find module '@opentelemetry/api'");
+        });
+      });
+
+      it("runs the callback directly", async () => {
+        const { withRemoteContext } = await import("../../src/telemetry/tracing.js");
+        const result = await withRemoteContext({ traceparent: "00-abc-def-01" }, async () => 99);
+        expect(result).toBe(99);
+      });
+    });
+
+    describe("when @opentelemetry/api IS installed", () => {
+      it("extracts context from headers and runs callback within it", async () => {
+        const mockExtractedCtx = { extracted: true };
+        const mockExtract = vi.fn(() => mockExtractedCtx);
+        const mockWithContext = vi.fn((_ctx: any, fn: any) => fn());
+
+        vi.doMock("@opentelemetry/api", () => ({
+          trace: {
+            getTracer: () => ({ startSpan: vi.fn() }),
+          },
+          context: {
+            active: vi.fn(() => ({})),
+            with: mockWithContext,
+          },
+          propagation: {
+            extract: mockExtract,
+          },
+        }));
+
+        const { withRemoteContext } = await import("../../src/telemetry/tracing.js");
+        const result = await withRemoteContext(
+          { traceparent: "00-abc-def-01", tracestate: "vendor=value" },
+          async () => "traced",
+        );
+
+        expect(result).toBe("traced");
+        expect(mockExtract).toHaveBeenCalledWith(expect.anything(), {
+          traceparent: "00-abc-def-01",
+          tracestate: "vendor=value",
+        });
+        expect(mockWithContext).toHaveBeenCalledWith(mockExtractedCtx, expect.any(Function));
+      });
+
+      it("filters out undefined header values", async () => {
+        const mockExtract = vi.fn(() => ({}));
+
+        vi.doMock("@opentelemetry/api", () => ({
+          trace: {
+            getTracer: () => ({ startSpan: vi.fn() }),
+          },
+          context: {
+            active: vi.fn(() => ({})),
+            with: vi.fn((_ctx: any, fn: any) => fn()),
+          },
+          propagation: {
+            extract: mockExtract,
+          },
+        }));
+
+        const { withRemoteContext } = await import("../../src/telemetry/tracing.js");
+        await withRemoteContext(
+          { traceparent: "00-abc-def-01", tracestate: undefined },
+          async () => {},
+        );
+
+        // Only defined values in the carrier
+        const carrier = mockExtract.mock.calls[0][1];
+        expect(carrier).toEqual({ traceparent: "00-abc-def-01" });
+        expect(carrier).not.toHaveProperty("tracestate");
+      });
+    });
+  });
 });

--- a/packages/core/test/telemetry/tracing.test.ts
+++ b/packages/core/test/telemetry/tracing.test.ts
@@ -301,7 +301,7 @@ describe("tracing helpers", () => {
         );
 
         // Only defined values in the carrier
-        const carrier = mockExtract.mock.calls[0][1];
+        const carrier = (mockExtract.mock.calls[0] as any[])[1];
         expect(carrier).toEqual({ traceparent: "00-abc-def-01" });
         expect(carrier).not.toHaveProperty("tracestate");
       });

--- a/packages/core/test/telemetry/tracing.test.ts
+++ b/packages/core/test/telemetry/tracing.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+describe("tracing helpers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  describe("when @opentelemetry/api is NOT installed", () => {
+    beforeEach(() => {
+      vi.doMock("@opentelemetry/api", () => {
+        throw new Error("Cannot find module '@opentelemetry/api'");
+      });
+    });
+
+    it("getOTelApi returns undefined", async () => {
+      const { getOTelApi } = await import("../../src/telemetry/tracing.js");
+      const api = await getOTelApi();
+      expect(api).toBeUndefined();
+    });
+
+    it("getTracer returns a no-op tracer", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test");
+      expect(tracer).toBeDefined();
+      expect(typeof tracer.startSpan).toBe("function");
+    });
+
+    it("no-op span methods are safe to call", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test");
+      const span = tracer.startSpan("my-span", {
+        attributes: { "test.attr": "value" },
+      });
+
+      expect(() => span.setAttribute("key", "value")).not.toThrow();
+      expect(() => span.setAttribute("key", 42)).not.toThrow();
+      expect(() => span.setAttribute("key", true)).not.toThrow();
+      expect(() => span.setStatus({ code: 1 })).not.toThrow();
+      expect(() => span.setStatus({ code: 2, message: "error" })).not.toThrow();
+      expect(() => span.recordException(new Error("oops"))).not.toThrow();
+      expect(() => span.recordException("string error")).not.toThrow();
+      expect(() => span.end()).not.toThrow();
+    });
+
+    it("no-op span setAttribute returns this for chaining", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test");
+      const span = tracer.startSpan("my-span");
+      const result = span.setAttribute("key", "value");
+      expect(result).toBe(span);
+    });
+
+    it("no-op span setStatus returns this for chaining", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test");
+      const span = tracer.startSpan("my-span");
+      const result = span.setStatus({ code: 0 });
+      expect(result).toBe(span);
+    });
+  });
+
+  describe("when @opentelemetry/api IS installed", () => {
+    beforeEach(() => {
+      vi.doUnmock("@opentelemetry/api");
+    });
+
+    it("getOTelApi returns the API module", async () => {
+      const { getOTelApi } = await import("../../src/telemetry/tracing.js");
+      const api = await getOTelApi();
+      // @opentelemetry/api is installed as a devDependency, so this should resolve
+      expect(api).toBeDefined();
+      expect(typeof api).toBe("object");
+    });
+
+    it("getTracer returns a real tracer", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test-tracer", "1.0.0");
+      expect(tracer).toBeDefined();
+      expect(typeof tracer.startSpan).toBe("function");
+    });
+  });
+
+  describe("SpanStatusCode constants", () => {
+    it("exports SpanStatusCode with OK=1 and ERROR=2", async () => {
+      const { SpanStatusCode } = await import("../../src/telemetry/tracing.js");
+      expect(SpanStatusCode.OK).toBe(1);
+      expect(SpanStatusCode.ERROR).toBe(2);
+    });
+
+    it("SpanStatusCode works without OTel installed", async () => {
+      vi.doMock("@opentelemetry/api", () => {
+        throw new Error("Cannot find module '@opentelemetry/api'");
+      });
+      const { SpanStatusCode } = await import("../../src/telemetry/tracing.js");
+      expect(SpanStatusCode.OK).toBe(1);
+      expect(SpanStatusCode.ERROR).toBe(2);
+    });
+  });
+
+  describe("caching", () => {
+    it("second call to getTracer returns same instance", async () => {
+      const { getTracer } = await import("../../src/telemetry/tracing.js");
+      const tracer1 = await getTracer("my-lib");
+      const tracer2 = await getTracer("my-lib");
+      expect(tracer1).toBe(tracer2);
+    });
+
+    it("second call to getOTelApi returns same result", async () => {
+      const { getOTelApi } = await import("../../src/telemetry/tracing.js");
+      const api1 = await getOTelApi();
+      const api2 = await getOTelApi();
+      expect(api1).toBe(api2);
+    });
+
+    it("does not retry after failed import", async () => {
+      let callCount = 0;
+      vi.doMock("@opentelemetry/api", () => {
+        callCount++;
+        throw new Error("Cannot find module '@opentelemetry/api'");
+      });
+
+      const { getOTelApi } = await import("../../src/telemetry/tracing.js");
+      await getOTelApi();
+      await getOTelApi();
+      await getOTelApi();
+
+      // Module resolution only attempted once (mocking intercepts the import)
+      expect(callCount).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe("withSpan", () => {
+    describe("when @opentelemetry/api is NOT installed", () => {
+      beforeEach(() => {
+        vi.doMock("@opentelemetry/api", () => {
+          throw new Error("Cannot find module '@opentelemetry/api'");
+        });
+      });
+
+      it("runs the callback with a no-op span", async () => {
+        const { withSpan } = await import("../../src/telemetry/tracing.js");
+        const result = await withSpan("test.span", {}, async (span) => {
+          span.setAttribute("key", "value"); // should not throw
+          return 42;
+        });
+        expect(result).toBe(42);
+      });
+
+      it("propagates errors from the callback", async () => {
+        const { withSpan } = await import("../../src/telemetry/tracing.js");
+        await expect(
+          withSpan("test.span", {}, async () => {
+            throw new Error("callback error");
+          }),
+        ).rejects.toThrow("callback error");
+      });
+    });
+
+    describe("when @opentelemetry/api IS installed", () => {
+      it("creates a span and ends it after callback completes", async () => {
+        const mockEnd = vi.fn();
+        const mockStartSpan = vi.fn(() => ({
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: vi.fn(),
+          end: mockEnd,
+        }));
+
+        const mockContext = {};
+        const mockWithContext = vi.fn((_ctx: any, fn: any) => fn());
+
+        vi.doMock("@opentelemetry/api", () => ({
+          trace: {
+            getTracer: () => ({ startSpan: mockStartSpan }),
+            setSpan: vi.fn(() => mockContext),
+          },
+          context: {
+            active: vi.fn(() => ({})),
+            with: mockWithContext,
+          },
+        }));
+
+        const { withSpan } = await import("../../src/telemetry/tracing.js");
+        const result = await withSpan(
+          "test.span",
+          { attributes: { "test.key": "val" } },
+          async (span) => {
+            span.setAttribute("extra", "attr");
+            return "done";
+          },
+        );
+
+        expect(result).toBe("done");
+        expect(mockStartSpan).toHaveBeenCalledWith("test.span", {
+          attributes: { "test.key": "val" },
+        });
+        expect(mockEnd).toHaveBeenCalled();
+        expect(mockWithContext).toHaveBeenCalled();
+      });
+
+      it("ends span even when callback throws", async () => {
+        const mockEnd = vi.fn();
+        const mockStartSpan = vi.fn(() => ({
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: vi.fn(),
+          end: mockEnd,
+        }));
+
+        vi.doMock("@opentelemetry/api", () => ({
+          trace: {
+            getTracer: () => ({ startSpan: mockStartSpan }),
+            setSpan: vi.fn(() => ({})),
+          },
+          context: {
+            active: vi.fn(() => ({})),
+            with: vi.fn((_ctx: any, fn: any) => fn()),
+          },
+        }));
+
+        const { withSpan } = await import("../../src/telemetry/tracing.js");
+        await expect(
+          withSpan("test.span", {}, async () => {
+            throw new Error("boom");
+          }),
+        ).rejects.toThrow("boom");
+
+        expect(mockEnd).toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -32,6 +32,13 @@
     "@hono/node-server": "^1.19.10",
     "@hono/node-ws": "^1.3.0",
     "@hono/sentry": "^1.2.2",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/exporter-metrics-otlp-proto": "^0.213.0",
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.213.0",
+    "@opentelemetry/resources": "^2.5.0",
+    "@opentelemetry/sdk-metrics": "^2.5.0",
+    "@opentelemetry/sdk-node": "^0.213.0",
+    "@opentelemetry/semantic-conventions": "^1.34.0",
     "dotenv": "^17.2.4",
     "hono": "^4.12.7",
     "pilo-core": "workspace:*"

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,9 @@
 import "dotenv/config";
+import { initTelemetry } from "./telemetry.js";
+
+// Initialize OTel SDK before app creation
+initTelemetry();
+
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";

--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -26,6 +26,7 @@ vi.mock("pilo-core", () => ({
   })),
   createNavigationRetryConfig: vi.fn(() => ({})),
   SEARCH_PROVIDERS: ["none", "duckduckgo", "google", "bing", "parallel-api"],
+  withRemoteContext: vi.fn((_headers: any, fn: any) => fn()),
 }));
 
 vi.mock("../../StreamLogger.js", () => ({
@@ -92,7 +93,9 @@ function createTestHarness() {
   } as unknown as WSContext;
 
   // Get the handlers for a new connection
-  const handlers = handlerFactory!(/* context */ {});
+  const handlers = handlerFactory!({
+    req: { header: () => undefined },
+  });
 
   function sendMessage(obj: any) {
     const evt = { data: JSON.stringify(obj) } as MessageEvent;

--- a/packages/server/src/routes/piloWs.ts
+++ b/packages/server/src/routes/piloWs.ts
@@ -19,6 +19,7 @@
 import { Hono } from "hono";
 import type { UpgradeWebSocket, WSContext } from "hono/ws";
 import type { UserDataCallback, UserDataResponse } from "pilo-core";
+import { withRemoteContext } from "pilo-core";
 import { runTask, validateTaskRequest, createErrorResponse, errorToString } from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
 
@@ -46,7 +47,14 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
 
   piloWs.get(
     "/run",
-    upgradeWebSocket((_c) => {
+    upgradeWebSocket((c) => {
+      // Capture W3C trace context headers from the WebSocket upgrade request
+      // so that task execution joins the caller's distributed trace.
+      const traceHeaders = {
+        traceparent: c.req.header("traceparent"),
+        tracestate: c.req.header("tracestate"),
+      };
+
       const abortController = new AbortController();
       const pendingRequests = new Map<string, PendingRequest>();
       let taskRunning = false;
@@ -103,17 +111,19 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               });
             };
 
-            // Run task asynchronously
+            // Run task asynchronously within the caller's trace context (if any).
             (async () => {
               try {
-                const result = await runTask({
-                  body,
-                  sendEvent: async (event, data) => {
-                    send(ws, event, data);
-                  },
-                  abortSignal: abortController.signal,
-                  onUserDataRequired,
-                });
+                const result = await withRemoteContext(traceHeaders, () =>
+                  runTask({
+                    body,
+                    sendEvent: async (event, data) => {
+                      send(ws, event, data);
+                    },
+                    abortSignal: abortController.signal,
+                    onUserDataRequired,
+                  }),
+                );
 
                 await send(ws, "complete", result);
               } catch (error) {

--- a/packages/server/src/telemetry.ts
+++ b/packages/server/src/telemetry.ts
@@ -1,0 +1,40 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+import { resourceFromAttributes } from "@opentelemetry/resources";
+import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
+
+export function initTelemetry(): (() => Promise<void>) | undefined {
+  if (!process.env.OTEL_EXPORTER_OTLP_ENDPOINT) {
+    return undefined;
+  }
+
+  const serviceName = process.env.OTEL_SERVICE_NAME || "pilo";
+  const metricIntervalMs = Number(process.env.OTEL_METRIC_EXPORT_INTERVAL) || 30_000;
+
+  const sdk = new NodeSDK({
+    resource: resourceFromAttributes({
+      [ATTR_SERVICE_NAME]: serviceName,
+    }),
+    traceExporter: new OTLPTraceExporter(),
+    metricReader: new PeriodicExportingMetricReader({
+      exporter: new OTLPMetricExporter(),
+      exportIntervalMillis: metricIntervalMs,
+    }),
+  });
+
+  sdk.start();
+  console.log(`[OTel] Telemetry enabled for ${serviceName}`);
+
+  const shutdown = async () => {
+    console.log("[OTel] Shutting down telemetry...");
+    await sdk.shutdown();
+  };
+
+  process.on("SIGTERM", () => {
+    shutdown().catch((err) => console.error("[OTel] Shutdown error:", err));
+  });
+
+  return shutdown;
+}

--- a/packages/server/test/telemetry.test.ts
+++ b/packages/server/test/telemetry.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+describe("server telemetry setup", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("does nothing when OTEL_EXPORTER_OTLP_ENDPOINT is not set", async () => {
+    delete process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+    const { initTelemetry } = await import("../src/telemetry.js");
+    const shutdown = initTelemetry();
+    expect(shutdown).toBeUndefined();
+  });
+
+  it("returns a shutdown function when OTEL_EXPORTER_OTLP_ENDPOINT is set", async () => {
+    process.env.OTEL_EXPORTER_OTLP_ENDPOINT = "http://localhost:4318";
+    process.env.OTEL_SERVICE_NAME = "test-pilo";
+
+    const { initTelemetry } = await import("../src/telemetry.js");
+    const shutdown = initTelemetry();
+    expect(shutdown).toBeTypeOf("function");
+
+    // Clean up - shutdown the SDK
+    if (shutdown) await shutdown();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/jsdom':
         specifier: ^28.0.0
         version: 28.0.0
@@ -253,7 +256,7 @@ importers:
         version: 0.12.5
       '@wxt-dev/webextension-polyfill':
         specifier: ^1.0.0
-        version: 1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -326,7 +329,7 @@ importers:
         version: 5.0.6
       '@wxt-dev/module-react':
         specifier: ^1.2.2
-        version: 1.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))
+        version: 1.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))
       happy-dom:
         specifier: ^20.8.9
         version: 20.8.9
@@ -341,7 +344,7 @@ importers:
         version: 4.1.2(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(happy-dom@20.8.9)(jsdom@29.0.1)(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       wxt:
         specifier: 0.20.20
-        version: 0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
 
   packages/server:
     dependencies:
@@ -354,6 +357,27 @@ importers:
       '@hono/sentry':
         specifier: ^1.2.2
         version: 1.2.2(hono@4.12.7)
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
+      '@opentelemetry/exporter-metrics-otlp-proto':
+        specifier: ^0.213.0
+        version: 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.213.0
+        version: 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources':
+        specifier: ^2.5.0
+        version: 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics':
+        specifier: ^2.5.0
+        version: 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-node':
+        specifier: ^0.213.0
+        version: 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions':
+        specifier: ^1.34.0
+        version: 1.40.0
       dotenv:
         specifier: ^17.2.4
         version: 17.3.1
@@ -776,10 +800,6 @@ packages:
     resolution: {integrity: sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint/config-array@0.21.1':
-    resolution: {integrity: sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/config-array@0.21.2':
     resolution: {integrity: sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -792,16 +812,8 @@ packages:
     resolution: {integrity: sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@3.3.4':
-    resolution: {integrity: sha512-4h4MVF8pmBsncB60r0wSJiIeUKTSD4m7FmTFThG8RHlsg9ajqckLm9OraguFGZE4vVdpiI1Q4+hFnisopmG6gQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
   '@eslint/eslintrc@3.3.5':
     resolution: {integrity: sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@eslint/js@9.39.2':
-    resolution: {integrity: sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@eslint/js@9.39.4':
@@ -870,6 +882,15 @@ packages:
 
   '@ghostery/url-parser@1.3.1':
     resolution: {integrity: sha512-QKqGi+7aDQ4RcyHyCwgEk6B9vWnsBP4Q7htaN0zPJV3ATqTKEQDtSTb9c/AN586oJUDs24YXKcwFYwNweY/YjQ==}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@hono/node-server@1.19.11':
     resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
@@ -1059,6 +1080,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@mdn/browser-compat-data@7.3.9':
     resolution: {integrity: sha512-ARxwDFfq4uhRSd9Wr1FMaxeKKIFDPyMnSoLe/8WX+nNXbKDILf1H8KDJW9nzu2QTR0hQ37jDCzAgyaNYdLzACQ==}
 
@@ -1072,9 +1096,191 @@ packages:
       ai: ^6.0.0
       zod: ^3.25.0 || ^4.0.0
 
+  '@opentelemetry/api-logs@0.213.0':
+    resolution: {integrity: sha512-zRM5/Qj6G84Ej3F1yt33xBVY/3tnMxtL1fiDIxYbDWYaZ/eudVw3/PBiZ8G7JwUxXxjW8gU4g6LnOyfGKYHYgw==}
+    engines: {node: '>=8.0.0'}
+
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/configuration@0.213.0':
+    resolution: {integrity: sha512-MfVgZiUuwL1d3bPPvXcEkVHGTGNUGoqGK97lfwBuRoKttcVGGqDyxTCCVa5MGbirtBQkUTysXMBUVWPaq7zbWw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+
+  '@opentelemetry/context-async-hooks@2.6.0':
+    resolution: {integrity: sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.0':
+    resolution: {integrity: sha512-HLM1v2cbZ4TgYN6KEOj+Bbj8rAKriOdkF9Ed3tG25FoprSiQl7kYc+RRT6fUZGOvx0oMi5U67GoFdT+XUn8zEg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/core@2.6.1':
+    resolution: {integrity: sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.213.0':
+    resolution: {integrity: sha512-QiRZzvayEOFnenSXi85Eorgy5WTqyNQ+E7gjl6P6r+W3IUIwAIH8A9/BgMWfP056LwmdrBL6+qvnwaIEmug6Yg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-http@0.213.0':
+    resolution: {integrity: sha512-vqDVSpLp09ZzcFIdb7QZrEFPxUlO3GzdhBKLstq3jhYB5ow3+ZtV5V0ngSdi/0BZs+J5WPiN1+UDV4X5zD/GzA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.213.0':
+    resolution: {integrity: sha512-gQk41nqfK3KhDk8jbSo3LR/fQBlV7f6Q5xRcfDmL1hZlbgXQPdVFV9/rIfYUrCoq1OM+2NnKnFfGjBt6QpLSsA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.213.0':
+    resolution: {integrity: sha512-Z8gYKUAU48qwm+a1tjnGv9xbE7a5lukVIwgF6Z5i3VPXPVMe4Sjra0nN3zU7m277h+V+ZpsPGZJ2Xf0OTkL7/w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.213.0':
+    resolution: {integrity: sha512-yw3fTIw4KQIRXC/ZyYQq5gtA3Ogfdfz/g5HVgleobQAcjUUE8Nj3spGMx8iQPp+S+u6/js7BixufRkXhzLmpJA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.213.0':
+    resolution: {integrity: sha512-geHF+zZaDb0/WRkJTxR8o8dG4fCWT/Wq7HBdNZCxwH5mxhwRi/5f37IDYH7nvU+dwU6IeY4Pg8TPI435JCiNkg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-prometheus@0.213.0':
+    resolution: {integrity: sha512-FyV3/JfKGAgx+zJUwCHdjQHbs+YeGd2fOWvBHYrW6dmfv/w89lb8WhJTSZEoWgP525jwv/gFeBttlGu1flebdA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.213.0':
+    resolution: {integrity: sha512-L8y6piP4jBIIx1Nv7/9hkx25ql6/Cro/kQrs+f9e8bPF0Ar5Dm991v7PnbtubKz6Q4fT872H56QXUWVnz/Cs4Q==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-http@0.213.0':
+    resolution: {integrity: sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.213.0':
+    resolution: {integrity: sha512-six3vPq3sL+ge1iZOfKEg+RHuFQhGb8ZTdlvD234w/0gi8ty/qKD46qoGpKvM3amy5yYunWBKiFBW47WaVS26w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/exporter-zipkin@2.6.0':
+    resolution: {integrity: sha512-AFP77OQMLfw/Jzh6WT2PtrywstNjdoyT9t9lYrYdk1s4igsvnMZ8DkZKCwxsItC01D+4Lydgrb+Wy0bAvpp8xg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/instrumentation@0.213.0':
+    resolution: {integrity: sha512-3i9NdkET/KvQomeh7UaR/F4r9P25Rx6ooALlWXPIjypcEOUxksCmVu0zA70NBJWlrMW1rPr/LRidFAflLI+s/w==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-exporter-base@0.213.0':
+    resolution: {integrity: sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.213.0':
+    resolution: {integrity: sha512-XgRGuLE9usFNlnw2lgMIM4HTwpcIyjdU/xPoJ8v3LbBLBfjaDkIugjc9HoWa7ZSJ/9Bhzgvm/aD0bGdYUFgnTw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/otlp-transformer@0.213.0':
+    resolution: {integrity: sha512-RSuAlxFFPjeK4d5Y6ps8L2WhaQI6CXWllIjvo5nkAlBpmq2XdYWEBGiAbOF4nDs8CX4QblJDv5BbMUft3sEfDw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/propagator-b3@2.6.0':
+    resolution: {integrity: sha512-SguK4jMmRvQ0c0dxAMl6K+Eu1+01X0OP7RLiIuHFjOS8hlB23ZYNnhnbAdSQEh5xVXQmH0OAS0TnmVI+6vB2Kg==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/propagator-jaeger@2.6.0':
+    resolution: {integrity: sha512-KGWJuvp9X8X36bhHgIhWEnHAzXDInFr+Fvo9IQhhuu6pXLT8mF7HzFyx/X+auZUITvPaZhM39Phj3vK12MbhwA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@2.6.0':
+    resolution: {integrity: sha512-D4y/+OGe3JSuYUCBxtH5T9DSAWNcvCb/nQWIga8HNtXTVPQn59j0nTBAgaAXxUVBDl40mG3Tc76b46wPlZaiJQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/resources@2.6.1':
+    resolution: {integrity: sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-logs@0.213.0':
+    resolution: {integrity: sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.6.0':
+    resolution: {integrity: sha512-CicxWZxX6z35HR83jl+PLgtFgUrKRQ9LCXyxgenMnz5A1lgYWfAog7VtdOvGkJYyQgMNPhXQwkYrDLujk7z1Iw==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@2.6.1':
+    resolution: {integrity: sha512-9t9hJHX15meBy2NmTJxL+NJfXmnausR2xUDvE19XQce0Qi/GBtDGamU8nS1RMbdgDmhgpm3VaOu2+fiS/SfTpQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.9.0 <1.10.0'
+
+  '@opentelemetry/sdk-node@0.213.0':
+    resolution: {integrity: sha512-8s7SQtY8DIAjraXFrUf0+I90SBAUQbsMWMtUGKmusswRHWXtKJx42aJQMoxEtC82Csqj+IlBH6FoP8XmmUDSrQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@2.6.0':
+    resolution: {integrity: sha512-g/OZVkqlxllgFM7qMKqbPV9c1DUPhQ7d4n3pgZFcrnrNft9eJXZM2TNHTPYREJBrtNdRytYyvwjgL5geDKl3EQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-node@2.6.0':
+    resolution: {integrity: sha512-YhswtasmsbIGEFvLGvR9p/y3PVRTfFf+mgY8van4Ygpnv4sA3vooAjvh+qAn9PNWxs4/IwGGqiQS0PPsaRJ0vQ==}
+    engines: {node: ^18.19.0 || >=20.6.0}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.40.0':
+    resolution: {integrity: sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==}
+    engines: {node: '>=14'}
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
@@ -1099,6 +1305,36 @@ packages:
   '@pnpm/npm-conf@3.0.2':
     resolution: {integrity: sha512-h104Kh26rR8tm+a3Qkc5S4VLYint3FE48as7+/5oCEcKR2idC/pF1G6AhIXKI+eHPJa/3J9i5z0Al47IeGHPkA==}
     engines: {node: '>=12'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2009,6 +2245,11 @@ packages:
       webextension-polyfill: '*'
       wxt: '>=0.20.0'
 
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2262,6 +2503,9 @@ packages:
 
   citty@0.2.1:
     resolution: {integrity: sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==}
+
+  cjs-module-lexer@2.2.0:
+    resolution: {integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -2599,16 +2843,6 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@9.39.2:
-    resolution: {integrity: sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2914,6 +3148,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  import-in-the-middle@3.0.1:
+    resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
+    engines: {node: '>=18'}
 
   import-meta-resolve@4.2.0:
     resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
@@ -3277,6 +3515,9 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -3304,6 +3545,9 @@ packages:
   log-update@7.1.0:
     resolution: {integrity: sha512-y9pi/ZOQQVvTgfRDEHV1Cj4zQUkJZPipEUNOxhn1R6KgmdMs7LKvXWCd9eMVPGJgvYzFLCenecWr0Ps8ChVv2A==}
     engines: {node: '>=20'}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -3387,6 +3631,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  module-details-from-path@1.0.4:
+    resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -3676,6 +3923,10 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   publish-browser-extension@4.0.4:
     resolution: {integrity: sha512-QMQbWL0FWgBfnkJ6w8HOJoIPaWLE7vTpewM4ae2vLs7SrD4eKdAk+SxOzqAICwbhEPuaLAOA+XkT9sZS5R0PmA==}
     engines: {node: '>=18.0.0'}
@@ -3782,6 +4033,10 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  require-in-the-middle@8.0.1:
+    resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
+    engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -4852,27 +5107,12 @@ snapshots:
   '@esbuild/win32-x64@0.27.4':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.2(jiti@2.6.1))':
-    dependencies:
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-    optional: true
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.6.1))':
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
-
-  '@eslint/config-array@0.21.1':
-    dependencies:
-      '@eslint/object-schema': 2.1.7
-      debug: 4.4.3
-      minimatch: 3.1.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   '@eslint/config-array@0.21.2':
     dependencies:
@@ -4890,21 +5130,6 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.4':
-    dependencies:
-      ajv: 6.14.0
-      debug: 4.4.3
-      espree: 10.4.0
-      globals: 14.0.0
-      ignore: 5.3.2
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      minimatch: 3.1.3
-      strip-json-comments: 3.1.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
@@ -4918,9 +5143,6 @@ snapshots:
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
-
-  '@eslint/js@9.39.2':
-    optional: true
 
   '@eslint/js@9.39.4': {}
 
@@ -4984,6 +5206,18 @@ snapshots:
   '@ghostery/url-parser@1.3.1':
     dependencies:
       tldts-experimental: 7.0.25
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
 
   '@hono/node-server@1.19.11(hono@4.12.7)':
     dependencies:
@@ -5161,6 +5395,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@mdn/browser-compat-data@7.3.9': {}
 
   '@mixmark-io/domino@2.2.0': {}
@@ -5170,7 +5406,259 @@ snapshots:
       ai: 6.0.142(zod@4.3.6)
       zod: 4.3.6
 
+  '@opentelemetry/api-logs@0.213.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
   '@opentelemetry/api@1.9.0': {}
+
+  '@opentelemetry/configuration@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      yaml: 2.8.3
+
+  '@opentelemetry/context-async-hooks@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+
+  '@opentelemetry/core@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-logs-otlp-grpc@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-http@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-logs-otlp-proto@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-grpc@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-http@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-metrics-otlp-proto@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-prometheus@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/exporter-trace-otlp-grpc@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-grpc-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/exporter-zipkin@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/instrumentation@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      import-in-the-middle: 3.0.1
+      require-in-the-middle: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/otlp-exporter-base@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-grpc-exporter-base@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-exporter-base': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/otlp-transformer': 0.213.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/otlp-transformer@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/propagator-b3@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/propagator-jaeger@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/resources@2.6.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/sdk-node@0.213.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.213.0
+      '@opentelemetry/configuration': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-grpc': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-grpc': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-metrics-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-prometheus': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-grpc': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-http': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-trace-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-zipkin': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-b3': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/propagator-jaeger': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/semantic-conventions': 1.40.0
+
+  '@opentelemetry/sdk-trace-node@2.6.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/context-async-hooks': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.0)
+
+  '@opentelemetry/semantic-conventions@1.40.0': {}
 
   '@pinojs/redact@0.4.0': {}
 
@@ -5192,6 +5680,29 @@ snapshots:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -5776,7 +6287,7 @@ snapshots:
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -5975,11 +6486,11 @@ snapshots:
       '@types/filesystem': 0.0.36
       '@types/har-format': 1.2.16
 
-  '@wxt-dev/module-react@1.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@wxt-dev/module-react@1.2.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@vitejs/plugin-react': 5.1.2(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3))
       vite: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
-      wxt: 0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
+      wxt: 0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -5989,10 +6500,14 @@ snapshots:
       async-mutex: 0.5.0
       dequal: 2.0.3
 
-  '@wxt-dev/webextension-polyfill@1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@wxt-dev/webextension-polyfill@1.0.0(webextension-polyfill@0.12.0)(wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       webextension-polyfill: 0.12.0
-      wxt: 0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
+      wxt: 0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3)
+
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -6277,6 +6792,8 @@ snapshots:
       consola: 3.4.2
 
   citty@0.2.1: {}
+
+  cjs-module-lexer@2.2.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -6575,48 +7092,6 @@ snapshots:
   eslint-visitor-keys@4.2.1: {}
 
   eslint-visitor-keys@5.0.1: {}
-
-  eslint@9.39.2(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.2(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.1
-      '@eslint/config-helpers': 0.4.2
-      '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.4
-      '@eslint/js': 9.39.2
-      '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.8
-      ajv: 6.14.0
-      chalk: 4.1.2
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 8.4.0
-      eslint-visitor-keys: 4.2.1
-      espree: 10.4.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      lodash.merge: 4.6.2
-      minimatch: 3.1.3
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
 
   eslint@9.39.4(jiti@2.6.1):
     dependencies:
@@ -6953,6 +7428,13 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-in-the-middle@3.0.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      cjs-module-lexer: 2.2.0
+      module-details-from-path: 1.0.4
+
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
@@ -7274,6 +7756,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.includes@4.3.0: {}
 
   lodash.isboolean@3.0.3: {}
@@ -7297,6 +7781,8 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
+
+  long@5.3.2: {}
 
   lru-cache@10.4.3: {}
 
@@ -7372,6 +7858,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  module-details-from-path@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -7669,6 +8157,21 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 25.5.0
+      long: 5.3.2
+
   publish-browser-extension@4.0.4:
     dependencies:
       cac: 6.7.14
@@ -7773,6 +8276,13 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  require-in-the-middle@8.0.1:
+    dependencies:
+      debug: 4.4.3
+      module-details-from-path: 1.0.4
+    transitivePeerDependencies:
+      - supports-color
 
   resolve-from@4.0.0: {}
 
@@ -8471,7 +8981,7 @@ snapshots:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0
 
-  wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.2(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3):
+  wxt@0.20.20(@types/node@25.5.0)(eslint@9.39.4(jiti@2.6.1))(jiti@2.6.1)(lightningcss@1.31.1)(rollup@4.59.0)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       '@1natsu/wait-element': 4.1.2
       '@aklinker1/rollup-plugin-visualizer': 5.12.0(rollup@4.59.0)
@@ -8518,7 +9028,7 @@ snapshots:
       vite-node: 5.3.0(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)(yaml@2.8.3)
       web-ext-run: 0.2.4
     optionalDependencies:
-      eslint: 9.39.2(jiti@2.6.1)
+      eslint: 9.39.4(jiti@2.6.1)
     transitivePeerDependencies:
       - '@types/node'
       - canvas


### PR DESCRIPTION
## Description
Adds distributed tracing support to pilo using OpenTelemetry. All 13 span sites use a withSpan helper that automatically creates parent-child relationships via OTel context propagation, producing connected trace hierarchies in backends like Jaeger, Datadog, or Google Cloud Trace.

Key changes:
- Add withSpan/withRemoteContext helpers with no-op fallback
- Instrument WebAgent (execute, plan, step, validate, reconnect)
- Instrument PlaywrightBrowser (navigate, snapshot, screenshot, perform)
- Instrument tools (browser actions, search) and retry logic
- Add server-side OTel SDK initialization (env-var driven)
- Extract W3C traceparent from WebSocket upgrade for distributed tracing
- @opentelemetry/api is an optional peer dep — zero overhead when absent

## PR Type

<!-- Delete the types that don't apply -->

- New Feature

## Related issues

<!-- e.g. "Fixes #123" or "Related to #456" -->

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`)
- [x] I have added tests that prove my fix/feature works (if applicable)
- [x] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

<!-- We welcome the use of AI to aid in contribution! Please indicate your AI usage below. -->

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

<!-- Optional: What LLM and tooling did you use? (e.g., Claude with Claude Code, GPT-4 with Copilot) -->
