### PR TITLE
A3: sanitize OTel exception recording (no error.message or stack on spans)

### DIFF
--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -26,7 +26,12 @@ import { NavigationRetryConfig, calculateTimeout } from "./navigationRetry.js";
 import { getConfigDefaults } from "../config/defaults.js";
 import { createNavigationRetryConfig } from "../utils/configMerge.js";
 import { ARIA_TREE_SCRIPT } from "./ariaTree/bundle.js";
-import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
+import {
+  withSpan,
+  SpanStatusCode,
+  SpanName,
+  recordSanitizedException,
+} from "../telemetry/tracing.js";
 
 export interface PlaywrightBrowserOptions {
   /** Browser type to use (defaults to 'firefox') */
@@ -351,9 +356,9 @@ export class PlaywrightBrowser implements AriaBrowser {
         } catch (error) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
           throw error;
         }
       },
@@ -576,15 +581,15 @@ export class PlaywrightBrowser implements AriaBrowser {
       } catch (error) {
         if (error instanceof Error && this.isBrowserDisconnectedError(error)) {
           const disconnectError = new BrowserDisconnectedError(error.message);
-          span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
-          span.recordException(disconnectError);
+          span.setStatus({ code: SpanStatusCode.ERROR, message: "BrowserDisconnectedError" });
+          recordSanitizedException(span, disconnectError);
           throw disconnectError;
         }
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
+          message: error instanceof Error ? error.constructor.name : "Unknown",
         });
-        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        recordSanitizedException(span, error);
         throw error;
       }
     });
@@ -739,9 +744,9 @@ export class PlaywrightBrowser implements AriaBrowser {
       } catch (error) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
+          message: error instanceof Error ? error.constructor.name : "Unknown",
         });
-        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        recordSanitizedException(span, error);
         throw error;
       }
     });
@@ -927,9 +932,9 @@ export class PlaywrightBrowser implements AriaBrowser {
         } catch (error) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
           throw error;
         }
       },

--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -7,6 +7,7 @@ interface Span {
   setAttribute(key: string, value: string | number | boolean): this;
   setStatus(status: { code: number; message?: string }): this;
   recordException(error: Error | string): void;
+  addEvent(name: string, attributes?: Record<string, string | number | boolean>): void;
   end(): void;
 }
 
@@ -67,6 +68,9 @@ function makeNoOpSpan(): Span {
       return span;
     },
     recordException(_error: Error | string): void {
+      // no-op
+    },
+    addEvent(_name: string, _attributes?: Record<string, string | number | boolean>): void {
       // no-op
     },
     end(): void {
@@ -221,4 +225,32 @@ async function withSpanAsync<T>(
       span.end();
     }
   });
+}
+
+/**
+ * Record an exception on a span with data-sensitivity protection.
+ *
+ * Unlike OTel's standard `span.recordException`, this helper emits ONLY the
+ * OTel `exception.type` attribute (the error's class name). It deliberately
+ * omits `exception.message` and `exception.stacktrace`, both of which
+ * commonly embed user input or page content in this codebase (agent errors
+ * quote the task, Playwright errors include selectors derived from the DOM,
+ * AI SDK errors can echo prompt fragments).
+ *
+ * Also sets:
+ * - `pilo.error.class` attribute (same value as `exception.type`) so dashboards
+ *   can filter on it without depending on OTel exception-event semantics.
+ * - `pilo.error.code` attribute when `opts.code` is provided.
+ */
+export function recordSanitizedException(
+  span: Span,
+  error: unknown,
+  opts: { code?: string } = {},
+): void {
+  const errorClass = error instanceof Error ? error.constructor.name : "Unknown";
+  span.addEvent("exception", { "exception.type": errorClass });
+  span.setAttribute("pilo.error.class", errorClass);
+  if (opts.code) {
+    span.setAttribute("pilo.error.code", opts.code);
+  }
 }

--- a/packages/core/src/tools/searchTools.ts
+++ b/packages/core/src/tools/searchTools.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 import type { SearchService } from "../search/searchService.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
 import { TOOL_STRINGS } from "../prompts.js";
