### PR TITLE
A4: add sensitive-data leak canary + fix 3 server console leaks

### DIFF
--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -67,7 +67,11 @@ pilo.post("/run", async (c) => {
         if (abortController.signal.aborted) {
           console.log("🛑 Task execution aborted due to client disconnection");
         } else {
-          console.error("Pilo task execution failed:", error);
+          console.error("[pilo-server] task execution failed", {
+            taskId,
+            phase: "execution",
+            error_class: error instanceof Error ? error.constructor.name : "Unknown",
+          });
           await stream.writeSSE({
             event: "error",
             data: JSON.stringify(
@@ -82,7 +86,11 @@ pilo.post("/run", async (c) => {
       }
     });
   } catch (error) {
-    console.error("Pilo task setup failed:", error);
+    console.error("[pilo-server] task setup failed", {
+      taskId,
+      phase: "setup",
+      error_class: error instanceof Error ? error.constructor.name : "Unknown",
+    });
     return c.json(
       createErrorResponse({
         message: "Failed to parse request body.",

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -368,7 +368,10 @@ describe("taskRunner", () => {
       });
 
       expect(result.success).toBe(true);
-      expect(consoleError).toHaveBeenCalledWith("Error closing agent:", expect.any(Error));
+      expect(consoleError).toHaveBeenCalledWith(
+        "[pilo-server] error closing agent",
+        expect.objectContaining({ error_class: expect.any(String) }),
+      );
       consoleError.mockRestore();
     });
   });

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -378,7 +378,10 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     try {
       await agent.close();
     } catch (closeError) {
-      console.error("Error closing agent:", closeError);
+      console.error("[pilo-server] error closing agent", {
+        taskId,
+        error_class: closeError instanceof Error ? closeError.constructor.name : "Unknown",
+      });
     }
   }
 }

--- a/packages/server/test/sensitive-data-leak.test.ts
+++ b/packages/server/test/sensitive-data-leak.test.ts
@@ -1,0 +1,227 @@
+/**
+ * CI gate: user-supplied data and thrown-error content must never reach
+ * telemetry surfaces (console logs, server-side structured output).
+ *
+ * This is an integration-style test that exercises the real server routes
+ * (pilo-core is mocked to let us force specific failure modes). It runs the
+ * full request path for each failure mode and asserts the sentinel string
+ * never appears in anything written to console.*.
+ *
+ * When this test fails, do not adjust the assertions. Fix the leak.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Hono } from "hono";
+
+const SENTINEL = "SENSITIVE-CANARY-a8f3d2";
+
+// Module-level hooks so individual tests can control WebAgent behavior.
+let mockExecute = vi.fn().mockResolvedValue({
+  success: true,
+  finalAnswer: "done",
+  stats: { iterations: 1, actions: 0, startTime: 0, endTime: 0, durationMs: 0 },
+});
+let mockClose = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("pilo-core", () => {
+  class MockWebAgent {
+    constructor(_browser: unknown, _opts: unknown) {}
+    execute = (...args: unknown[]) => mockExecute(...args);
+    close = (...args: unknown[]) => mockClose(...args);
+  }
+  class MockPlaywrightBrowser {}
+
+  return {
+    RecoverableError: class extends Error {},
+    WebAgent: MockWebAgent,
+    PlaywrightBrowser: MockPlaywrightBrowser,
+    config: {
+      getConfig: vi.fn(() => ({
+        provider: "openai",
+        openai_api_key: "sk-test123",
+      })),
+    },
+    createAIProvider: vi.fn(() => ({})),
+    getAIProviderInfo: vi.fn(() => ({
+      provider: "openai",
+      model: "gpt-4.1",
+      hasApiKey: true,
+      keySource: "env",
+    })),
+    createNavigationRetryConfig: vi.fn((overrides: { baseTimeoutMs?: number } | undefined) => ({
+      baseTimeoutMs: overrides?.baseTimeoutMs ?? 30000,
+      maxTimeoutMs: 120000,
+      maxAttempts: 3,
+      timeoutMultiplier: 2,
+    })),
+    SEARCH_PROVIDERS: ["none", "duckduckgo", "google", "bing", "parallel-api"],
+    withRemoteContext: vi.fn((_headers: unknown, fn: () => unknown) => fn()),
+  };
+});
+
+vi.mock("@ai-sdk/openai", () => ({
+  openai: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock("../src/StreamLogger.js", () => ({
+  StreamLogger: class MockStreamLogger {},
+}));
+
+interface CapturedConsole {
+  log: string[];
+  error: string[];
+  warn: string[];
+  info: string[];
+  debug: string[];
+}
+
+function captureConsole(): {
+  captured: CapturedConsole;
+  restore: () => void;
+  all: () => string;
+} {
+  const captured: CapturedConsole = { log: [], error: [], warn: [], info: [], debug: [] };
+  const methods: (keyof CapturedConsole)[] = ["log", "error", "warn", "info", "debug"];
+  const originals: Record<string, (...args: unknown[]) => void> = {};
+
+  for (const method of methods) {
+    originals[method] = console[method] as (...args: unknown[]) => void;
+    console[method] = vi.fn((...args: unknown[]) => {
+      captured[method].push(
+        args
+          .map((a) => {
+            if (a instanceof Error) {
+              // What Node's util.inspect would show on console.error(err) —
+              // includes message + stack.
+              return `${a.name}: ${a.message}\n${a.stack ?? ""}`;
+            }
+            if (typeof a === "string") return a;
+            try {
+              return JSON.stringify(a);
+            } catch {
+              return String(a);
+            }
+          })
+          .join(" "),
+      );
+    }) as typeof console.log;
+  }
+
+  return {
+    captured,
+    restore() {
+      for (const method of methods) {
+        console[method] = originals[method] as (...args: unknown[]) => void;
+      }
+    },
+    all() {
+      return [
+        ...captured.log,
+        ...captured.error,
+        ...captured.warn,
+        ...captured.info,
+        ...captured.debug,
+      ].join("\n");
+    },
+  };
+}
+
+describe("sensitive data leak canary", () => {
+  let app: Hono;
+  let cap: ReturnType<typeof captureConsole>;
+
+  beforeEach(async () => {
+    process.env.OPENAI_API_KEY = "sk-test";
+    // Reset mocks to default happy-path behavior.
+    mockExecute = vi.fn().mockResolvedValue({
+      success: true,
+      finalAnswer: "done",
+      stats: { iterations: 1, actions: 0, startTime: 0, endTime: 0, durationMs: 0 },
+    });
+    mockClose = vi.fn().mockResolvedValue(undefined);
+
+    cap = captureConsole();
+    const piloRoutes = (await import("../src/routes/pilo.js")).default;
+    app = new Hono();
+    app.route("/pilo", piloRoutes);
+  });
+
+  afterEach(() => {
+    cap.restore();
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  describe("SSE /pilo/run", () => {
+    it("validation error: sentinel in url/data never leaks to console", async () => {
+      await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          url: `https://example.com/secret?token=${SENTINEL}`,
+          data: { user: SENTINEL },
+        }),
+      });
+
+      expect(cap.all()).not.toContain(SENTINEL);
+    });
+
+    it("malformed JSON with sentinel inside never leaks to console", async () => {
+      await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: `{ "task": "${SENTINEL}", broken`,
+      });
+
+      expect(cap.all()).not.toContain(SENTINEL);
+    });
+
+    it("sentinel inside a thrown WebAgent error.message never leaks to console", async () => {
+      mockExecute = vi.fn().mockRejectedValue(new Error(`agent boom touching ${SENTINEL}`));
+
+      const res = await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task: "do a thing" }),
+      });
+      await res.text();
+
+      // Sanity check: this failure mode must produce a "Pilo task execution failed"
+      // console.error entry, otherwise the test isn't exercising the leak path.
+      expect(cap.captured.error.join("\n")).toContain("task execution failed");
+      expect(cap.all()).not.toContain(SENTINEL);
+    });
+
+    it("sentinel inside a thrown agent.close error never leaks to console", async () => {
+      mockClose = vi.fn().mockRejectedValue(new Error(`close failed with ${SENTINEL}`));
+
+      const res = await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task: "do a thing" }),
+      });
+      await res.text();
+
+      // Sanity check: must produce an "Error closing agent" entry.
+      expect(cap.captured.error.join("\n")).toContain("closing agent");
+      expect(cap.all()).not.toContain(SENTINEL);
+    });
+
+    it("aggregated: all user-supplied fields + thrown message, zero console leaks", async () => {
+      mockExecute = vi.fn().mockRejectedValue(new Error(SENTINEL));
+
+      const res = await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          task: `${SENTINEL} task content`,
+          url: `https://example.com/${SENTINEL}?q=${SENTINEL}`,
+          data: { key: SENTINEL },
+          guardrails: `do not ${SENTINEL}`,
+        }),
+      });
+      await res.text();
+
+      expect(cap.all()).not.toContain(SENTINEL);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fourth and final PR in Stack A. Stacked on #391 (A3).

Adds a CI-gated integration test that posts sentinel strings into every
user-supplied field, drives the full request path against a mocked
pilo-core, and asserts the sentinel never appears in anything written to
`console.*`. When this test fails in a future PR, the answer is to fix
the leak, not relax the assertion.

The test caught three real leaks in the current server code - bundled the
fixes in this PR so the canary passes on merge.

### Leaks fixed (split into commit 1)
1. `packages/server/src/routes/pilo.ts:55` -
   `console.error("Pilo task execution failed:", error)` logged the full
   Error including `.message`, which for a task-execution failure can embed
   user input or page content. Replaced with structured metadata:
   `{ taskId, phase: "execution", error_class }`.
2. `packages/server/src/routes/pilo.ts:66` - same pattern for setup errors.
   `SyntaxError.message` from malformed JSON commonly quotes a snippet of
   the malformed body, which is user-provided. Replaced with
   `{ taskId, phase: "setup", error_class }`.
3. `packages/server/src/taskRunner.ts:251` -
   `console.error("Error closing agent:", closeError)` logged the full
   Playwright close error, which can include selectors derived from page
   content. Replaced with `{ taskId, error_class }`.

### Canary (commit 2)
`packages/server/test/sensitive-data-leak.test.ts` (227 lines):
- Spies on `console.log`/`error`/`warn`/`info`/`debug`, including
  Error-object capture (message + stack).
- Runs five failure modes against the SSE route:
  1. Validation error with sentinel in `url` and `data`
  2. Malformed JSON containing sentinel
  3. Thrown `WebAgent.execute` error with sentinel in `error.message`
  4. Thrown `agent.close` error with sentinel in `error.message`
  5. Aggregate: sentinel in `task`, `url`, `data`, `guardrails`, AND
     thrown `error.message` all at once
- Sanity-checks each test actually exercises the intended leak path
  (e.g. "task execution failed" or "closing agent" appears in the log)
  so a future refactor that silences the console by accident doesn't
  make the test trivially pass.
- Asserts sentinel never appears in captured output.

## Test plan
- [ ] `pnpm --filter pilo-server run test` (83 passing: 78 prior + 5 canary)
- [ ] `pnpm --filter pilo-core run test` (666 passing)
- [ ] `pnpm --filter pilo-cli run test` (221 passing)
- [ ] `pnpm run typecheck` green
- [ ] `pnpm run format:check` green
- [ ] Canary verified: revert the `console.error` changes in commit 1 and
  confirm the canary fails with clear sentinel-match output, then re-apply

## Notes
- Base: `travis/pilo-otel-sanitized-exception` (stacks on #391)
- Scope deliberately limited to **server-side console leaks**. OTel span
  leaks on the core path are covered by A3's unit tests (recordSanitizedException).
  Known remaining leak - `webAgent.ts:287` sets `pilo.task` span attribute to
  the full task text - is tracked for C1 (core span enrichment), not this PR.
- WS route not yet covered by canary. Its code paths all use the same
  `createErrorResponse` / `errorResponseFromError` helpers that A2 locked
  down, but a dedicated WS canary test would be a good follow-up.
- **This completes Stack A.** Stack B (server observability: request
  logging, Sentry scrubber, concurrency limit) and Stack C (core
  observability) unlock once these four PRs land.