### PR TITLE
fix(ci): run release on node 24 for npm 11 trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
-
-      - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v2


### PR DESCRIPTION
## Summary
- The v0.19.1 release failed on the `Upgrade npm for trusted publishing`
  step I added in #396. `npm install -g npm@latest` on Node 22 hit npm's
  known self-replacement bug where the new CLI ends up missing its own
  runtime deps (`Cannot find module 'promise-retry'`).
- Simpler fix: use Node 24 LTS, which ships with npm 11.6+ (supports
  trusted publishing natively). No self-upgrade dance required.
- Removes the `npm install -g npm@latest` step.

## Test plan
- [ ] Merge this PR
- [ ] Delete the broken v0.19.1 GitHub release + tag
- [ ] Recreate v0.19.1 from the new main
- [ ] Confirm release workflow succeeds and `npm view @tabstack/pilo versions` shows 0.19.1