### PR TITLE
A2: add sanitized error classification fields (additive)

### DIFF
--- a/packages/server/src/routes/pilo.test.ts
+++ b/packages/server/src/routes/pilo.test.ts
@@ -4,6 +4,7 @@ import piloRoutes from "./pilo.js";
 
 // Mock the pilo library
 vi.mock("pilo-core", () => ({
+  RecoverableError: class extends Error {},
   WebAgent: vi.fn().mockImplementation(() => ({
     execute: vi.fn().mockResolvedValue({
       success: true,
@@ -88,7 +89,7 @@ describe("Pilo Routes", () => {
       delete process.env.OPENAI_API_KEY;
     });
 
-    it("should reject requests without task", async () => {
+    it("should reject requests without task with new error shape", async () => {
       const res = await app.request("/pilo/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -98,13 +99,15 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toBe("Task is required");
       expect(data.error.code).toBe("MISSING_TASK");
-      expect(data.error.timestamp).toBeDefined();
+      expect(data.error.reason).toBe("INVALID_REQUEST");
+      expect(data.error.phase).toBe("setup");
+      expect(data.error.at).toBeDefined();
+      expect(data.error.message).toBeUndefined();
+      expect(data.error.timestamp).toBeUndefined();
     });
 
-    it("should reject requests without OpenAI API key", async () => {
-      // Mock getAIProviderInfo to throw an error for missing API key
+    it("should reject requests without OpenAI API key with new error shape", async () => {
       const { getAIProviderInfo } = await import("pilo-core");
       vi.mocked(getAIProviderInfo).mockImplementation(() => {
         throw new Error(
@@ -121,9 +124,10 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toBe("AI provider not configured: Error");
       expect(data.error.code).toBe("MISSING_API_KEY");
-      expect(data.error.timestamp).toBeDefined();
+      expect(data.error.reason).toBe("PROVIDER_UNAUTHORIZED");
+      expect(data.error.phase).toBe("setup");
+      expect(data.error.message).toBeUndefined();
     });
 
     it("should return SSE headers for valid request", async () => {
@@ -169,7 +173,7 @@ describe("Pilo Routes", () => {
       expect(res.headers.get("Content-Type")).toBe("text/event-stream");
     });
 
-    it("should handle malformed JSON", async () => {
+    it("should handle malformed JSON with new error shape", async () => {
       const res = await app.request("/pilo/run", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -179,9 +183,33 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
-      expect(data.error.message).toBe("SyntaxError");
+      expect(data.error.class).toBe("SyntaxError");
       expect(data.error.code).toBe("TASK_SETUP_FAILED");
-      expect(data.error.timestamp).toBeDefined();
+      expect(data.error.reason).toBe("INVALID_REQUEST");
+      expect(data.error.phase).toBe("setup");
+      expect(data.error.at).toBeDefined();
+      expect(data.error.message).toBeUndefined();
+      expect(data.error.timestamp).toBeUndefined();
+    });
+
+    it("should never include error.message in any response body", async () => {
+      // Hit several error paths and confirm 'message' is never present
+      const responses = await Promise.all([
+        app.request("/pilo/run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        }),
+        app.request("/pilo/run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "invalid json",
+        }),
+      ]);
+      for (const res of responses) {
+        const data = await res.json();
+        expect(data.error.message).toBeUndefined();
+      }
     });
 
     it("should return readable stream for SSE", async () => {

--- a/packages/server/src/routes/pilo.test.ts
+++ b/packages/server/src/routes/pilo.test.ts
@@ -99,12 +99,11 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(400);
       const data = await res.json();
       expect(data.success).toBe(false);
+      expect(data.error.message).toBe("Task is required");
       expect(data.error.code).toBe("MISSING_TASK");
       expect(data.error.reason).toBe("INVALID_REQUEST");
       expect(data.error.phase).toBe("setup");
-      expect(data.error.at).toBeDefined();
-      expect(data.error.message).toBeUndefined();
-      expect(data.error.timestamp).toBeUndefined();
+      expect(data.error.timestamp).toBeDefined();
     });
 
     it("should reject requests without OpenAI API key with new error shape", async () => {
@@ -124,10 +123,12 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
+      expect(data.error.message).toBe("AI provider is not configured.");
       expect(data.error.code).toBe("MISSING_API_KEY");
       expect(data.error.reason).toBe("PROVIDER_UNAUTHORIZED");
       expect(data.error.phase).toBe("setup");
-      expect(data.error.message).toBeUndefined();
+      // Must not leak the original dynamic message from pilo-core
+      expect(data.error.message).not.toContain("OPENAI_API_KEY");
     });
 
     it("should return SSE headers for valid request", async () => {
@@ -183,33 +184,12 @@ describe("Pilo Routes", () => {
       expect(res.status).toBe(500);
       const data = await res.json();
       expect(data.success).toBe(false);
+      expect(data.error.message).toBe("Failed to parse request body.");
       expect(data.error.class).toBe("SyntaxError");
       expect(data.error.code).toBe("TASK_SETUP_FAILED");
       expect(data.error.reason).toBe("INVALID_REQUEST");
       expect(data.error.phase).toBe("setup");
-      expect(data.error.at).toBeDefined();
-      expect(data.error.message).toBeUndefined();
-      expect(data.error.timestamp).toBeUndefined();
-    });
-
-    it("should never include error.message in any response body", async () => {
-      // Hit several error paths and confirm 'message' is never present
-      const responses = await Promise.all([
-        app.request("/pilo/run", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({}),
-        }),
-        app.request("/pilo/run", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: "invalid json",
-        }),
-      ]);
-      for (const res of responses) {
-        const data = await res.json();
-        expect(data.error.message).toBeUndefined();
-      }
+      expect(data.error.timestamp).toBeDefined();
     });
 
     it("should return readable stream for SSE", async () => {

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -1,7 +1,12 @@
 import { randomUUID } from "node:crypto";
 import { Hono } from "hono";
 import { streamSSE } from "hono/streaming";
-import { runTask, validateTaskRequest, createErrorResponse, errorToString } from "../taskRunner.js";
+import {
+  runTask,
+  validateTaskRequest,
+  createErrorResponse,
+  errorResponseFromError,
+} from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
 
 const pilo = new Hono();
@@ -66,7 +71,11 @@ pilo.post("/run", async (c) => {
           await stream.writeSSE({
             event: "error",
             data: JSON.stringify(
-              createErrorResponse(errorToString(error), "TASK_EXECUTION_FAILED", taskId),
+              errorResponseFromError(error, {
+                code: "TASK_EXECUTION_FAILED",
+                phase: "execution",
+                taskId,
+              }),
             ),
           });
         }
@@ -74,7 +83,16 @@ pilo.post("/run", async (c) => {
     });
   } catch (error) {
     console.error("Pilo task setup failed:", error);
-    return c.json(createErrorResponse(errorToString(error), "TASK_SETUP_FAILED", taskId), 500);
+    return c.json(
+      createErrorResponse({
+        class: error instanceof Error ? error.constructor.name : "Unknown",
+        code: "TASK_SETUP_FAILED",
+        reason: "INVALID_REQUEST",
+        phase: "setup",
+        taskId,
+      }),
+      500,
+    );
   }
 });
 

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -85,6 +85,7 @@ pilo.post("/run", async (c) => {
     console.error("Pilo task setup failed:", error);
     return c.json(
       createErrorResponse({
+        message: "Failed to parse request body.",
         class: error instanceof Error ? error.constructor.name : "Unknown",
         code: "TASK_SETUP_FAILED",
         reason: "INVALID_REQUEST",

--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -39,16 +39,40 @@ const mockValidateTaskRequest = vi.fn().mockReturnValue(null);
 vi.mock("../taskRunner.js", () => ({
   runTask: (...args: any[]) => mockRunTask(...args),
   validateTaskRequest: (...args: any[]) => mockValidateTaskRequest(...args),
-  createErrorResponse: (message: string, code: string, taskId?: string) => ({
+  createErrorResponse: (params: {
+    class?: string;
+    code: string;
+    reason: string;
+    recoverable?: boolean;
+    phase?: string;
+    taskId?: string;
+  }) => ({
     success: false,
     error: {
-      message,
-      code,
-      timestamp: new Date().toISOString(),
-      ...(taskId !== undefined && { taskId }),
+      class: params.class ?? "Error",
+      code: params.code,
+      reason: params.reason,
+      recoverable: params.recoverable ?? false,
+      ...(params.phase && { phase: params.phase }),
+      at: new Date().toISOString(),
+      ...(params.taskId && { taskId: params.taskId }),
     },
   }),
-  errorToString: (error: unknown) => (error instanceof Error ? error.name : "Unknown error"),
+  errorResponseFromError: (
+    error: unknown,
+    opts: { code: string; phase: string; taskId?: string },
+  ) => ({
+    success: false,
+    error: {
+      class: error instanceof Error ? error.constructor.name : "Unknown",
+      code: opts.code,
+      reason: "INTERNAL_ERROR",
+      recoverable: false,
+      phase: opts.phase,
+      at: new Date().toISOString(),
+      ...(opts.taskId && { taskId: opts.taskId }),
+    },
+  }),
 }));
 
 import { createPiloWsRoute } from "./piloWs.js";
@@ -171,7 +195,7 @@ describe("piloWs", () => {
       expect(h.sentMessages).toHaveLength(1);
       expect(h.sentMessages[0].event).toBe("error");
       expect(h.sentMessages[0].data.error.code).toBe("UNKNOWN_EVENT");
-      expect(h.sentMessages[0].data.error.message).toContain("unknown_event");
+      expect(h.sentMessages[0].data.error.reason).toBe("INVALID_REQUEST");
     });
   });
 
@@ -227,7 +251,7 @@ describe("piloWs", () => {
       expect(h.closeReason).toBe("Task finished");
     });
 
-    it("should send error event when task throws", async () => {
+    it("should send error event with new shape when task throws", async () => {
       mockRunTask.mockRejectedValue(new TypeError("something broke"));
 
       const h = createTestHarness();
@@ -237,7 +261,22 @@ describe("piloWs", () => {
       const errorMsg = h.sentMessages.find((m) => m.event === "error");
       expect(errorMsg).toBeDefined();
       expect(errorMsg!.data.error.code).toBe("TASK_EXECUTION_FAILED");
-      expect(errorMsg!.data.error.message).toBe("TypeError");
+      expect(errorMsg!.data.error.class).toBe("TypeError");
+      expect(errorMsg!.data.error.phase).toBe("execution");
+      expect(errorMsg!.data.error.message).toBeUndefined();
+    });
+
+    it("should never leak error.message into WS error event", async () => {
+      mockRunTask.mockRejectedValue(new Error("SENSITIVE: task data was fill-form-with-ssn"));
+
+      const h = createTestHarness();
+      h.sendMessage({ event: "task:details", data: { task: "test" } });
+      await vi.runAllTimersAsync();
+
+      const errorMsg = h.sentMessages.find((m) => m.event === "error");
+      const json = JSON.stringify(errorMsg);
+      expect(json).not.toContain("SENSITIVE");
+      expect(json).not.toContain("fill-form-with-ssn");
     });
 
     it("should close WebSocket after task error", async () => {
@@ -371,7 +410,7 @@ describe("piloWs", () => {
 
       expect(h.sentMessages).toHaveLength(1);
       expect(h.sentMessages[0].data.error.code).toBe("UNKNOWN_REQUEST_ID");
-      expect(h.sentMessages[0].data.error.message).toContain("nonexistent");
+      expect(h.sentMessages[0].data.error.reason).toBe("INVALID_REQUEST");
     });
 
     it("should resolve a pending request when matched", async () => {

--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -40,6 +40,7 @@ vi.mock("../taskRunner.js", () => ({
   runTask: (...args: any[]) => mockRunTask(...args),
   validateTaskRequest: (...args: any[]) => mockValidateTaskRequest(...args),
   createErrorResponse: (params: {
+    message: string;
     class?: string;
     code: string;
     reason: string;
@@ -49,12 +50,13 @@ vi.mock("../taskRunner.js", () => ({
   }) => ({
     success: false,
     error: {
-      class: params.class ?? "Error",
+      message: params.message,
       code: params.code,
+      timestamp: new Date().toISOString(),
+      class: params.class ?? "Error",
       reason: params.reason,
       recoverable: params.recoverable ?? false,
       ...(params.phase && { phase: params.phase }),
-      at: new Date().toISOString(),
       ...(params.taskId && { taskId: params.taskId }),
     },
   }),
@@ -64,12 +66,13 @@ vi.mock("../taskRunner.js", () => ({
   ) => ({
     success: false,
     error: {
-      class: error instanceof Error ? error.constructor.name : "Unknown",
+      message: "The task failed due to an internal error.",
       code: opts.code,
+      timestamp: new Date().toISOString(),
+      class: error instanceof Error ? error.constructor.name : "Unknown",
       reason: "INTERNAL_ERROR",
       recoverable: false,
       phase: opts.phase,
-      at: new Date().toISOString(),
       ...(opts.taskId && { taskId: opts.taskId }),
     },
   }),
@@ -263,7 +266,9 @@ describe("piloWs", () => {
       expect(errorMsg!.data.error.code).toBe("TASK_EXECUTION_FAILED");
       expect(errorMsg!.data.error.class).toBe("TypeError");
       expect(errorMsg!.data.error.phase).toBe("execution");
-      expect(errorMsg!.data.error.message).toBeUndefined();
+      expect(errorMsg!.data.error.message).toBeDefined();
+      // Message is server-controlled, never forwards the thrown value's message
+      expect(errorMsg!.data.error.message).not.toContain("something broke");
     });
 
     it("should never leak error.message into WS error event", async () => {

--- a/packages/server/src/routes/piloWs.ts
+++ b/packages/server/src/routes/piloWs.ts
@@ -21,7 +21,12 @@ import { Hono } from "hono";
 import type { UpgradeWebSocket, WSContext } from "hono/ws";
 import type { UserDataCallback, UserDataResponse } from "pilo-core";
 import { withRemoteContext } from "pilo-core";
-import { runTask, validateTaskRequest, createErrorResponse, errorToString } from "../taskRunner.js";
+import {
+  runTask,
+  validateTaskRequest,
+  createErrorResponse,
+  errorResponseFromError,
+} from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
 
 /** Default timeout for waiting on a user data response (5 minutes). */
@@ -66,7 +71,15 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
           try {
             msg = JSON.parse(typeof evt.data === "string" ? evt.data : String(evt.data));
           } catch {
-            send(ws, "error", createErrorResponse("Invalid JSON message", "INVALID_MESSAGE"));
+            send(
+              ws,
+              "error",
+              createErrorResponse({
+                code: "INVALID_MESSAGE",
+                reason: "INVALID_REQUEST",
+                phase: "setup",
+              }),
+            );
             return;
           }
 
@@ -75,10 +88,11 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               send(
                 ws,
                 "error",
-                createErrorResponse(
-                  "A task is already running on this connection",
-                  "TASK_ALREADY_RUNNING",
-                ),
+                createErrorResponse({
+                  code: "TASK_ALREADY_RUNNING",
+                  reason: "INVALID_REQUEST",
+                  phase: "setup",
+                }),
               );
               return;
             }
@@ -86,7 +100,16 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
             const body = msg.data as PiloTaskRequest;
             const taskId = randomUUID();
             if (!body) {
-              send(ws, "error", createErrorResponse("Missing data", "MISSING_DATA", taskId));
+              send(
+                ws,
+                "error",
+                createErrorResponse({
+                  code: "MISSING_DATA",
+                  reason: "INVALID_REQUEST",
+                  phase: "setup",
+                  taskId,
+                }),
+              );
               return;
             }
 
@@ -138,7 +161,11 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
                   await send(
                     ws,
                     "error",
-                    createErrorResponse(errorToString(error), "TASK_EXECUTION_FAILED", taskId),
+                    errorResponseFromError(error, {
+                      code: "TASK_EXECUTION_FAILED",
+                      phase: "execution",
+                      taskId,
+                    }),
                   );
                 }
               } finally {
@@ -157,7 +184,10 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               send(
                 ws,
                 "error",
-                createErrorResponse("Missing requestId in response", "INVALID_RESPONSE"),
+                createErrorResponse({
+                  code: "INVALID_RESPONSE",
+                  reason: "INVALID_REQUEST",
+                }),
               );
               return;
             }
@@ -167,10 +197,10 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               send(
                 ws,
                 "error",
-                createErrorResponse(
-                  `No pending request for id: ${response.requestId}`,
-                  "UNKNOWN_REQUEST_ID",
-                ),
+                createErrorResponse({
+                  code: "UNKNOWN_REQUEST_ID",
+                  reason: "INVALID_REQUEST",
+                }),
               );
               return;
             }
@@ -179,7 +209,14 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
             pendingRequests.delete(response.requestId);
             pending.resolve(response);
           } else {
-            send(ws, "error", createErrorResponse(`Unknown event: ${msg.event}`, "UNKNOWN_EVENT"));
+            send(
+              ws,
+              "error",
+              createErrorResponse({
+                code: "UNKNOWN_EVENT",
+                reason: "INVALID_REQUEST",
+              }),
+            );
           }
         },
 

--- a/packages/server/src/routes/piloWs.ts
+++ b/packages/server/src/routes/piloWs.ts
@@ -75,6 +75,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               ws,
               "error",
               createErrorResponse({
+                message: "Invalid JSON message",
                 code: "INVALID_MESSAGE",
                 reason: "INVALID_REQUEST",
                 phase: "setup",
@@ -89,6 +90,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
                 ws,
                 "error",
                 createErrorResponse({
+                  message: "A task is already running on this connection",
                   code: "TASK_ALREADY_RUNNING",
                   reason: "INVALID_REQUEST",
                   phase: "setup",
@@ -104,6 +106,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
                 ws,
                 "error",
                 createErrorResponse({
+                  message: "Missing data",
                   code: "MISSING_DATA",
                   reason: "INVALID_REQUEST",
                   phase: "setup",
@@ -185,6 +188,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
                 ws,
                 "error",
                 createErrorResponse({
+                  message: "Missing requestId in response",
                   code: "INVALID_RESPONSE",
                   reason: "INVALID_REQUEST",
                 }),
@@ -198,6 +202,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
                 ws,
                 "error",
                 createErrorResponse({
+                  message: "No pending request matches the given requestId",
                   code: "UNKNOWN_REQUEST_ID",
                   reason: "INVALID_REQUEST",
                 }),
@@ -213,6 +218,7 @@ export function createPiloWsRoute(upgradeWebSocket: UpgradeWebSocket): Hono {
               ws,
               "error",
               createErrorResponse({
+                message: "Unknown event type",
                 code: "UNKNOWN_EVENT",
                 reason: "INVALID_REQUEST",
               }),

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -65,6 +65,7 @@ describe("taskRunner", () => {
   describe("createErrorResponse", () => {
     it("should build the structured error shape from explicit fields", () => {
       const res = createErrorResponse({
+        message: "something failed",
         class: "CustomError",
         code: "SOME_CODE",
         reason: "INVALID_REQUEST",
@@ -73,58 +74,59 @@ describe("taskRunner", () => {
         taskId: "task-abc-123",
       });
       expect(res.success).toBe(false);
+      expect(res.error.message).toBe("something failed");
       expect(res.error.class).toBe("CustomError");
       expect(res.error.code).toBe("SOME_CODE");
       expect(res.error.reason).toBe("INVALID_REQUEST");
       expect(res.error.recoverable).toBe(false);
       expect(res.error.phase).toBe("setup");
       expect(res.error.taskId).toBe("task-abc-123");
-      expect(res.error.at).toBeDefined();
+      expect(res.error.timestamp).toBeDefined();
     });
 
-    it("should never include a message field", () => {
+    it("should produce a valid ISO timestamp", () => {
       const res = createErrorResponse({
-        code: "SOME_CODE",
-        reason: "INTERNAL_ERROR",
-      });
-      expect((res.error as Record<string, unknown>).message).toBeUndefined();
-    });
-
-    it("should never include a timestamp field (renamed to 'at')", () => {
-      const res = createErrorResponse({
-        code: "SOME_CODE",
-        reason: "INTERNAL_ERROR",
-      });
-      expect((res.error as Record<string, unknown>).timestamp).toBeUndefined();
-      expect(res.error.at).toBeDefined();
-    });
-
-    it("should produce a valid ISO timestamp in 'at'", () => {
-      const res = createErrorResponse({
+        message: "msg",
         code: "CODE",
         reason: "INTERNAL_ERROR",
       });
-      const parsed = new Date(res.error.at);
+      const parsed = new Date(res.error.timestamp);
       expect(parsed.getTime()).not.toBeNaN();
     });
 
     it("should default class to 'Error' when not provided", () => {
-      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      const res = createErrorResponse({
+        message: "msg",
+        code: "CODE",
+        reason: "INTERNAL_ERROR",
+      });
       expect(res.error.class).toBe("Error");
     });
 
     it("should default recoverable to false when not provided", () => {
-      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      const res = createErrorResponse({
+        message: "msg",
+        code: "CODE",
+        reason: "INTERNAL_ERROR",
+      });
       expect(res.error.recoverable).toBe(false);
     });
 
     it("should omit taskId when not provided", () => {
-      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      const res = createErrorResponse({
+        message: "msg",
+        code: "CODE",
+        reason: "INTERNAL_ERROR",
+      });
       expect(res.error.taskId).toBeUndefined();
     });
 
     it("should omit phase when not provided", () => {
-      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      const res = createErrorResponse({
+        message: "msg",
+        code: "CODE",
+        reason: "INTERNAL_ERROR",
+      });
       expect(res.error.phase).toBeUndefined();
     });
   });
@@ -145,7 +147,15 @@ describe("taskRunner", () => {
       });
       const json = JSON.stringify(res);
       expect(json).not.toContain("DO NOT LOG THIS SENTINEL");
-      expect((res.error as Record<string, unknown>).message).toBeUndefined();
+    });
+
+    it("should set message from the reason hint map (not error.message)", () => {
+      const res = errorResponseFromError(new Error("ignored dynamic detail"), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      // INTERNAL_ERROR hint
+      expect(res.error.message).toBe("The task failed due to an internal error.");
     });
 
     it("should classify unknown errors as INTERNAL_ERROR, not recoverable", () => {
@@ -205,6 +215,7 @@ describe("taskRunner", () => {
       const result = validateTaskRequest({ task: "" });
       expect(result).not.toBeNull();
       expect(result!.status).toBe(400);
+      expect(result!.response.error.message).toBe("Task is required");
       expect(result!.response.error.code).toBe("MISSING_TASK");
       expect(result!.response.error.reason).toBe("INVALID_REQUEST");
       expect(result!.response.error.phase).toBe("setup");
@@ -224,6 +235,9 @@ describe("taskRunner", () => {
       expect(result!.status).toBe(400);
       expect(result!.response.error.code).toBe("INVALID_SEARCH_PROVIDER");
       expect(result!.response.error.reason).toBe("INVALID_REQUEST");
+      expect(result!.response.error.message).toContain("Must be one of");
+      // Must not echo the user-provided value back
+      expect(result!.response.error.message).not.toContain("invalid-provider");
     });
 
     it("should accept valid search providers", () => {
@@ -242,6 +256,7 @@ describe("taskRunner", () => {
       const result = validateTaskRequest({ task: "test" });
       expect(result).not.toBeNull();
       expect(result!.status).toBe(500);
+      expect(result!.response.error.message).toBe("AI provider is not configured.");
       expect(result!.response.error.code).toBe("MISSING_API_KEY");
       expect(result!.response.error.reason).toBe("PROVIDER_UNAUTHORIZED");
       expect(result!.response.error.phase).toBe("setup");
@@ -257,7 +272,6 @@ describe("taskRunner", () => {
       const json = JSON.stringify(result!.response);
       expect(json).not.toContain("SENSITIVE");
       expect(json).not.toContain("sk-abc123");
-      expect((result!.response.error as Record<string, unknown>).message).toBeUndefined();
     });
   });
 

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -19,9 +19,12 @@ vi.mock("pilo-core", () => {
   }
   class MockPlaywrightBrowser {}
 
+  class RecoverableError extends Error {}
+
   return {
     WebAgent: MockWebAgent,
     PlaywrightBrowser: MockPlaywrightBrowser,
+    RecoverableError,
     config: {
       getConfig: vi.fn(() => ({
         provider: "openai",
@@ -51,49 +54,134 @@ vi.mock("./StreamLogger.js", () => ({
   StreamLogger: class MockStreamLogger {},
 }));
 
-import { validateTaskRequest, createErrorResponse, errorToString, runTask } from "./taskRunner.js";
+import {
+  validateTaskRequest,
+  createErrorResponse,
+  errorResponseFromError,
+  runTask,
+} from "./taskRunner.js";
 
 describe("taskRunner", () => {
-  describe("errorToString", () => {
-    it("should return error name for Error instances", () => {
-      expect(errorToString(new Error("something broke"))).toBe("Error");
-    });
-
-    it("should return error name for typed errors", () => {
-      expect(errorToString(new TypeError("bad type"))).toBe("TypeError");
-    });
-
-    it("should return 'Unknown error' for non-Error values", () => {
-      expect(errorToString("a string")).toBe("Unknown error");
-      expect(errorToString(null)).toBe("Unknown error");
-      expect(errorToString(undefined)).toBe("Unknown error");
-      expect(errorToString(42)).toBe("Unknown error");
-    });
-  });
-
   describe("createErrorResponse", () => {
-    it("should create a properly shaped error response", () => {
-      const res = createErrorResponse("something failed", "SOME_CODE");
+    it("should build the structured error shape from explicit fields", () => {
+      const res = createErrorResponse({
+        class: "CustomError",
+        code: "SOME_CODE",
+        reason: "INVALID_REQUEST",
+        recoverable: false,
+        phase: "setup",
+        taskId: "task-abc-123",
+      });
       expect(res.success).toBe(false);
-      expect(res.error.message).toBe("something failed");
+      expect(res.error.class).toBe("CustomError");
       expect(res.error.code).toBe("SOME_CODE");
-      expect(res.error.timestamp).toBeDefined();
+      expect(res.error.reason).toBe("INVALID_REQUEST");
+      expect(res.error.recoverable).toBe(false);
+      expect(res.error.phase).toBe("setup");
+      expect(res.error.taskId).toBe("task-abc-123");
+      expect(res.error.at).toBeDefined();
     });
 
-    it("should have a valid ISO timestamp", () => {
-      const res = createErrorResponse("msg", "CODE");
-      const parsed = new Date(res.error.timestamp);
+    it("should never include a message field", () => {
+      const res = createErrorResponse({
+        code: "SOME_CODE",
+        reason: "INTERNAL_ERROR",
+      });
+      expect((res.error as Record<string, unknown>).message).toBeUndefined();
+    });
+
+    it("should never include a timestamp field (renamed to 'at')", () => {
+      const res = createErrorResponse({
+        code: "SOME_CODE",
+        reason: "INTERNAL_ERROR",
+      });
+      expect((res.error as Record<string, unknown>).timestamp).toBeUndefined();
+      expect(res.error.at).toBeDefined();
+    });
+
+    it("should produce a valid ISO timestamp in 'at'", () => {
+      const res = createErrorResponse({
+        code: "CODE",
+        reason: "INTERNAL_ERROR",
+      });
+      const parsed = new Date(res.error.at);
       expect(parsed.getTime()).not.toBeNaN();
     });
 
-    it("should include taskId when provided", () => {
-      const res = createErrorResponse("msg", "CODE", "task-abc-123");
-      expect(res.error.taskId).toBe("task-abc-123");
+    it("should default class to 'Error' when not provided", () => {
+      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      expect(res.error.class).toBe("Error");
+    });
+
+    it("should default recoverable to false when not provided", () => {
+      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      expect(res.error.recoverable).toBe(false);
     });
 
     it("should omit taskId when not provided", () => {
-      const res = createErrorResponse("msg", "CODE");
+      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
       expect(res.error.taskId).toBeUndefined();
+    });
+
+    it("should omit phase when not provided", () => {
+      const res = createErrorResponse({ code: "CODE", reason: "INTERNAL_ERROR" });
+      expect(res.error.phase).toBeUndefined();
+    });
+  });
+
+  describe("errorResponseFromError", () => {
+    it("should derive class from error constructor name", () => {
+      const res = errorResponseFromError(new TypeError("bad"), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      expect(res.error.class).toBe("TypeError");
+    });
+
+    it("should never forward error.message to the response", () => {
+      const res = errorResponseFromError(new Error("DO NOT LOG THIS SENTINEL"), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      const json = JSON.stringify(res);
+      expect(json).not.toContain("DO NOT LOG THIS SENTINEL");
+      expect((res.error as Record<string, unknown>).message).toBeUndefined();
+    });
+
+    it("should classify unknown errors as INTERNAL_ERROR, not recoverable", () => {
+      const res = errorResponseFromError(new Error("boom"), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      expect(res.error.reason).toBe("INTERNAL_ERROR");
+      expect(res.error.recoverable).toBe(false);
+    });
+
+    it("should classify non-Error throws as INTERNAL_ERROR with class Unknown", () => {
+      const res = errorResponseFromError("a string", {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      expect(res.error.class).toBe("Unknown");
+      expect(res.error.reason).toBe("INTERNAL_ERROR");
+      expect(res.error.recoverable).toBe(false);
+    });
+
+    it("should include the phase passed in opts", () => {
+      const res = errorResponseFromError(new Error(), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+      });
+      expect(res.error.phase).toBe("execution");
+    });
+
+    it("should include taskId when provided", () => {
+      const res = errorResponseFromError(new Error(), {
+        code: "TASK_EXECUTION_FAILED",
+        phase: "execution",
+        taskId: "task-abc-123",
+      });
+      expect(res.error.taskId).toBe("task-abc-123");
     });
   });
 
@@ -113,11 +201,13 @@ describe("taskRunner", () => {
       delete process.env.OPENAI_API_KEY;
     });
 
-    it("should return error when task is missing", () => {
+    it("should return INVALID_REQUEST when task is missing", () => {
       const result = validateTaskRequest({ task: "" });
       expect(result).not.toBeNull();
       expect(result!.status).toBe(400);
       expect(result!.response.error.code).toBe("MISSING_TASK");
+      expect(result!.response.error.reason).toBe("INVALID_REQUEST");
+      expect(result!.response.error.phase).toBe("setup");
     });
 
     it("should return null for a valid request", () => {
@@ -125,7 +215,7 @@ describe("taskRunner", () => {
       expect(result).toBeNull();
     });
 
-    it("should return error for invalid search provider", () => {
+    it("should return INVALID_REQUEST for invalid search provider", () => {
       const result = validateTaskRequest({
         task: "test",
         searchProvider: "invalid-provider" as any,
@@ -133,7 +223,7 @@ describe("taskRunner", () => {
       expect(result).not.toBeNull();
       expect(result!.status).toBe(400);
       expect(result!.response.error.code).toBe("INVALID_SEARCH_PROVIDER");
-      expect(result!.response.error.message).toContain("invalid-provider");
+      expect(result!.response.error.reason).toBe("INVALID_REQUEST");
     });
 
     it("should accept valid search providers", () => {
@@ -143,7 +233,7 @@ describe("taskRunner", () => {
       }
     });
 
-    it("should return error when AI provider is not configured", async () => {
+    it("should return PROVIDER_UNAUTHORIZED when AI provider is not configured", async () => {
       const { getAIProviderInfo } = await import("pilo-core");
       vi.mocked(getAIProviderInfo).mockImplementation(() => {
         throw new Error("No API key found");
@@ -153,6 +243,21 @@ describe("taskRunner", () => {
       expect(result).not.toBeNull();
       expect(result!.status).toBe(500);
       expect(result!.response.error.code).toBe("MISSING_API_KEY");
+      expect(result!.response.error.reason).toBe("PROVIDER_UNAUTHORIZED");
+      expect(result!.response.error.phase).toBe("setup");
+    });
+
+    it("should never leak error.message from getAIProviderInfo into validation response", async () => {
+      const { getAIProviderInfo } = await import("pilo-core");
+      vi.mocked(getAIProviderInfo).mockImplementation(() => {
+        throw new Error("SENSITIVE: key sk-abc123 not found in env");
+      });
+
+      const result = validateTaskRequest({ task: "test" });
+      const json = JSON.stringify(result!.response);
+      expect(json).not.toContain("SENSITIVE");
+      expect(json).not.toContain("sk-abc123");
+      expect((result!.response.error as Record<string, unknown>).message).toBeUndefined();
     });
   });
 

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -8,6 +8,7 @@ import {
   createAIProvider,
   getAIProviderInfo,
   createNavigationRetryConfig,
+  RecoverableError,
   SEARCH_PROVIDERS,
 } from "pilo-core";
 import type { TaskExecutionResult, UserDataCallback } from "pilo-core";
@@ -83,33 +84,110 @@ export interface PiloTaskRequest {
   includeScreenshotImages?: boolean;
 }
 
+/**
+ * Coarse-grained error categories. Bounded cardinality so they're safe to use
+ * as metric labels and dashboard filters. Never derived from user input or page
+ * content. Refine over time; always extend via enum, never open-ended.
+ */
+export type ErrorReason =
+  | "INVALID_REQUEST"
+  | "PROVIDER_UNAUTHORIZED"
+  | "NAVIGATION_TIMEOUT"
+  | "BROWSER_DISCONNECTED"
+  | "MAX_ITERATIONS"
+  | "MAX_ERRORS"
+  | "TIMEOUT"
+  | "INTERNAL_ERROR";
+
+/** Which phase of the request pipeline produced the error. */
+export type ErrorPhase = "setup" | "execution";
+
 export interface ErrorResponse {
   success: false;
   error: {
-    message: string;
+    /** Error constructor name (e.g. "TypeError", "NavigationTimeoutException"). */
+    class: string;
+    /** Fine-grained semantic code for programmatic handling (e.g. "MISSING_TASK"). */
     code: string;
-    timestamp: string;
+    /** Coarse-grained category, safe for metric labels. */
+    reason: ErrorReason;
+    /** True if the underlying error is a RecoverableError; hint for callers. */
+    recoverable: boolean;
+    /** Which pipeline phase the error occurred in. */
+    phase?: ErrorPhase;
+    /** ISO timestamp when the response was generated. */
+    at: string;
+    /** Server-generated correlation ID for this task, if available. */
     taskId?: string;
   };
 }
 
-// Use error.name rather than error.message to avoid leaking sensitive data
-export const errorToString = (error: unknown): string =>
-  error instanceof Error ? error.name : "Unknown error";
+export interface CreateErrorResponseParams {
+  class?: string;
+  code: string;
+  reason: ErrorReason;
+  recoverable?: boolean;
+  phase?: ErrorPhase;
+  taskId?: string;
+}
 
-export const createErrorResponse = (
-  message: string,
-  code: string,
-  taskId?: string,
-): ErrorResponse => ({
+export const createErrorResponse = (params: CreateErrorResponseParams): ErrorResponse => ({
   success: false,
   error: {
-    message,
-    code,
-    timestamp: new Date().toISOString(),
-    ...(taskId !== undefined && { taskId }),
+    class: params.class ?? "Error",
+    code: params.code,
+    reason: params.reason,
+    recoverable: params.recoverable ?? false,
+    ...(params.phase && { phase: params.phase }),
+    at: new Date().toISOString(),
+    ...(params.taskId && { taskId: params.taskId }),
   },
 });
+
+/**
+ * Map an unknown thrown value to a safe (reason, recoverable) pair.
+ *
+ * Uses `instanceof RecoverableError` for the recoverable flag and
+ * `error.constructor.name` string matching for the specific reason. The string
+ * matching is intentionally temporary — stack D2 replaces Playwright/AI SDK
+ * error wrapping so we can use instanceof checks for specific classes too.
+ */
+function classifyError(error: unknown): { reason: ErrorReason; recoverable: boolean } {
+  const recoverable = error instanceof RecoverableError;
+  if (!(error instanceof Error)) {
+    return { reason: "INTERNAL_ERROR", recoverable: false };
+  }
+  switch (error.constructor.name) {
+    case "NavigationTimeoutException":
+    case "NavigationNetworkException":
+      return { reason: "NAVIGATION_TIMEOUT", recoverable: true };
+    case "BrowserDisconnectedError":
+      return { reason: "BROWSER_DISCONNECTED", recoverable: true };
+    default:
+      return { reason: "INTERNAL_ERROR", recoverable };
+  }
+}
+
+/**
+ * Build an ErrorResponse from an unknown thrown value. Extracts the error's
+ * class name and classifies into a reason + recoverable flag. Never forwards
+ * error.message — agent/browser errors can embed user input or page content.
+ */
+export const errorResponseFromError = (
+  error: unknown,
+  opts: { code: string; phase: ErrorPhase; taskId?: string },
+): ErrorResponse => {
+  const errorClass = error instanceof Error ? error.constructor.name : "Unknown";
+  const { reason, recoverable } = classifyError(error);
+  return createErrorResponse({
+    class: errorClass,
+    code: opts.code,
+    reason,
+    recoverable,
+    phase: opts.phase,
+    taskId: opts.taskId,
+  });
+};
 
 /**
  * Validate a task request and return an error response if invalid, or null if valid.
@@ -118,7 +196,14 @@ export function validateTaskRequest(
   body: PiloTaskRequest,
 ): { status: number; response: ErrorResponse } | null {
   if (!body.task) {
-    return { status: 400, response: createErrorResponse("Task is required", "MISSING_TASK") };
+    return {
+      status: 400,
+      response: createErrorResponse({
+        code: "MISSING_TASK",
+        reason: "INVALID_REQUEST",
+        phase: "setup",
+      }),
+    };
   }
 
   if (
@@ -127,10 +212,11 @@ export function validateTaskRequest(
   ) {
     return {
       status: 400,
-      response: createErrorResponse(
-        `Invalid search provider: ${body.searchProvider}. Must be one of: ${SEARCH_PROVIDERS.join(", ")}`,
-        "INVALID_SEARCH_PROVIDER",
-      ),
+      response: createErrorResponse({
+        code: "INVALID_SEARCH_PROVIDER",
+        reason: "INVALID_REQUEST",
+        phase: "setup",
+      }),
     };
   }
 
@@ -139,22 +225,24 @@ export function validateTaskRequest(
   if (effectiveSearchProvider === "parallel-api" && !serverConfig.parallel_api_key) {
     return {
       status: 400,
-      response: createErrorResponse(
-        "parallel-api search provider requires PARALLEL_API_KEY to be configured on the server",
-        "MISSING_SEARCH_API_KEY",
-      ),
+      response: createErrorResponse({
+        code: "MISSING_SEARCH_API_KEY",
+        reason: "INVALID_REQUEST",
+        phase: "setup",
+      }),
     };
   }
 
   try {
     getAIProviderInfo();
-  } catch (error) {
+  } catch {
     return {
       status: 500,
-      response: createErrorResponse(
-        `AI provider not configured: ${errorToString(error)}`,
-        "MISSING_API_KEY",
-      ),
+      response: createErrorResponse({
+        code: "MISSING_API_KEY",
+        reason: "PROVIDER_UNAUTHORIZED",
+        phase: "setup",
+      }),
     };
   }
 

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -105,24 +105,32 @@ export type ErrorPhase = "setup" | "execution";
 export interface ErrorResponse {
   success: false;
   error: {
-    /** Error constructor name (e.g. "TypeError", "NavigationTimeoutException"). */
-    class: string;
+    /**
+     * Human-readable description of the error. Definitionally safe: always
+     * populated from a server-controlled source (a hardcoded literal at the
+     * callsite or the REASON_HINTS map). Never derived from `error.message`
+     * of a thrown value, which could embed user input or page content.
+     */
+    message: string;
     /** Fine-grained semantic code for programmatic handling (e.g. "MISSING_TASK"). */
     code: string;
+    /** ISO timestamp when the response was generated. */
+    timestamp: string;
+    /** Error constructor name (e.g. "TypeError", "NavigationTimeoutException"). */
+    class: string;
     /** Coarse-grained category, safe for metric labels. */
     reason: ErrorReason;
     /** True if the underlying error is a RecoverableError; hint for callers. */
     recoverable: boolean;
     /** Which pipeline phase the error occurred in. */
     phase?: ErrorPhase;
-    /** ISO timestamp when the response was generated. */
-    at: string;
     /** Server-generated correlation ID for this task, if available. */
     taskId?: string;
   };
 }
 
 export interface CreateErrorResponseParams {
+  message: string;
   class?: string;
   code: string;
   reason: ErrorReason;
@@ -134,15 +142,33 @@ export interface CreateErrorResponseParams {
 export const createErrorResponse = (params: CreateErrorResponseParams): ErrorResponse => ({
   success: false,
   error: {
-    class: params.class ?? "Error",
+    message: params.message,
     code: params.code,
+    timestamp: new Date().toISOString(),
+    class: params.class ?? "Error",
     reason: params.reason,
     recoverable: params.recoverable ?? false,
     ...(params.phase && { phase: params.phase }),
-    at: new Date().toISOString(),
     ...(params.taskId && { taskId: params.taskId }),
   },
 });
+
+/**
+ * Server-controlled human-readable hint per reason. Used as the `message`
+ * for task-execution errors where the callsite has no better hardcoded
+ * string. NEVER merges `error.message` of the thrown value.
+ */
+const REASON_HINTS: Record<ErrorReason, string> = {
+  INVALID_REQUEST: "The request is invalid.",
+  PROVIDER_UNAUTHORIZED: "The AI provider is not configured or the key is invalid.",
+  NAVIGATION_TIMEOUT: "The target page did not finish loading in time.",
+  BROWSER_DISCONNECTED: "The browser disconnected during task execution.",
+  MAX_ITERATIONS:
+    "The agent exceeded the maximum number of iterations without completing the task.",
+  MAX_ERRORS: "The agent hit the error threshold and aborted.",
+  TIMEOUT: "The task exceeded its time budget.",
+  INTERNAL_ERROR: "The task failed due to an internal error.",
+};
 
 /**
  * Map an unknown thrown value to a safe (reason, recoverable) pair.
@@ -170,8 +196,10 @@ function classifyError(error: unknown): { reason: ErrorReason; recoverable: bool
 
 /**
  * Build an ErrorResponse from an unknown thrown value. Extracts the error's
- * class name and classifies into a reason + recoverable flag. Never forwards
- * error.message — agent/browser errors can embed user input or page content.
+ * class name, classifies into a reason + recoverable flag, and picks a
+ * human-readable message from REASON_HINTS. Never forwards error.message
+ * from the thrown value — agent/browser errors can embed user input or page
+ * content.
  */
 export const errorResponseFromError = (
   error: unknown,
@@ -180,6 +208,7 @@ export const errorResponseFromError = (
   const errorClass = error instanceof Error ? error.constructor.name : "Unknown";
   const { reason, recoverable } = classifyError(error);
   return createErrorResponse({
+    message: REASON_HINTS[reason],
     class: errorClass,
     code: opts.code,
     reason,
@@ -199,6 +228,7 @@ export function validateTaskRequest(
     return {
       status: 400,
       response: createErrorResponse({
+        message: "Task is required",
         code: "MISSING_TASK",
         reason: "INVALID_REQUEST",
         phase: "setup",
@@ -213,6 +243,7 @@ export function validateTaskRequest(
     return {
       status: 400,
       response: createErrorResponse({
+        message: `Invalid search provider. Must be one of: ${SEARCH_PROVIDERS.join(", ")}`,
         code: "INVALID_SEARCH_PROVIDER",
         reason: "INVALID_REQUEST",
         phase: "setup",
@@ -226,6 +257,8 @@ export function validateTaskRequest(
     return {
       status: 400,
       response: createErrorResponse({
+        message:
+          "parallel-api search provider requires PARALLEL_API_KEY to be configured on the server",
         code: "MISSING_SEARCH_API_KEY",
         reason: "INVALID_REQUEST",
         phase: "setup",
@@ -239,6 +272,7 @@ export function validateTaskRequest(
     return {
       status: 500,
       response: createErrorResponse({
+        message: "AI provider is not configured.",
         code: "MISSING_API_KEY",
         reason: "PROVIDER_UNAUTHORIZED",
         phase: "setup",


### PR DESCRIPTION
## Summary
Second PR in Stack A. Stacked on #389 (A1).

**Additive change** - no existing field is removed, no caller breaks. Adds
structured classification fields to the error response so dashboards and
programmatic retry logic can reason about failures without parsing
`message` strings.

### What's added
- `error.class` - error constructor name (e.g. `"TypeError"`, `"SyntaxError"`)
- `error.reason` - coarse-grained enum, safe for metric labels: `INVALID_REQUEST`,
  `PROVIDER_UNAUTHORIZED`, `NAVIGATION_TIMEOUT`, `BROWSER_DISCONNECTED`,
  `MAX_ITERATIONS`, `MAX_ERRORS`, `TIMEOUT`, `INTERNAL_ERROR`
- `error.recoverable` - boolean derived from `error instanceof RecoverableError`
- `error.phase` - which pipeline phase produced the error: `"setup"` or `"execution"`

### What stays (unchanged for consumers)
- `error.message` - human-readable string, still present
- `error.timestamp` - ISO timestamp, still present
- `error.code` - fine-grained semantic code, still present
- `error.taskId` - from A1, still present

### The data-sensitivity invariant
`error.message` must never contain raw `error.message` of a thrown value
(agent errors can quote task text, URL selectors derived from page content,
or extracted values). The new code enforces this two ways:

1. **Validation / setup errors** use hardcoded string literals at the callsite
   ("Task is required", "AI provider is not configured.", etc.). Server-controlled
   by construction.
2. **Task execution errors** go through `errorResponseFromError`, which sets
   `message` from a fixed `REASON_HINTS` map keyed by the `reason` enum. No code
   path reads `error.message` of the thrown value into the response.

A canary test throws `new Error("DO NOT LOG THIS SENTINEL")` and asserts the
sentinel never appears in the serialized response.

### Before / after
**Before** (old code, still passes through tabs-api to customers):
```json
{
  "success": false,
  "error": {
    "message": "Task is required",
    "code": "MISSING_TASK",
    "timestamp": "2026-04-21T12:00:00.000Z"
  }
}
```
**After** (additive, still readable by old consumers):
```json
{
  "success": false,
  "error": {
    "message": "Task is required",
    "code": "MISSING_TASK",
    "timestamp": "2026-04-21T12:00:00.000Z",
    "class": "Error",
    "reason": "INVALID_REQUEST",
    "recoverable": false,
    "phase": "setup",
    "taskId": "..."
  }
}
```

### Minor security improvements (bundled)
Dropped two WS error paths that previously echoed client-provided strings
back in the message:
- `UNKNOWN_EVENT` no longer quotes `msg.event`
- `UNKNOWN_REQUEST_ID` no longer quotes the requestId
- `INVALID_SEARCH_PROVIDER` no longer echoes the user-provided value

### Changes
- `packages/server/src/taskRunner.ts` - new `ErrorReason` / `ErrorPhase`
  types, extended `ErrorResponse`, new `createErrorResponse` (object-param
  signature) and `errorResponseFromError` helpers, `classifyError` mapper,
  `REASON_HINTS` map. `errorToString` removed (no callers left).
- `packages/server/src/routes/pilo.ts` - validation errors use new shape via
  `validateTaskRequest`; setup-error path uses `createErrorResponse` with
  explicit `reason: INVALID_REQUEST`; task-execution path uses
  `errorResponseFromError`.
- `packages/server/src/routes/piloWs.ts` - all `createErrorResponse` callsites
  migrated; task-execution error uses `errorResponseFromError`; dropped
  client-provided values from error messages.
- Tests: `taskRunner.test.ts` / `pilo.test.ts` / `piloWs.test.ts` updated to
  assert new fields alongside existing `message`/`timestamp`/`code`. Added
  canary tests that assert no sentinel string ever appears in the serialized
  response regardless of what the thrown value's `.message` is.

## Test plan
- [ ] `pnpm --filter pilo-server run test` (78 passing)
- [ ] `pnpm --filter pilo-core run test` (658 passing)
- [ ] `pnpm --filter pilo-cli run test` (221 passing)
- [ ] `pnpm run typecheck` green
- [ ] `pnpm run format:check` green
- [ ] Canary: thrown `Error("DO NOT LOG THIS SENTINEL")` never appears in response JSON
- [ ] Manual: `curl -X POST /pilo/run -d '{}'` returns 400 with both the old
  `message: "Task is required"` AND the new `reason: "INVALID_REQUEST"`,
  `phase: "setup"`, `class: "Error"`, `recoverable: false`

## Notes
- Base: `travis/pilo-task-id` (stacks on #389)
- Revised from an earlier internal design that dropped `message`/`timestamp`
  outright - that removed visibility for consumers with no safety benefit
  (both fields were already server-controlled). This revision keeps both,
  enforces server-control at the helper layer, and adds classification
  fields alongside.
- A3 next: redacting OTel `recordSanitizedException` wrapper so span
  payloads also stop leaking raw error messages.