### PR TITLE
feat(core): emit WebAgentEvent JSON Schema as a release artifact

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -143,6 +143,13 @@ jobs:
       - name: Typecheck core
         run: pnpm --filter pilo-core run typecheck
 
+      - name: Check schema artifacts are up-to-date
+        # Regenerates schemas/ and fails if the committed artifact drifts
+        # from what the generator produces. If this fails, run
+        # `pnpm --filter pilo-core run generate:schemas` locally and commit.
+        if: needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.workflows == 'true'
+        run: pnpm --filter pilo-core run check:schemas
+
       - name: Test core
         if: needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.workflows == 'true'
         run: pnpm --filter pilo-core run test

--- a/.prettierignore
+++ b/.prettierignore
@@ -11,6 +11,11 @@ build/
 # Generated bundles
 packages/core/src/browser/ariaTree/bundle.ts
 
+# Generated JSON Schema artifacts (from `pnpm --filter pilo-core run generate:schemas`)
+# Excluded because prettier's formatting diverges from ts-json-schema-generator's
+# output, which would cause the check:schemas drift gate to fail after a reformat.
+packages/core/schemas/
+
 # WXT framework auto-generated files
 packages/extension/.wxt/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ pnpm pilo extension install firefox [--tmp] [--firefox-binary <path>]
    - Run `pnpm run typecheck` to run formatting checks and typecheck all packages (single entry point for both).
    - Run `pnpm -r run test` to verify all tests pass.
 3. **Full validation**: `pnpm run check` chains `typecheck` (which includes pretest + format:check + per-package typechecks) and then all tests.
+4. **Before pushing to a branch**: always run at minimum `pnpm run format:check` locally so CI's `Check formatting` step doesn't fail on missed prettier pass. Per-package filters (e.g. `pnpm --filter pilo-core run check:schemas`) only cover the named package — they do NOT run the root-level prettier check.
 
 ## Testing
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,9 @@
     "pretest": "pnpm run bundle:aria",
     "typecheck": "pnpm run bundle:aria && tsc --project tsconfig.check.json",
     "test": "vitest run",
-    "test:only": "pnpm run bundle:aria && pnpm run test"
+    "test:only": "pnpm run bundle:aria && pnpm run test",
+    "generate:schemas": "ts-json-schema-generator --path src/events.ts --tsconfig tsconfig.json --type WebAgentEvent --out schemas/webagent-event.json && node scripts/normalize-schema.cjs schemas/webagent-event.json",
+    "check:schemas": "pnpm run generate:schemas && git diff --exit-code schemas/"
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.59",
@@ -64,6 +66,7 @@
     "@vitest/coverage-v8": "^4.1.1",
     "esbuild": "^0.28.0",
     "jsdom": "^29.0.2",
+    "ts-json-schema-generator": "2.5.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",
     "vitest": "^4.1.3"