-import { withSpan, SpanName } from "../telemetry/tracing.js";
+import { withSpan, SpanName, recordSanitizedException } from "../telemetry/tracing.js";
 
 interface SearchToolContext {
   searchService: SearchService;
@@ -64,7 +64,7 @@ export function createSearchTools(context: SearchToolContext) {
               // recoverable (the LLM sees the error and can retry or move on).
               // We do NOT set span status to ERROR — matching the webActionTools
               // pattern for recoverable failures.
-              span.recordException(error instanceof Error ? error : new Error(errorMessage));
+              recordSanitizedException(span, error);
               return {
                 success: false,
                 action: "webSearch",

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -13,7 +13,12 @@ import { buildExtractionPrompt, TOOL_STRINGS } from "../prompts.js";
 import type { ProviderConfig } from "../provider.js";
 import { BrowserException } from "../errors.js";
 import { generateTextWithRetry } from "../utils/retry.js";
-import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
+import {
+  withSpan,
+  SpanStatusCode,
+  SpanName,
+  recordSanitizedException,
+} from "../telemetry/tracing.js";
 
 interface WebActionContext {
   browser: AriaBrowser;
@@ -124,9 +129,9 @@ async function performActionWithValidation(
 
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message: error instanceof Error ? error.message : String(error),
+          message: error instanceof Error ? error.constructor.name : "Unknown",
         });
-        span.recordException(error instanceof Error ? error : new Error(String(error)));
+        recordSanitizedException(span, error);
         throw error;
       }
     },

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -12,7 +12,12 @@ import {
   DEFAULT_RETRY_MAX_DELAY_MS,
   DEFAULT_RETRY_BACKOFF_FACTOR,
 } from "../constants.js";
-import { withSpan, SpanStatusCode, SpanName } from "../telemetry/tracing.js";
+import {
+  withSpan,
+  SpanStatusCode,
+  SpanName,
+  recordSanitizedException,
+} from "../telemetry/tracing.js";
 
 /**
  * Check if an error is retryable
@@ -120,9 +125,9 @@ export async function generateTextWithRetry<TOOLS extends Record<string, any> = 
           span.setAttribute("pilo.ai.attempts", attempt);
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: errorMessage,
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
           throw error;
         }
 
@@ -164,9 +169,9 @@ export async function generateTextWithRetry<TOOLS extends Record<string, any> = 
     span.setAttribute("pilo.ai.attempts", maxAttempts);
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: errorMessage,
+      message: lastError instanceof Error ? lastError.constructor.name : "Unknown",
     });
-    span.recordException(lastError instanceof Error ? lastError : new Error(String(lastError)));
+    recordSanitizedException(span, lastError);
     throw lastError;
   });
 }

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -48,7 +48,12 @@ import {
   DEFAULT_PLANNING_MAX_TOKENS,
   DEFAULT_VALIDATION_MAX_TOKENS,
 } from "./constants.js";
-import { withSpan, SpanStatusCode, SpanName } from "./telemetry/tracing.js";
+import {
+  withSpan,
+  SpanStatusCode,
+  SpanName,
+  recordSanitizedException,
+} from "./telemetry/tracing.js";
 
 // === Type Definitions ===
 
@@ -360,9 +365,9 @@ export class WebAgent {
         } catch (error) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
           throw error;
         }
       },
@@ -549,9 +554,9 @@ export class WebAgent {
             // Only mark non-disconnect errors as span failures
             stepSpan.setStatus({
               code: SpanStatusCode.ERROR,
-              message: error instanceof Error ? error.message : String(error),
+              message: error instanceof Error ? error.constructor.name : "Unknown",
             });
-            stepSpan.recordException(error instanceof Error ? error : new Error(String(error)));
+            recordSanitizedException(stepSpan, error);
 
             trackError();
 
@@ -966,8 +971,11 @@ export class WebAgent {
         } catch (error) {
           // Preserve original error
           generationError = error instanceof Error ? error : new Error(String(error));
-          aiSpan.setStatus({ code: SpanStatusCode.ERROR, message: generationError.message });
-          aiSpan.recordException(generationError);
+          aiSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: generationError.constructor.name,
+          });
+          recordSanitizedException(aiSpan, generationError);
           return null;
         }
       },
@@ -1308,9 +1316,9 @@ export class WebAgent {
         } catch (error) {
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
 
           // On validation error, accept the result if we've hit max attempts
           if (executionState.validationAttempts >= this.maxValidationAttempts) {
@@ -1453,9 +1461,9 @@ export class WebAgent {
 
           span.setStatus({
             code: SpanStatusCode.ERROR,
-            message: error instanceof Error ? error.message : String(error),
+            message: error instanceof Error ? error.constructor.name : "Unknown",
           });
-          span.recordException(error instanceof Error ? error : new Error(String(error)));
+          recordSanitizedException(span, error);
 
           // Check if the error message already contains "Failed to generate plan" to avoid double-wrapping
           if (errorMsg.includes("Failed to generate plan")) {
@@ -1816,12 +1824,9 @@ export class WebAgent {
       } catch (reconnectError) {
         span.setStatus({
           code: SpanStatusCode.ERROR,
-          message:
-            reconnectError instanceof Error ? reconnectError.message : String(reconnectError),
+          message: reconnectError instanceof Error ? reconnectError.constructor.name : "Unknown",
         });
-        span.recordException(
-          reconnectError instanceof Error ? reconnectError : new Error(String(reconnectError)),
-        );
+        recordSanitizedException(span, reconnectError);
         throw reconnectError;
       }
     });

--- a/packages/core/test/telemetry/tracing.test.ts
+++ b/packages/core/test/telemetry/tracing.test.ts
@@ -230,6 +230,145 @@ describe("tracing helpers", () => {
     });
   });
 
+  describe("recordSanitizedException", () => {
+    it("sets pilo.error.class from error constructor name", async () => {
+      const mockSetAttribute = vi.fn().mockReturnThis();
+      const mockAddEvent = vi.fn();
+      const span = {
+        setAttribute: mockSetAttribute,
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: mockAddEvent,
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new TypeError("bad"));
+
+      expect(mockSetAttribute).toHaveBeenCalledWith("pilo.error.class", "TypeError");
+    });
+
+    it("emits an OTel exception event with only exception.type", async () => {
+      const mockAddEvent = vi.fn();
+      const span = {
+        setAttribute: vi.fn().mockReturnThis(),
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: mockAddEvent,
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new TypeError("bad"));
+
+      expect(mockAddEvent).toHaveBeenCalledWith("exception", { "exception.type": "TypeError" });
+    });
+
+    it("never emits exception.message or exception.stacktrace", async () => {
+      const mockAddEvent = vi.fn();
+      const span = {
+        setAttribute: vi.fn().mockReturnThis(),
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: mockAddEvent,
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new Error("DO NOT LOG THIS SENTINEL"));
+
+      for (const call of mockAddEvent.mock.calls) {
+        const attrs = (call[1] as Record<string, unknown>) ?? {};
+        expect(attrs).not.toHaveProperty("exception.message");
+        expect(attrs).not.toHaveProperty("exception.stacktrace");
+      }
+      const allCalls = JSON.stringify([
+        mockAddEvent.mock.calls,
+        (span.setAttribute as any).mock.calls,
+      ]);
+      expect(allCalls).not.toContain("DO NOT LOG THIS SENTINEL");
+    });
+
+    it("never calls span.recordException (avoids OTel's default message+stack emission)", async () => {
+      const mockRecordException = vi.fn();
+      const span = {
+        setAttribute: vi.fn().mockReturnThis(),
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: mockRecordException,
+        addEvent: vi.fn(),
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new Error("anything"));
+
+      expect(mockRecordException).not.toHaveBeenCalled();
+    });
+
+    it("sets class to 'Unknown' for non-Error throws", async () => {
+      const mockSetAttribute = vi.fn().mockReturnThis();
+      const mockAddEvent = vi.fn();
+      const span = {
+        setAttribute: mockSetAttribute,
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: mockAddEvent,
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, "a string");
+
+      expect(mockSetAttribute).toHaveBeenCalledWith("pilo.error.class", "Unknown");
+      expect(mockAddEvent).toHaveBeenCalledWith("exception", { "exception.type": "Unknown" });
+    });
+
+    it("sets pilo.error.code when opts.code is provided", async () => {
+      const mockSetAttribute = vi.fn().mockReturnThis();
+      const span = {
+        setAttribute: mockSetAttribute,
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: vi.fn(),
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new Error("x"), { code: "NAVIGATION_TIMEOUT" });
+
+      expect(mockSetAttribute).toHaveBeenCalledWith("pilo.error.code", "NAVIGATION_TIMEOUT");
+    });
+
+    it("omits pilo.error.code when opts.code is not provided", async () => {
+      const mockSetAttribute = vi.fn().mockReturnThis();
+      const span = {
+        setAttribute: mockSetAttribute,
+        setStatus: vi.fn().mockReturnThis(),
+        recordException: vi.fn(),
+        addEvent: vi.fn(),
+        end: vi.fn(),
+      };
+
+      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+      recordSanitizedException(span as any, new Error("x"));
+
+      const attrCalls = mockSetAttribute.mock.calls.map((c) => c[0]);
+      expect(attrCalls).not.toContain("pilo.error.code");
+    });
+
+    it("works with a no-op span when OTel is not installed", async () => {
+      vi.doMock("@opentelemetry/api", () => {
+        throw new Error("Cannot find module '@opentelemetry/api'");
+      });
+      const { getTracer, recordSanitizedException } =
+        await import("../../src/telemetry/tracing.js");
+      const tracer = await getTracer("test");
+      const span = tracer.startSpan("s");
+
+      expect(() => recordSanitizedException(span, new Error("x"))).not.toThrow();
+    });
+  });
+
   describe("withRemoteContext", () => {
     describe("when @opentelemetry/api is NOT installed", () => {
       beforeEach(() => {


### PR DESCRIPTION
## Summary
Third PR in Stack A. Stacked on #390 (A2).

Adds a `recordSanitizedException(span, error, opts?)` helper to
`packages/core/src/telemetry/tracing.ts` and migrates all 14 existing
`span.recordException` callsites. The helper emits the OTel-standard
`exception` event with **only** `exception.type` (the error's class name),
deliberately omitting `exception.message` and `exception.stacktrace` - both
of which routinely embed user input or page content in this codebase
(agent errors quote the task, Playwright errors include selectors derived
from the DOM, AI SDK errors can echo prompt fragments).

Also bundles the related leak from `span.setStatus({ code: ERROR, message: error.message })`:
at each migrated callsite, the status message is now `error.constructor.name`
instead of `error.message`. Same leak class, same fix.

### New helper
```ts
recordSanitizedException(span, error, { code?: string })
```
- Emits `addEvent("exception", { "exception.type": errorClass })` (OTel semconv)
- Sets `pilo.error.class` span attribute (fallback for tools that don't use
  OTel exception events)
- Sets `pilo.error.code` span attribute when `opts.code` is provided
- Never sets `exception.message`, `exception.stacktrace`, or the raw error object
- Handles non-Error throws (class = `"Unknown"`)
- Zero-overhead no-op when `@opentelemetry/api` is not installed

### Callsites migrated (14 total)
- `packages/core/src/webAgent.ts` (6)
- `packages/core/src/browser/playwrightBrowser.ts` (5)
- `packages/core/src/tools/webActionTools.ts` (1)
- `packages/core/src/tools/searchTools.ts` (1)
- `packages/core/src/utils/retry.ts` (2)

### Tests
- 8 new tests in `packages/core/test/telemetry/tracing.test.ts`:
  - Sets `pilo.error.class` from constructor name
  - Emits `exception` event with only `exception.type`
  - Never emits `exception.message` or `exception.stacktrace`
  - Never calls `span.recordException` (avoids OTel default message+stack emission)
  - Handles non-Error throws (class = `"Unknown"`)
  - Sets `pilo.error.code` when opts.code provided
  - Omits `pilo.error.code` when opts.code not provided
  - Works with no-op span when OTel is not installed
- Canary: `new Error("DO NOT LOG THIS SENTINEL")` - sentinel must not appear
  in any setAttribute or addEvent call

### Span interface extension
Added `addEvent(name, attributes?)` to the thin `Span` interface and the
no-op span factory. No runtime behavior change when OTel is not installed.

## Test plan
- [ ] `pnpm --filter pilo-core run test` (666 passing: 658 baseline + 8 new)
- [ ] `pnpm --filter pilo-server run test` (78 passing)
- [ ] `pnpm --filter pilo-cli run test` (221 passing)
- [ ] `pnpm run typecheck` green
- [ ] `pnpm run format:check` green
- [ ] Manual: run a task with `OTEL_EXPORTER_OTLP_ENDPOINT` pointed at a local
  collector. Force an error (e.g. bad URL). Inspect the span: should have
  `pilo.error.class` attribute and an `exception` event with only
  `exception.type`. No `exception.message` or `exception.stacktrace`.

## Notes
- Base: `travis/pilo-sanitized-error-shape` (stacks on #390)
- A4 next: CI sentinel-leak test (spans the full request path: logs +
  Sentry + OTel trace export)
- Not in this PR: setStatus message for NON-migrated code paths (none
  remain in core - all 14 callsites are now using the sanitized helper)