### PR TITLE
fix(ci): derive release version from tag and fix npm OIDC auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,6 +45,18 @@ jobs:
       - name: Run tests
         run: pnpm -r run test
 
+      - name: Set package version from release tag
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          TAG_VERSION="${TAG_NAME#v}"
+          if ! [[ "$TAG_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Release tag '$TAG_NAME' is not a valid semver version"
+            exit 1
+          fi
+          npm pkg set version="$TAG_VERSION"
+          echo "Set package.json version to $TAG_VERSION"
+
       - name: Create package tarball
         id: tarball
         run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tabstack/pilo",
-  "version": "0.18.0",
+  "version": "0.0.0-dev",
   "description": "AI-powered web automation library and CLI tool",
   "type": "module",
   "engines": {


### PR DESCRIPTION
## Summary
- Release workflow was packing the stale `package.json` version (0.18.0) and
  trying to publish that under the v0.19.0 release, then hit a 404 from npm.
  Two root causes:
  - The old release-branch flow bumped `package.json` manually. PR #337
    dropped that flow without replacement, so v0.19.0 went out with a stale
    version field.
  - npm CLI 10.x (default on Node 22) doesn't support trusted publishing OIDC
    auth, so npm fell back to the placeholder `_authToken` that
    `actions/setup-node` writes and got 404'd.
- Workflow now injects the version from the release tag via `npm pkg set
  version=...` before `npm pack`, and upgrades npm to latest so trusted
  publishing works.
- `package.json` version is now a `0.0.0-dev` placeholder. The tag is the only
  source of truth for the published version.

## Test plan
- [ ] Delete the broken v0.19.0 GitHub release + tag
- [ ] Merge this PR
- [ ] Recreate the v0.19.0 release from the new main
- [ ] Confirm the release workflow passes, `tabstack-pilo-0.19.0.tgz` is uploaded to the release, and `npm view @tabstack/pilo versions` shows 0.19.0