--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -1,0 +1,4523 @@
+{
+  "$ref": "#/definitions/WebAgentEvent",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "AIGenerationErrorEventData": {
+      "additionalProperties": false,
+      "description": "Event data when AI generation error occurs",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "messages": {
+          "items": {},
+          "type": "array"
+        },
+        "prompt": {
+          "type": "string"
+        },
+        "schema": {},
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "error",
+        "iterationId",
+        "prompt",
+        "schema",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "AIGenerationEventData": {
+      "additionalProperties": false,
+      "description": "Event data when AI generation occurs",
+      "properties": {
+        "finishReason": {
+          "enum": [
+            "stop",
+            "length",
+            "content-filter",
+            "tool-calls",
+            "error",
+            "other"
+          ],
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "messages": {
+          "items": {
+            "anyOf": [
+              {
+                "additionalProperties": false,
+                "description": "A system message. It can contain system information.\n\nNote: using the \"system\" part of the prompt is strongly preferred to increase the resilience against prompt injection attacks, and because not all providers support several system messages.",
+                "properties": {
+                  "content": {
+                    "type": "string"
+                  },
+                  "providerOptions": {
+                    "additionalProperties": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                              },
+                              {
+                                "items": {
+                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                          },
+                          {
+                            "not": {}
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                    "type": "object"
+                  },
+                  "role": {
+                    "const": "system",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role",
+                  "content"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "A user message. It can contain text or a combination of text and images.",
+                "properties": {
+                  "content": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "Text content part of a prompt. It contains a string of text.",
+                              "properties": {
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "text": {
+                                  "description": "The text content.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "text",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "text"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "Image content part of a prompt. It contains an image.",
+                              "properties": {
+                                "image": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "additionalProperties": {
+                                            "type": "number"
+                                          },
+                                          "properties": {
+                                            "BYTES_PER_ELEMENT": {
+                                              "type": "number"
+                                            },
+                                            "buffer": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "byteLength": {
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "byteLength"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "byteLength": {
+                                              "type": "number"
+                                            },
+                                            "byteOffset": {
+                                              "type": "number"
+                                            },
+                                            "length": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "BYTES_PER_ELEMENT",
+                                            "buffer",
+                                            "byteLength",
+                                            "byteOffset",
+                                            "length"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "byteLength": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "byteLength"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "$ref": "#/definitions/global.Buffer"
+                                        }
+                                      ],
+                                      "description": "Data content. Can either be a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer."
+                                    },
+                                    {
+                                      "format": "uri",
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "Image data. Can either be:\n\n- data: a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer\n- URL: a URL that points to the image"
+                                },
+                                "mediaType": {
+                                  "description": "Optional IANA media type of the image.",
+                                  "type": "string"
+                                },
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "type": {
+                                  "const": "image",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "image"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "File content part of a prompt. It contains a file.",
+                              "properties": {
+                                "data": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "additionalProperties": {
+                                            "type": "number"
+                                          },
+                                          "properties": {
+                                            "BYTES_PER_ELEMENT": {
+                                              "type": "number"
+                                            },
+                                            "buffer": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "byteLength": {
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "byteLength"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "byteLength": {
+                                              "type": "number"
+                                            },
+                                            "byteOffset": {
+                                              "type": "number"
+                                            },
+                                            "length": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "BYTES_PER_ELEMENT",
+                                            "buffer",
+                                            "byteLength",
+                                            "byteOffset",
+                                            "length"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "byteLength": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "byteLength"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "$ref": "#/definitions/global.Buffer"
+                                        }
+                                      ],
+                                      "description": "Data content. Can either be a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer."
+                                    },
+                                    {
+                                      "format": "uri",
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "File data. Can either be:\n\n- data: a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer\n- URL: a URL that points to the image"
+                                },
+                                "filename": {
+                                  "description": "Optional filename of the file.",
+                                  "type": "string"
+                                },
+                                "mediaType": {
+                                  "description": "IANA media type of the file.",
+                                  "type": "string"
+                                },
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "type": {
+                                  "const": "file",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "data",
+                                "mediaType"
+                              ],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "Content of a user message. It can be a string or an array of text and image parts."
+                  },
+                  "providerOptions": {
+                    "additionalProperties": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                              },
+                              {
+                                "items": {
+                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                          },
+                          {
+                            "not": {}
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                    "type": "object"
+                  },
+                  "role": {
+                    "const": "user",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role",
+                  "content"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "An assistant message. It can contain text, tool calls, or a combination of text and tool calls.",
+                "properties": {
+                  "content": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "items": {
+                          "anyOf": [
+                            {
+                              "additionalProperties": false,
+                              "description": "Text content part of a prompt. It contains a string of text.",
+                              "properties": {
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "text": {
+                                  "description": "The text content.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "text",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "text"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "File content part of a prompt. It contains a file.",
+                              "properties": {
+                                "data": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "additionalProperties": {
+                                            "type": "number"
+                                          },
+                                          "properties": {
+                                            "BYTES_PER_ELEMENT": {
+                                              "type": "number"
+                                            },
+                                            "buffer": {
+                                              "additionalProperties": false,
+                                              "properties": {
+                                                "byteLength": {
+                                                  "type": "number"
+                                                }
+                                              },
+                                              "required": [
+                                                "byteLength"
+                                              ],
+                                              "type": "object"
+                                            },
+                                            "byteLength": {
+                                              "type": "number"
+                                            },
+                                            "byteOffset": {
+                                              "type": "number"
+                                            },
+                                            "length": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "BYTES_PER_ELEMENT",
+                                            "buffer",
+                                            "byteLength",
+                                            "byteOffset",
+                                            "length"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "additionalProperties": false,
+                                          "properties": {
+                                            "byteLength": {
+                                              "type": "number"
+                                            }
+                                          },
+                                          "required": [
+                                            "byteLength"
+                                          ],
+                                          "type": "object"
+                                        },
+                                        {
+                                          "$ref": "#/definitions/global.Buffer"
+                                        }
+                                      ],
+                                      "description": "Data content. Can either be a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer."
+                                    },
+                                    {
+                                      "format": "uri",
+                                      "type": "string"
+                                    }
+                                  ],
+                                  "description": "File data. Can either be:\n\n- data: a base64-encoded string, a Uint8Array, an ArrayBuffer, or a Buffer\n- URL: a URL that points to the image"
+                                },
+                                "filename": {
+                                  "description": "Optional filename of the file.",
+                                  "type": "string"
+                                },
+                                "mediaType": {
+                                  "description": "IANA media type of the file.",
+                                  "type": "string"
+                                },
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "type": {
+                                  "const": "file",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "data",
+                                "mediaType"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "Reasoning content part of a prompt. It contains a reasoning.",
+                              "properties": {
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "text": {
+                                  "description": "The reasoning text.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "reasoning",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "text"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "Tool call content part of a prompt. It contains a tool call (usually generated by the AI model).",
+                              "properties": {
+                                "input": {
+                                  "description": "Arguments of the tool call. This is a JSON-serializable object that matches the tool's input schema."
+                                },
+                                "providerExecuted": {
+                                  "description": "Whether the tool call was executed by the provider.",
+                                  "type": "boolean"
+                                },
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "toolCallId": {
+                                  "description": "ID of the tool call. This ID is used to match the tool call with the tool result.",
+                                  "type": "string"
+                                },
+                                "toolName": {
+                                  "description": "Name of the tool that is being called.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "tool-call",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "toolCallId",
+                                "toolName",
+                                "input"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "Tool result content part of a prompt. It contains the result of the tool call with the matching ID.",
+                              "properties": {
+                                "output": {
+                                  "anyOf": [
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "providerOptions": {
+                                          "additionalProperties": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "null"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                    },
+                                                    {
+                                                      "items": {
+                                                        "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  ],
+                                                  "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                },
+                                                {
+                                                  "not": {}
+                                                }
+                                              ]
+                                            },
+                                            "type": "object"
+                                          },
+                                          "description": "Provider-specific options.",
+                                          "type": "object"
+                                        },
+                                        "type": {
+                                          "const": "text",
+                                          "description": "Text tool output that should be directly sent to the API.",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "providerOptions": {
+                                          "additionalProperties": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "null"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                    },
+                                                    {
+                                                      "items": {
+                                                        "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  ],
+                                                  "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                },
+                                                {
+                                                  "not": {}
+                                                }
+                                              ]
+                                            },
+                                            "type": "object"
+                                          },
+                                          "description": "Provider-specific options.",
+                                          "type": "object"
+                                        },
+                                        "type": {
+                                          "const": "json",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "null"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                      },
+                                                      {
+                                                        "items": {
+                                                          "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    ],
+                                                    "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                  },
+                                                  {
+                                                    "not": {}
+                                                  }
+                                                ]
+                                              },
+                                              "type": "object"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "providerOptions": {
+                                          "additionalProperties": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "null"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                    },
+                                                    {
+                                                      "items": {
+                                                        "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  ],
+                                                  "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                },
+                                                {
+                                                  "not": {}
+                                                }
+                                              ]
+                                            },
+                                            "type": "object"
+                                          },
+                                          "description": "Provider-specific options.",
+                                          "type": "object"
+                                        },
+                                        "reason": {
+                                          "description": "Optional reason for the execution denial.",
+                                          "type": "string"
+                                        },
+                                        "type": {
+                                          "const": "execution-denied",
+                                          "description": "Type when the user has denied the execution of the tool call.",
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "providerOptions": {
+                                          "additionalProperties": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "null"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                    },
+                                                    {
+                                                      "items": {
+                                                        "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  ],
+                                                  "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                },
+                                                {
+                                                  "not": {}
+                                                }
+                                              ]
+                                            },
+                                            "type": "object"
+                                          },
+                                          "description": "Provider-specific options.",
+                                          "type": "object"
+                                        },
+                                        "type": {
+                                          "const": "error-text",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "type": "string"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "providerOptions": {
+                                          "additionalProperties": {
+                                            "additionalProperties": {
+                                              "anyOf": [
+                                                {
+                                                  "anyOf": [
+                                                    {
+                                                      "type": "null"
+                                                    },
+                                                    {
+                                                      "type": "string"
+                                                    },
+                                                    {
+                                                      "type": "number"
+                                                    },
+                                                    {
+                                                      "type": "boolean"
+                                                    },
+                                                    {
+                                                      "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                    },
+                                                    {
+                                                      "items": {
+                                                        "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                      },
+                                                      "type": "array"
+                                                    }
+                                                  ],
+                                                  "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                },
+                                                {
+                                                  "not": {}
+                                                }
+                                              ]
+                                            },
+                                            "type": "object"
+                                          },
+                                          "description": "Provider-specific options.",
+                                          "type": "object"
+                                        },
+                                        "type": {
+                                          "const": "error-json",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "additionalProperties": {
+                                                "anyOf": [
+                                                  {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "null"
+                                                      },
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "type": "number"
+                                                      },
+                                                      {
+                                                        "type": "boolean"
+                                                      },
+                                                      {
+                                                        "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                      },
+                                                      {
+                                                        "items": {
+                                                          "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                        },
+                                                        "type": "array"
+                                                      }
+                                                    ],
+                                                    "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                  },
+                                                  {
+                                                    "not": {}
+                                                  }
+                                                ]
+                                              },
+                                              "type": "object"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    },
+                                    {
+                                      "additionalProperties": false,
+                                      "properties": {
+                                        "type": {
+                                          "const": "content",
+                                          "type": "string"
+                                        },
+                                        "value": {
+                                          "items": {
+                                            "anyOf": [
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "text": {
+                                                    "description": "Text content.",
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "const": "text",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "text"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "data": {
+                                                    "type": "string"
+                                                  },
+                                                  "mediaType": {
+                                                    "type": "string"
+                                                  },
+                                                  "type": {
+                                                    "const": "media",
+                                                    "deprecated": true,
+                                                    "description": "Deprecated. Use image-data or file-data instead.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "data",
+                                                  "mediaType"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "data": {
+                                                    "description": "Base-64 encoded media data.",
+                                                    "type": "string"
+                                                  },
+                                                  "filename": {
+                                                    "description": "Optional filename of the file.",
+                                                    "type": "string"
+                                                  },
+                                                  "mediaType": {
+                                                    "description": "IANA media type.",
+                                                    "type": "string"
+                                                  },
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "file-data",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "data",
+                                                  "mediaType"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "file-url",
+                                                    "type": "string"
+                                                  },
+                                                  "url": {
+                                                    "description": "URL of the file.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "url"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fileId": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    ],
+                                                    "description": "ID of the file.\n\nIf you use multiple providers, you need to specify the provider specific ids using the Record option. The key is the provider name, e.g. 'openai' or 'anthropic'."
+                                                  },
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "file-id",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "fileId"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "data": {
+                                                    "description": "Base-64 encoded image data.",
+                                                    "type": "string"
+                                                  },
+                                                  "mediaType": {
+                                                    "description": "IANA media type.",
+                                                    "type": "string"
+                                                  },
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "image-data",
+                                                    "description": "Images that are referenced using base64 encoded data.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "data",
+                                                  "mediaType"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "image-url",
+                                                    "description": "Images that are referenced using a URL.",
+                                                    "type": "string"
+                                                  },
+                                                  "url": {
+                                                    "description": "URL of the image.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "url"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "fileId": {
+                                                    "anyOf": [
+                                                      {
+                                                        "type": "string"
+                                                      },
+                                                      {
+                                                        "additionalProperties": {
+                                                          "type": "string"
+                                                        },
+                                                        "type": "object"
+                                                      }
+                                                    ],
+                                                    "description": "Image that is referenced using a provider file id.\n\nIf you use multiple providers, you need to specify the provider specific ids using the Record option. The key is the provider name, e.g. 'openai' or 'anthropic'."
+                                                  },
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "image-file-id",
+                                                    "description": "Images that are referenced using a provider file id.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type",
+                                                  "fileId"
+                                                ],
+                                                "type": "object"
+                                              },
+                                              {
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                  "providerOptions": {
+                                                    "additionalProperties": {
+                                                      "additionalProperties": {
+                                                        "anyOf": [
+                                                          {
+                                                            "anyOf": [
+                                                              {
+                                                                "type": "null"
+                                                              },
+                                                              {
+                                                                "type": "string"
+                                                              },
+                                                              {
+                                                                "type": "number"
+                                                              },
+                                                              {
+                                                                "type": "boolean"
+                                                              },
+                                                              {
+                                                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                              },
+                                                              {
+                                                                "items": {
+                                                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                                },
+                                                                "type": "array"
+                                                              }
+                                                            ],
+                                                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                          },
+                                                          {
+                                                            "not": {}
+                                                          }
+                                                        ]
+                                                      },
+                                                      "type": "object"
+                                                    },
+                                                    "description": "Provider-specific options.",
+                                                    "type": "object"
+                                                  },
+                                                  "type": {
+                                                    "const": "custom",
+                                                    "description": "Custom content part. This can be used to implement provider-specific content parts.",
+                                                    "type": "string"
+                                                  }
+                                                },
+                                                "required": [
+                                                  "type"
+                                                ],
+                                                "type": "object"
+                                              }
+                                            ]
+                                          },
+                                          "type": "array"
+                                        }
+                                      },
+                                      "required": [
+                                        "type",
+                                        "value"
+                                      ],
+                                      "type": "object"
+                                    }
+                                  ],
+                                  "description": "Result of the tool call. This is a JSON-serializable object."
+                                },
+                                "providerOptions": {
+                                  "additionalProperties": {
+                                    "additionalProperties": {
+                                      "anyOf": [
+                                        {
+                                          "anyOf": [
+                                            {
+                                              "type": "null"
+                                            },
+                                            {
+                                              "type": "string"
+                                            },
+                                            {
+                                              "type": "number"
+                                            },
+                                            {
+                                              "type": "boolean"
+                                            },
+                                            {
+                                              "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                            },
+                                            {
+                                              "items": {
+                                                "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                              },
+                                              "type": "array"
+                                            }
+                                          ],
+                                          "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                        },
+                                        {
+                                          "not": {}
+                                        }
+                                      ]
+                                    },
+                                    "type": "object"
+                                  },
+                                  "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                                  "type": "object"
+                                },
+                                "toolCallId": {
+                                  "description": "ID of the tool call that this result is associated with.",
+                                  "type": "string"
+                                },
+                                "toolName": {
+                                  "description": "Name of the tool that generated this result.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "tool-result",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "toolCallId",
+                                "toolName",
+                                "output"
+                              ],
+                              "type": "object"
+                            },
+                            {
+                              "additionalProperties": false,
+                              "description": "Tool approval request prompt part.",
+                              "properties": {
+                                "approvalId": {
+                                  "description": "ID of the tool approval.",
+                                  "type": "string"
+                                },
+                                "toolCallId": {
+                                  "description": "ID of the tool call that the approval request is for.",
+                                  "type": "string"
+                                },
+                                "type": {
+                                  "const": "tool-approval-request",
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "type",
+                                "approvalId",
+                                "toolCallId"
+                              ],
+                              "type": "object"
+                            }
+                          ]
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "description": "Content of an assistant message. It can be a string or an array of text, image, reasoning, redacted reasoning, and tool call parts."
+                  },
+                  "providerOptions": {
+                    "additionalProperties": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                              },
+                              {
+                                "items": {
+                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                          },
+                          {
+                            "not": {}
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                    "type": "object"
+                  },
+                  "role": {
+                    "const": "assistant",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role",
+                  "content"
+                ],
+                "type": "object"
+              },
+              {
+                "additionalProperties": false,
+                "description": "A tool message. It contains the result of one or more tool calls.",
+                "properties": {
+                  "content": {
+                    "description": "Content of a tool message. It is an array of tool result parts.",
+                    "items": {
+                      "anyOf": [
+                        {
+                          "additionalProperties": false,
+                          "description": "Tool result content part of a prompt. It contains the result of the tool call with the matching ID.",
+                          "properties": {
+                            "output": {
+                              "anyOf": [
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "providerOptions": {
+                                      "additionalProperties": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "anyOf": [
+                                                {
+                                                  "type": "null"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                },
+                                                {
+                                                  "items": {
+                                                    "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              ],
+                                              "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                            },
+                                            {
+                                              "not": {}
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "description": "Provider-specific options.",
+                                      "type": "object"
+                                    },
+                                    "type": {
+                                      "const": "text",
+                                      "description": "Text tool output that should be directly sent to the API.",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "providerOptions": {
+                                      "additionalProperties": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "anyOf": [
+                                                {
+                                                  "type": "null"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                },
+                                                {
+                                                  "items": {
+                                                    "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              ],
+                                              "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                            },
+                                            {
+                                              "not": {}
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "description": "Provider-specific options.",
+                                      "type": "object"
+                                    },
+                                    "type": {
+                                      "const": "json",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "null"
+                                        },
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "null"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                  },
+                                                  {
+                                                    "items": {
+                                                      "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                ],
+                                                "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                              },
+                                              {
+                                                "not": {}
+                                              }
+                                            ]
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "items": {
+                                            "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                          },
+                                          "type": "array"
+                                        }
+                                      ],
+                                      "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "providerOptions": {
+                                      "additionalProperties": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "anyOf": [
+                                                {
+                                                  "type": "null"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                },
+                                                {
+                                                  "items": {
+                                                    "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              ],
+                                              "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                            },
+                                            {
+                                              "not": {}
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "description": "Provider-specific options.",
+                                      "type": "object"
+                                    },
+                                    "reason": {
+                                      "description": "Optional reason for the execution denial.",
+                                      "type": "string"
+                                    },
+                                    "type": {
+                                      "const": "execution-denied",
+                                      "description": "Type when the user has denied the execution of the tool call.",
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "providerOptions": {
+                                      "additionalProperties": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "anyOf": [
+                                                {
+                                                  "type": "null"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                },
+                                                {
+                                                  "items": {
+                                                    "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              ],
+                                              "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                            },
+                                            {
+                                              "not": {}
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "description": "Provider-specific options.",
+                                      "type": "object"
+                                    },
+                                    "type": {
+                                      "const": "error-text",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "providerOptions": {
+                                      "additionalProperties": {
+                                        "additionalProperties": {
+                                          "anyOf": [
+                                            {
+                                              "anyOf": [
+                                                {
+                                                  "type": "null"
+                                                },
+                                                {
+                                                  "type": "string"
+                                                },
+                                                {
+                                                  "type": "number"
+                                                },
+                                                {
+                                                  "type": "boolean"
+                                                },
+                                                {
+                                                  "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                },
+                                                {
+                                                  "items": {
+                                                    "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                  },
+                                                  "type": "array"
+                                                }
+                                              ],
+                                              "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                            },
+                                            {
+                                              "not": {}
+                                            }
+                                          ]
+                                        },
+                                        "type": "object"
+                                      },
+                                      "description": "Provider-specific options.",
+                                      "type": "object"
+                                    },
+                                    "type": {
+                                      "const": "error-json",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "anyOf": [
+                                        {
+                                          "type": "null"
+                                        },
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "additionalProperties": {
+                                            "anyOf": [
+                                              {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "null"
+                                                  },
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "type": "number"
+                                                  },
+                                                  {
+                                                    "type": "boolean"
+                                                  },
+                                                  {
+                                                    "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                  },
+                                                  {
+                                                    "items": {
+                                                      "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                    },
+                                                    "type": "array"
+                                                  }
+                                                ],
+                                                "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                              },
+                                              {
+                                                "not": {}
+                                              }
+                                            ]
+                                          },
+                                          "type": "object"
+                                        },
+                                        {
+                                          "items": {
+                                            "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                          },
+                                          "type": "array"
+                                        }
+                                      ],
+                                      "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                },
+                                {
+                                  "additionalProperties": false,
+                                  "properties": {
+                                    "type": {
+                                      "const": "content",
+                                      "type": "string"
+                                    },
+                                    "value": {
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "text": {
+                                                "description": "Text content.",
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "const": "text",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "text"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "data": {
+                                                "type": "string"
+                                              },
+                                              "mediaType": {
+                                                "type": "string"
+                                              },
+                                              "type": {
+                                                "const": "media",
+                                                "deprecated": true,
+                                                "description": "Deprecated. Use image-data or file-data instead.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "data",
+                                              "mediaType"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "data": {
+                                                "description": "Base-64 encoded media data.",
+                                                "type": "string"
+                                              },
+                                              "filename": {
+                                                "description": "Optional filename of the file.",
+                                                "type": "string"
+                                              },
+                                              "mediaType": {
+                                                "description": "IANA media type.",
+                                                "type": "string"
+                                              },
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "file-data",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "data",
+                                              "mediaType"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "file-url",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL of the file.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "url"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "fileId": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                ],
+                                                "description": "ID of the file.\n\nIf you use multiple providers, you need to specify the provider specific ids using the Record option. The key is the provider name, e.g. 'openai' or 'anthropic'."
+                                              },
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "file-id",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "fileId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "data": {
+                                                "description": "Base-64 encoded image data.",
+                                                "type": "string"
+                                              },
+                                              "mediaType": {
+                                                "description": "IANA media type.",
+                                                "type": "string"
+                                              },
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "image-data",
+                                                "description": "Images that are referenced using base64 encoded data.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "data",
+                                              "mediaType"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "image-url",
+                                                "description": "Images that are referenced using a URL.",
+                                                "type": "string"
+                                              },
+                                              "url": {
+                                                "description": "URL of the image.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "url"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "fileId": {
+                                                "anyOf": [
+                                                  {
+                                                    "type": "string"
+                                                  },
+                                                  {
+                                                    "additionalProperties": {
+                                                      "type": "string"
+                                                    },
+                                                    "type": "object"
+                                                  }
+                                                ],
+                                                "description": "Image that is referenced using a provider file id.\n\nIf you use multiple providers, you need to specify the provider specific ids using the Record option. The key is the provider name, e.g. 'openai' or 'anthropic'."
+                                              },
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "image-file-id",
+                                                "description": "Images that are referenced using a provider file id.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type",
+                                              "fileId"
+                                            ],
+                                            "type": "object"
+                                          },
+                                          {
+                                            "additionalProperties": false,
+                                            "properties": {
+                                              "providerOptions": {
+                                                "additionalProperties": {
+                                                  "additionalProperties": {
+                                                    "anyOf": [
+                                                      {
+                                                        "anyOf": [
+                                                          {
+                                                            "type": "null"
+                                                          },
+                                                          {
+                                                            "type": "string"
+                                                          },
+                                                          {
+                                                            "type": "number"
+                                                          },
+                                                          {
+                                                            "type": "boolean"
+                                                          },
+                                                          {
+                                                            "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                                          },
+                                                          {
+                                                            "items": {
+                                                              "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                                            },
+                                                            "type": "array"
+                                                          }
+                                                        ],
+                                                        "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                                      },
+                                                      {
+                                                        "not": {}
+                                                      }
+                                                    ]
+                                                  },
+                                                  "type": "object"
+                                                },
+                                                "description": "Provider-specific options.",
+                                                "type": "object"
+                                              },
+                                              "type": {
+                                                "const": "custom",
+                                                "description": "Custom content part. This can be used to implement provider-specific content parts.",
+                                                "type": "string"
+                                              }
+                                            },
+                                            "required": [
+                                              "type"
+                                            ],
+                                            "type": "object"
+                                          }
+                                        ]
+                                      },
+                                      "type": "array"
+                                    }
+                                  },
+                                  "required": [
+                                    "type",
+                                    "value"
+                                  ],
+                                  "type": "object"
+                                }
+                              ],
+                              "description": "Result of the tool call. This is a JSON-serializable object."
+                            },
+                            "providerOptions": {
+                              "additionalProperties": {
+                                "additionalProperties": {
+                                  "anyOf": [
+                                    {
+                                      "anyOf": [
+                                        {
+                                          "type": "null"
+                                        },
+                                        {
+                                          "type": "string"
+                                        },
+                                        {
+                                          "type": "number"
+                                        },
+                                        {
+                                          "type": "boolean"
+                                        },
+                                        {
+                                          "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                                        },
+                                        {
+                                          "items": {
+                                            "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                          },
+                                          "type": "array"
+                                        }
+                                      ],
+                                      "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                                    },
+                                    {
+                                      "not": {}
+                                    }
+                                  ]
+                                },
+                                "type": "object"
+                              },
+                              "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                              "type": "object"
+                            },
+                            "toolCallId": {
+                              "description": "ID of the tool call that this result is associated with.",
+                              "type": "string"
+                            },
+                            "toolName": {
+                              "description": "Name of the tool that generated this result.",
+                              "type": "string"
+                            },
+                            "type": {
+                              "const": "tool-result",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "toolCallId",
+                            "toolName",
+                            "output"
+                          ],
+                          "type": "object"
+                        },
+                        {
+                          "additionalProperties": false,
+                          "description": "Tool approval response prompt part.",
+                          "properties": {
+                            "approvalId": {
+                              "description": "ID of the tool approval.",
+                              "type": "string"
+                            },
+                            "approved": {
+                              "description": "Flag indicating whether the approval was granted or denied.",
+                              "type": "boolean"
+                            },
+                            "providerExecuted": {
+                              "description": "Flag indicating whether the tool call is provider-executed. Only provider-executed tool approval responses should be sent to the model.",
+                              "type": "boolean"
+                            },
+                            "reason": {
+                              "description": "Optional reason for the approval or denial.",
+                              "type": "string"
+                            },
+                            "type": {
+                              "const": "tool-approval-response",
+                              "type": "string"
+                            }
+                          },
+                          "required": [
+                            "type",
+                            "approvalId",
+                            "approved"
+                          ],
+                          "type": "object"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "providerOptions": {
+                    "additionalProperties": {
+                      "additionalProperties": {
+                        "anyOf": [
+                          {
+                            "anyOf": [
+                              {
+                                "type": "null"
+                              },
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "boolean"
+                              },
+                              {
+                                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+                              },
+                              {
+                                "items": {
+                                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                                },
+                                "type": "array"
+                              }
+                            ],
+                            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+                          },
+                          {
+                            "not": {}
+                          }
+                        ]
+                      },
+                      "type": "object"
+                    },
+                    "description": "Additional provider-specific metadata. They are passed through to the provider from the AI SDK and enable provider-specific functionality that can be fully encapsulated in the provider.",
+                    "type": "object"
+                  },
+                  "role": {
+                    "const": "tool",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "role",
+                  "content"
+                ],
+                "type": "object"
+              }
+            ],
+            "description": "A message that can be used in the `messages` field of a prompt. It can be a user message, an assistant message, or a tool message."
+          },
+          "type": "array"
+        },
+        "object": {},
+        "prompt": {
+          "type": "string"
+        },
+        "providerMetadata": {
+          "additionalProperties": {},
+          "type": "object"
+        },
+        "schema": {},
+        "temperature": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "usage": {
+          "additionalProperties": false,
+          "properties": {
+            "inputTokens": {
+              "type": "number"
+            },
+            "outputTokens": {
+              "type": "number"
+            },
+            "totalTokens": {
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "warnings": {
+          "items": {},
+          "type": "array"
+        }
+      },
+      "required": [
+        "finishReason",
+        "iterationId",
+        "prompt",
+        "schema",
+        "timestamp",
+        "usage"
+      ],
+      "type": "object"
+    },
+    "ActionExecutionEventData": {
+      "additionalProperties": false,
+      "description": "Event data for action execution",
+      "properties": {
+        "action": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "ref": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "value": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "action",
+        "iterationId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ActionResultEventData": {
+      "additionalProperties": false,
+      "description": "Event data for action results",
+      "properties": {
+        "error": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "iterationId",
+        "success",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "AgentStepEventData": {
+      "additionalProperties": false,
+      "description": "Event data for agent step tracking (each loop iteration)",
+      "properties": {
+        "currentIteration": {
+          "type": "number"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "currentIteration",
+        "iterationId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "BrowserReconnectedEventData": {
+      "additionalProperties": false,
+      "description": "Event data when the browser reconnects after a mid-task disconnect",
+      "properties": {
+        "endpointIndex": {
+          "description": "1-based index of the CDP endpoint now in use",
+          "type": "number"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "startingUrl": {
+          "description": "The original starting URL the agent is restarting execution from",
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "total": {
+          "description": "Total number of configured CDP endpoints",
+          "type": "number"
+        }
+      },
+      "required": [
+        "endpointIndex",
+        "iterationId",
+        "startingUrl",
+        "timestamp",
+        "total"
+      ],
+      "type": "object"
+    },
+    "CdpEndpointConnectedEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a CDP endpoint is successfully connected to",
+      "properties": {
+        "endpointIndex": {
+          "description": "1-based index of the endpoint that connected",
+          "type": "number"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "total": {
+          "description": "Total number of configured CDP endpoints",
+          "type": "number"
+        }
+      },
+      "required": [
+        "endpointIndex",
+        "iterationId",
+        "timestamp",
+        "total"
+      ],
+      "type": "object"
+    },
+    "CdpEndpointCycleEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a CDP endpoint fails and the next one is being tried",
+      "properties": {
+        "attempt": {
+          "description": "1-based index of the endpoint attempt that failed",
+          "type": "number"
+        },
+        "error": {
+          "description": "Sanitized error identifier from the failed connection attempt (error.name, not error.message — full messages may contain endpoint URLs)",
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "total": {
+          "description": "Total number of configured CDP endpoints",
+          "type": "number"
+        }
+      },
+      "required": [
+        "attempt",
+        "error",
+        "iterationId",
+        "timestamp",
+        "total"
+      ],
+      "type": "object"
+    },
+    "CompressionDebugEventData": {
+      "additionalProperties": false,
+      "description": "Event data for compression debug info",
+      "properties": {
+        "compressedSize": {
+          "type": "number"
+        },
+        "compressionPercent": {
+          "type": "number"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "originalSize": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "compressedSize",
+        "compressionPercent",
+        "iterationId",
+        "originalSize",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ExtractedDataEventData": {
+      "additionalProperties": false,
+      "description": "Event data for extracted data",
+      "properties": {
+        "extractedData": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "extractedData",
+        "iterationId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "FormFieldRequest": {
+      "additionalProperties": false,
+      "description": "A single form field the agent needs data for.",
+      "properties": {
+        "currentValue": {
+          "description": "Current value if already partially filled",
+          "type": "string"
+        },
+        "description": {
+          "description": "Additional context (e.g., validation error message on re-request)",
+          "type": "string"
+        },
+        "fieldType": {
+          "description": "Semantic field type",
+          "enum": [
+            "text",
+            "email",
+            "phone",
+            "date",
+            "number",
+            "select",
+            "checkbox",
+            "radio",
+            "textarea",
+            "password",
+            "other"
+          ],
+          "type": "string"
+        },
+        "label": {
+          "description": "The field's visible label",
+          "type": "string"
+        },
+        "options": {
+          "description": "Available options for select/radio fields",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "ref": {
+          "description": "Element ref from the accessibility tree (e.g., \"E42\")",
+          "type": "string"
+        },
+        "required": {
+          "description": "Whether this field must be filled",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "ref",
+        "label",
+        "fieldType",
+        "required"
+      ],
+      "type": "object"
+    },
+    "InteractiveFormDataErrorEventData": {
+      "additionalProperties": false,
+      "description": "Event data when form validation fails and the agent re-requests data. Carries both the error context and the fields that need new values. Callers respond to this the same way as a request event.",
+      "properties": {
+        "fieldErrors": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Per-field error messages from validation (field ref -> error text)",
+          "type": "object"
+        },
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/FormFieldRequest"
+          },
+          "type": "array"
+        },
+        "formDescription": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "pageTitle": {
+          "type": "string"
+        },
+        "pageUrl": {
+          "type": "string"
+        },
+        "requestId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "fieldErrors",
+        "fields",
+        "formDescription",
+        "iterationId",
+        "pageTitle",
+        "pageUrl",
+        "requestId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "InteractiveFormDataRequestEventData": {
+      "additionalProperties": false,
+      "description": "Event data when the agent requests user data for form fields",
+      "properties": {
+        "fields": {
+          "items": {
+            "$ref": "#/definitions/FormFieldRequest"
+          },
+          "type": "array"
+        },
+        "formDescription": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "pageTitle": {
+          "type": "string"
+        },
+        "pageUrl": {
+          "type": "string"
+        },
+        "requestId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "fields",
+        "formDescription",
+        "iterationId",
+        "pageTitle",
+        "pageUrl",
+        "requestId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "MessagesDebugEventData": {
+      "additionalProperties": false,
+      "description": "Event data for message debug info",
+      "properties": {
+        "iterationId": {
+          "type": "string"
+        },
+        "messages": {
+          "items": {},
+          "type": "array"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "iterationId",
+        "messages",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "PageNavigationEventData": {
+      "additionalProperties": false,
+      "description": "Event data when navigating to a page",
+      "properties": {
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "title": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "iterationId",
+        "timestamp",
+        "title",
+        "url"
+      ],
+      "type": "object"
+    },
+    "ProcessingEventData": {
+      "additionalProperties": false,
+      "description": "Event data for when the agent is waiting for model generation",
+      "properties": {
+        "hasScreenshot": {
+          "type": "boolean"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "operation": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "hasScreenshot",
+        "iterationId",
+        "operation",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ReasoningEventData": {
+      "additionalProperties": false,
+      "description": "Event data for agent reasoning",
+      "properties": {
+        "iterationId": {
+          "type": "string"
+        },
+        "reasoning": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "iterationId",
+        "reasoning",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ScreenshotCapturedEventData": {
+      "additionalProperties": false,
+      "description": "Event data for screenshot capture",
+      "properties": {
+        "format": {
+          "enum": [
+            "jpeg",
+            "png"
+          ],
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "size": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "format",
+        "iterationId",
+        "size",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ScreenshotCapturedImageEventData": {
+      "additionalProperties": false,
+      "description": "Event data for screenshot image capture with full image data This event contains the complete screenshot and can be very large",
+      "properties": {
+        "image": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "mediaType": {
+          "enum": [
+            "image/jpeg",
+            "image/png"
+          ],
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "image",
+        "iterationId",
+        "mediaType",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "StatusMessageEventData": {
+      "additionalProperties": false,
+      "description": "Event data for status messages",
+      "properties": {
+        "iterationId": {
+          "type": "string"
+        },
+        "message": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "iterationId",
+        "message",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "TaskAbortedEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a task is aborted",
+      "properties": {
+        "finalAnswer": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "reason": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "finalAnswer",
+        "iterationId",
+        "reason",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "TaskCompleteEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a task is completed",
+      "properties": {
+        "finalAnswer": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "success": {
+          "type": "boolean"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "finalAnswer",
+        "iterationId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "TaskMetricsEventData": {
+      "additionalProperties": false,
+      "properties": {
+        "aiGenerationCount": {
+          "type": "number"
+        },
+        "aiGenerationErrorCount": {
+          "type": "number"
+        },
+        "eventCounts": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "type": "object"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "stepCount": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "totalInputTokens": {
+          "type": "number"
+        },
+        "totalOutputTokens": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "aiGenerationCount",
+        "aiGenerationErrorCount",
+        "eventCounts",
+        "iterationId",
+        "stepCount",
+        "timestamp",
+        "totalInputTokens",
+        "totalOutputTokens"
+      ],
+      "type": "object"
+    },
+    "TaskSetupEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a task is setup",
+      "properties": {
+        "browserName": {
+          "type": "string"
+        },
+        "data": {},
+        "guardrails": {
+          "type": "string"
+        },
+        "hasApiKey": {
+          "type": "boolean"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "keySource": {
+          "enum": [
+            "global",
+            "env",
+            "not_set"
+          ],
+          "type": "string"
+        },
+        "model": {
+          "type": "string"
+        },
+        "provider": {
+          "type": "string"
+        },
+        "proxy": {
+          "type": "string"
+        },
+        "pwCdpEndpoint": {
+          "type": "string"
+        },
+        "pwCdpEndpointCount": {
+          "description": "Total number of CDP endpoints configured (index, not URLs)",
+          "type": "number"
+        },
+        "pwCdpEndpoints": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "pwEndpoint": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "url": {
+          "type": "string"
+        },
+        "vision": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "browserName",
+        "iterationId",
+        "task",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "TaskStartEventData": {
+      "additionalProperties": false,
+      "description": "Event data when a task is started",
+      "properties": {
+        "actionItems": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "plan": {
+          "type": "string"
+        },
+        "successCriteria": {
+          "type": "string"
+        },
+        "task": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        },
+        "url": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "iterationId",
+        "plan",
+        "successCriteria",
+        "task",
+        "timestamp",
+        "url"
+      ],
+      "type": "object"
+    },
+    "TaskValidationEventData": {
+      "additionalProperties": false,
+      "description": "Event data for task validation",
+      "properties": {
+        "completionQuality": {
+          "enum": [
+            "failed",
+            "partial",
+            "complete",
+            "excellent"
+          ],
+          "type": "string"
+        },
+        "feedback": {
+          "type": "string"
+        },
+        "finalAnswer": {
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "observation": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "completionQuality",
+        "finalAnswer",
+        "iterationId",
+        "observation",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "ValidationErrorEventData": {
+      "additionalProperties": false,
+      "description": "Event data for validation errors during action response processing",
+      "properties": {
+        "errors": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "rawResponse": {},
+        "retryCount": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "errors",
+        "iterationId",
+        "rawResponse",
+        "retryCount",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "WaitingEventData": {
+      "additionalProperties": false,
+      "description": "Event data for waiting notifications",
+      "properties": {
+        "iterationId": {
+          "type": "string"
+        },
+        "seconds": {
+          "type": "number"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "iterationId",
+        "seconds",
+        "timestamp"
+      ],
+      "type": "object"
+    },
+    "WebAgentEvent": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskSetupEventData"
+            },
+            "type": {
+              "const": "task:setup",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskStartEventData"
+            },
+            "type": {
+              "const": "task:started",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskCompleteEventData"
+            },
+            "type": {
+              "const": "task:completed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskAbortedEventData"
+            },
+            "type": {
+              "const": "task:aborted",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskValidationEventData"
+            },
+            "type": {
+              "const": "task:validated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ValidationErrorEventData"
+            },
+            "type": {
+              "const": "task:validation_error",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskMetricsEventData"
+            },
+            "type": {
+              "const": "task:metrics",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/TaskMetricsEventData"
+            },
+            "type": {
+              "const": "task:metrics_incremental",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/AIGenerationEventData"
+            },
+            "type": {
+              "const": "ai:generation",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/AIGenerationErrorEventData"
+            },
+            "type": {
+              "const": "ai:generation:error",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ActionExecutionEventData"
+            },
+            "type": {
+              "const": "agent:action",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/AgentStepEventData"
+            },
+            "type": {
+              "const": "agent:step",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ReasoningEventData"
+            },
+            "type": {
+              "const": "agent:reasoned",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ExtractedDataEventData"
+            },
+            "type": {
+              "const": "agent:extracted",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ProcessingEventData"
+            },
+            "type": {
+              "const": "agent:processing",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/StatusMessageEventData"
+            },
+            "type": {
+              "const": "agent:status",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/WaitingEventData"
+            },
+            "type": {
+              "const": "agent:waiting",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ActionExecutionEventData"
+            },
+            "type": {
+              "const": "browser:action_started",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ActionResultEventData"
+            },
+            "type": {
+              "const": "browser:action_completed",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/PageNavigationEventData"
+            },
+            "type": {
+              "const": "browser:navigated",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ScreenshotCapturedEventData"
+            },
+            "type": {
+              "const": "browser:screenshot_captured",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/ScreenshotCapturedImageEventData"
+            },
+            "type": {
+              "const": "browser:screenshot_captured_image",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/CompressionDebugEventData"
+            },
+            "type": {
+              "const": "system:debug_compression",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/MessagesDebugEventData"
+            },
+            "type": {
+              "const": "system:debug_message",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/CdpEndpointConnectedEventData"
+            },
+            "type": {
+              "const": "cdp:endpoint_connected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/CdpEndpointCycleEventData"
+            },
+            "type": {
+              "const": "cdp:endpoint_cycle",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/BrowserReconnectedEventData"
+            },
+            "type": {
+              "const": "browser:reconnected",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/InteractiveFormDataRequestEventData"
+            },
+            "type": {
+              "const": "interactive:form_data:request",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/InteractiveFormDataErrorEventData"
+            },
+            "type": {
+              "const": "interactive:form_data:error",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Union type of all event data types"
+    },
+    "alias-922155206-156-411-922155206-0-129727133205725": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "number"
+        },
+        {
+          "type": "boolean"
+        },
+        {
+          "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+        },
+        {
+          "items": {
+            "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+          },
+          "type": "array"
+        }
+      ],
+      "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+    },
+    "alias-922155206-411-476-922155206-0-129727": {
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "anyOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "string"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/definitions/alias-922155206-411-476-922155206-0-129727"
+              },
+              {
+                "items": {
+                  "$ref": "#/definitions/alias-922155206-156-411-922155206-0-129727133205725"
+                },
+                "type": "array"
+              }
+            ],
+            "description": "A JSON value can be a string, number, boolean, object, array, or null. JSON values can be serialized and deserialized by the JSON.stringify and JSON.parse methods."
+          },
+          {
+            "not": {}
+          }
+        ]
+      },
+      "type": "object"
+    },
+    "global.Buffer": {
+      "additionalProperties": {
+        "type": "number"
+      },
+      "properties": {
+        "BYTES_PER_ELEMENT": {
+          "type": "number"
+        },
+        "buffer": {
+          "additionalProperties": false,
+          "properties": {
+            "byteLength": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "byteLength"
+          ],
+          "type": "object"
+        },
+        "byteLength": {
+          "type": "number"
+        },
+        "byteOffset": {
+          "type": "number"
+        },
+        "length": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "BYTES_PER_ELEMENT",
+        "buffer",
+        "byteLength",
+        "byteOffset",
+        "length"
+      ],
+      "type": "object"
+    }
+  }
+}

--- a/packages/core/scripts/normalize-schema.cjs
+++ b/packages/core/scripts/normalize-schema.cjs
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Post-processes a JSON Schema file from ts-json-schema-generator to fix
+ * a compatibility issue:
+ *
+ * The generator emits `@deprecated "<msg>"` JSDoc annotations as
+ * `"deprecated": "<msg>"` (string). JSON Schema / OpenAPI tooling expects
+ * `deprecated` to be a boolean — the message belongs in `description`.
+ *
+ * This script walks the JSON tree, and for every object that has
+ * `"deprecated": <string>`:
+ *   - sets `deprecated: true`
+ *   - prepends the original message to `description` (creating one if absent)
+ *
+ * Output is re-serialized with 2-space indent and alphabetically-sorted keys,
+ * matching ts-json-schema-generator's default output shape so the drift gate
+ * stays happy.
+ *
+ * Usage:
+ *   node packages/core/scripts/normalize-schema.cjs <schema.json>
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const [inputPath] = process.argv.slice(2);
+if (!inputPath) {
+  console.error("usage: normalize-schema.cjs <schema.json>");
+  process.exit(1);
+}
+
+const schema = JSON.parse(fs.readFileSync(inputPath, "utf-8"));
+
+let fixCount = 0;
+
+function walk(node) {
+  if (node === null || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach(walk);
+    return;
+  }
+  if (typeof node.deprecated === "string") {
+    const msg = node.deprecated.trim();
+    node.deprecated = true;
+    const prefix = `Deprecated. ${msg}`.trim();
+    node.description = node.description ? `${prefix} ${node.description}`.trim() : prefix;
+    fixCount++;
+  }
+  for (const key of Object.keys(node)) {
+    walk(node[key]);
+  }
+}
+
+walk(schema);
+
+// Sort keys alphabetically at every object level to match the generator's
+// default output so the drift gate continues to compare cleanly.
+function sortReplacer(_key, value) {
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const sorted = {};
+    for (const k of Object.keys(value).sort()) {
+      sorted[k] = value[k];
+    }
+    return sorted;
+  }
+  return value;
+}
+
+fs.writeFileSync(inputPath, JSON.stringify(schema, sortReplacer, 2) + "\n");
+console.error(
+  `normalize-schema: fixed ${fixCount} deprecated string value(s) in ${path.basename(inputPath)}`,
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
+      ts-json-schema-generator:
+        specifier: 2.5.0
+        version: 2.5.0
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -4683,6 +4686,11 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-json-schema-generator@2.5.0:
+    resolution: {integrity: sha512-sYY7AInozRbtj9OD3ynJJuMDWZ5lGxzxTevtmH3W9Hnd2J2szBC0HdPqSyuIirXnQ6g8KDJxS/HENoypUwBrlg==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4730,6 +4738,11 @@ packages:
 
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.2:
     resolution: {integrity: sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==}
@@ -9167,6 +9180,16 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-json-schema-generator@2.5.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      commander: 14.0.3
+      json5: 2.2.3
+      normalize-path: 3.0.0
+      safe-stable-stringify: 2.5.0
+      tslib: 2.8.1
+      typescript: 5.9.3
+
   tslib@2.8.1: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3):
@@ -9219,6 +9242,8 @@ snapshots:
   type-fest@4.41.0: {}
 
   typedarray@0.0.6: {}
+
+  typescript@5.9.3: {}
 
   typescript@6.0.2: {}
 


### PR DESCRIPTION
## Summary

Adds a build step that produces `packages/core/schemas/webagent-event.json` from the `WebAgentEvent` discriminated union via `ts-json-schema-generator`. The committed artifact is the source-of-truth for downstream consumers — specifically `tabs-api`, which pins a pilo commit SHA and fetches this schema during its OpenAPI regen to type the `/v1/automate` endpoint's SSE stream in `@tabstack/sdk` and Stainless's generated API reference docs.

Complements [mozilla/pilo#394](https://github.com/mozilla/pilo/pull/394), which flattened `AIGenerationEventData`'s AI SDK type indirection so the full `WebAgentEvent` union now extracts cleanly. Before that refactor, extraction bailed out on one variant. With the refactor in place, all 29 event variants appear in the schema with typed payloads.

## Changes

- **`packages/core/package.json`:**
  - Dev dep `ts-json-schema-generator@^2.5.0`.
  - `generate:schemas` script — runs the generator over `src/events.ts` with `-t WebAgentEvent`, writing `schemas/webagent-event.json`.
  - `check:schemas` script — regenerates and runs `git diff --exit-code schemas/` to detect drift.
- **`packages/core/schemas/webagent-event.json`:** 4520-line initial artifact covering all 29 `WebAgentEventType` variants + transitive payload types.
- **`.github/workflows/build-test.yml`:** `core` job runs `check:schemas` between typecheck and tests. Any change to `events.ts` that isn't reflected in the committed schema fails CI.

## Consumer impact

None in the pilo repo — purely additive. Downstream:

- **`tabs-api`** will consume this schema via a pinned-SHA fetch, running its own codegen to produce the typed `AutomateEvent` spec consumed by Stainless. Work in progress on the event-schema-pipeline spike branch.
- **Other consumers** (none today) can fetch `webagent-event.json` at a pinned pilo SHA via `gh api` / raw content URL / git clone.

## Test plan

- [ ] `pnpm install` resolves the new devDep.
- [ ] `pnpm --filter pilo-core run generate:schemas` produces `schemas/webagent-event.json` deterministically (4520 lines).
- [ ] `pnpm --filter pilo-core run check:schemas` exits 0 on a clean branch (no drift).
- [ ] CI's `core` job runs `check:schemas` after typecheck; intentionally breaking `events.ts` without regenerating fails CI.
- [ ] No other test surface affected — existing tests continue to pass.

## Risks

- **Generator version drift.** If `ts-json-schema-generator` changes output format between versions (field ordering, description handling, etc.), CI flags a spurious drift. Mitigation: pinned range `^2.5.0`; any generator bump is an explicit PR.
- **Schema file format churn.** If consumers need a different shape (e.g., a separate events-map.json sidecar), we can add more `generate:*` scripts without affecting this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)