### PR TITLE
feat(core): export AutomateStreamEvent covering full /automate SSE stream

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,7 +26,7 @@
     "typecheck": "pnpm run bundle:aria && tsc --project tsconfig.check.json",
     "test": "vitest run",
     "test:only": "pnpm run bundle:aria && pnpm run test",
-    "generate:schemas": "ts-json-schema-generator --path src/events.ts --tsconfig tsconfig.json --type WebAgentEvent --out schemas/webagent-event.json && node scripts/normalize-schema.cjs schemas/webagent-event.json",
+    "generate:schemas": "ts-json-schema-generator --path src/events.ts --tsconfig tsconfig.json --type AutomateStreamEvent --out schemas/webagent-event.json && node scripts/normalize-schema.cjs schemas/webagent-event.json",
     "check:schemas": "pnpm run generate:schemas && git diff --exit-code schemas/"
   },
   "dependencies": {

--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -1,5 +1,5 @@
 {
-  "$ref": "#/definitions/WebAgentEvent",
+  "$ref": "#/definitions/AutomateStreamEvent",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "AIGenerationErrorEventData": {
@@ -3168,6 +3168,65 @@
       ],
       "type": "object"
     },
+    "AutomateStreamEvent": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/WebAgentEvent"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/StreamCompleteEventData"
+            },
+            "type": {
+              "const": "complete",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/StreamDoneEventData"
+            },
+            "type": {
+              "const": "done",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/StreamErrorEventData"
+            },
+            "type": {
+              "const": "error",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Top-level discriminated union of every event a `/v1/automate` SSE client can receive on the wire. Composes  {@link  WebAgentEvent }  (agent-loop events emitted via  {@link  WebAgentEventEmitter } ) with the stream-wrapper events (`complete`, `done`, `error`) emitted by the HTTP route handler after the agent returns.\n\nThis is the authoritative source-of-truth for downstream SDK generation. Its JSON Schema export (`schemas/automate-stream-event.json`) is consumed by tabs-api to type `/v1/automate`'s SSE response in `@tabstack/sdk`."
+    },
     "BrowserReconnectedEventData": {
       "additionalProperties": false,
       "description": "Event data when the browser reconnects after a mid-task disconnect",
@@ -3626,6 +3685,53 @@
       ],
       "type": "object"
     },
+    "StreamCompleteEventData": {
+      "$ref": "#/definitions/TaskExecutionResult",
+      "description": "Payload for the `complete` stream event. Structurally identical to TaskExecutionResult from webAgent.ts — the `complete` event's data is the agent's final TaskExecutionResult, stringified onto the SSE stream."
+    },
+    "StreamDoneEventData": {
+      "additionalProperties": {
+        "not": {}
+      },
+      "description": "Payload for the `done` stream terminator event. Empty today; reserved for future metadata.",
+      "type": "object"
+    },
+    "StreamErrorEventData": {
+      "additionalProperties": false,
+      "description": "Payload for the top-level `error` stream event. Emitted when an uncaught error escapes the task runner. Mirrors `ErrorResponse` from the server package's `taskRunner.ts` — kept structurally aligned so schema and runtime stay consistent. Distinct from agent-level error events like `ai:generation:error` and `task:validation_error`, which are emitted through the normal event emitter during the agent loop.",
+      "properties": {
+        "error": {
+          "additionalProperties": false,
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "message": {
+              "type": "string"
+            },
+            "timestamp": {
+              "description": "ISO-8601 timestamp",
+              "type": "string"
+            }
+          },
+          "required": [
+            "message",
+            "code",
+            "timestamp"
+          ],
+          "type": "object"
+        },
+        "success": {
+          "const": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "success",
+        "error"
+      ],
+      "type": "object"
+    },
     "TaskAbortedEventData": {
       "additionalProperties": false,
       "description": "Event data when a task is aborted",
@@ -3675,6 +3781,90 @@
         "finalAnswer",
         "iterationId",
         "timestamp"
+      ],
+      "type": "object"
+    },
+    "TaskError": {
+      "additionalProperties": false,
+      "description": "Structured error information for failed tasks",
+      "properties": {
+        "code": {
+          "$ref": "#/definitions/TaskErrorCode",
+          "description": "Error code for programmatic handling"
+        },
+        "message": {
+          "description": "Human-readable error message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "code",
+        "message"
+      ],
+      "type": "object"
+    },
+    "TaskErrorCode": {
+      "description": "Error codes for task failures",
+      "enum": [
+        "TASK_ABORTED",
+        "MAX_ITERATIONS",
+        "MAX_ERRORS",
+        "TASK_FAILED"
+      ],
+      "type": "string"
+    },
+    "TaskExecutionResult": {
+      "additionalProperties": false,
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/TaskError",
+          "description": "Error details when success is false"
+        },
+        "finalAnswer": {
+          "description": "Final answer or result from the agent",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "stats": {
+          "additionalProperties": false,
+          "description": "Execution statistics",
+          "properties": {
+            "actions": {
+              "type": "number"
+            },
+            "durationMs": {
+              "type": "number"
+            },
+            "endTime": {
+              "type": "number"
+            },
+            "iterations": {
+              "type": "number"
+            },
+            "startTime": {
+              "type": "number"
+            }
+          },
+          "required": [
+            "iterations",
+            "actions",
+            "startTime",
+            "endTime",
+            "durationMs"
+          ],
+          "type": "object"
+        },
+        "success": {
+          "description": "Whether the task completed successfully",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "success",
+        "finalAnswer",
+        "stats"
       ],
       "type": "object"
     },

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -35,6 +35,10 @@ export type {
   ValidationErrorEventData,
   InteractiveFormDataRequestEventData,
   InteractiveFormDataErrorEventData,
+  AutomateStreamEvent,
+  StreamCompleteEventData,
+  StreamDoneEventData,
+  StreamErrorEventData,
 } from "./events.js";
 export { GenericLogger } from "./loggers/generic.js";
 export { ConsoleLogger } from "./loggers/console.js";

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -1,6 +1,7 @@
 import { ModelMessage } from "ai";
 import { EventEmitter } from "eventemitter3";
 import type { FormFieldRequest } from "./types/interactive.js";
+import type { TaskExecutionResult } from "./webAgent.js";
 
 /**
  * Enum of all possible event types in the web agent
@@ -387,6 +388,65 @@ export type WebAgentEvent =
       type: WebAgentEventType.INTERACTIVE_FORM_DATA_ERROR;
       data: InteractiveFormDataErrorEventData;
     };
+
+// ============================================================================
+// Stream-wrapper events
+// ============================================================================
+//
+// The events below are emitted by the HTTP route handler
+// (packages/server/src/routes/pilo.ts) after the agent loop completes, not
+// through WebAgentEventEmitter. They terminate the SSE stream. Wire-level
+// consumers see them interleaved with WebAgentEvents on the response stream,
+// so the authoritative schema for /v1/automate is AutomateStreamEvent (below),
+// which composes both sets.
+
+/**
+ * Payload for the `complete` stream event. Structurally identical to
+ * TaskExecutionResult from webAgent.ts — the `complete` event's data is
+ * the agent's final TaskExecutionResult, stringified onto the SSE stream.
+ */
+export type StreamCompleteEventData = TaskExecutionResult;
+
+/**
+ * Payload for the `done` stream terminator event. Empty today; reserved for
+ * future metadata.
+ */
+export type StreamDoneEventData = Record<string, never>;
+
+/**
+ * Payload for the top-level `error` stream event. Emitted when an uncaught
+ * error escapes the task runner. Mirrors `ErrorResponse` from the server
+ * package's `taskRunner.ts` — kept structurally aligned so schema and
+ * runtime stay consistent. Distinct from agent-level error events like
+ * `ai:generation:error` and `task:validation_error`, which are emitted
+ * through the normal event emitter during the agent loop.
+ */
+export interface StreamErrorEventData {
+  success: false;
+  error: {
+    message: string;
+    code: string;
+    /** ISO-8601 timestamp */
+    timestamp: string;
+  };
+}
+
+/**
+ * Top-level discriminated union of every event a `/v1/automate` SSE client
+ * can receive on the wire. Composes {@link WebAgentEvent} (agent-loop events
+ * emitted via {@link WebAgentEventEmitter}) with the stream-wrapper events
+ * (`complete`, `done`, `error`) emitted by the HTTP route handler after the
+ * agent returns.
+ *
+ * This is the authoritative source-of-truth for downstream SDK generation.
+ * Its JSON Schema export (`schemas/automate-stream-event.json`) is consumed
+ * by tabs-api to type `/v1/automate`'s SSE response in `@tabstack/sdk`.
+ */
+export type AutomateStreamEvent =
+  | WebAgentEvent
+  | { type: "complete"; data: StreamCompleteEventData }
+  | { type: "done"; data: StreamDoneEventData }
+  | { type: "error"; data: StreamErrorEventData };
 
 /**
  * Event emitter for WebAgent events


### PR DESCRIPTION
## Description

Adds a new `AutomateStreamEvent` discriminated union covering every event a `/v1/automate` SSE client sees on the wire — composed of `WebAgentEvent` plus the three stream-wrapper events (`complete`, `done`, `error`) emitted directly by the server route. Repoints the exported `webagent-event.json` root `$ref` at `AutomateStreamEvent`, so the single schema file is now the authoritative wire-level source for `/automate` SDK codegen.

## The gap this fixes

`WebAgentEvent` is the authoritative union for events emitted via `WebAgentEventEmitter` inside the agent loop. But `packages/server/src/routes/pilo.ts:42-50` emits three additional events directly on the SSE stream after `runTask()` returns:

- `complete` — carries a `TaskExecutionResult` (`success`, `finalAnswer`, `error?`, `stats`)
- `done` — empty terminator
- `error` — mirrors `ErrorResponse` from `packages/server/src/taskRunner.ts` (nested `{ success: false, error: { message, code, timestamp } }`)

None of these appear in `WebAgentEvent`, so none appear in the exported schema. Downstream consumers that consume the schema to type the SSE stream (tabs-api → `@tabstack/sdk` and `tabstack`) don't get typed access to them.

The symptom in `tabstack` (Python SDK v2.5.0) is the clearest: the `AutomateEvent` discriminated union has no variant for `event: "complete"`, so Pydantic falls back to the wrong variant (currently `V1AutomateEventAgentActionData`) and `finalAnswer`/`stats`/`success` leak through as undeclared camelCase extras. Any Python guide that uses `event.event == "complete"` followed by dict-style or snake_case typed access fails or silently mistypes.

## What this PR does

- Adds `StreamCompleteEventData` (= `TaskExecutionResult`), `StreamDoneEventData` (empty), and `StreamErrorEventData` to `packages/core/src/events.ts`.
- Adds the `AutomateStreamEvent` union composing `WebAgentEvent` with the three wrapper variants.
- Exports all new types from `packages/core/src/core.ts`.
- Updates `generate:schemas` so the existing `schemas/webagent-event.json` file now has its root `$ref` pointing at `AutomateStreamEvent` instead of `WebAgentEvent`. `WebAgentEvent` stays available as `#/definitions/WebAgentEvent` inside the same file for any consumer that wants the agent-only subset.
- No changes to runtime emission or the wire format — this PR describes what's already on the wire, it doesn't change it.

## Design notes

- **Why one schema file, with AutomateStreamEvent as the new root.** The original draft of this PR emitted a second file (`automate-stream-event.json`) alongside `webagent-event.json` for backward compat, but the two would have ~95% overlap (same `WebAgentEvent` definition nested inside the new one). Given tabs-api is the only known consumer and it's going to need an update regardless (see follow-up section below), consolidating to a single authoritative file is cleaner. Kept the existing filename so tabs-api's `gh api contents/packages/core/schemas/webagent-event.json` fetch URL doesn't break.
- **Why `StreamCompleteEventData = TaskExecutionResult`.** The route handler emits the result returned by `runTask()` directly, so the schema type is the same shape. Aliasing (vs. redefining) ensures they stay aligned automatically.
- **Why `StreamErrorEventData` duplicates `ErrorResponse` structurally.** `ErrorResponse` lives in the server package's `taskRunner.ts`; importing it from core would invert the layering. The shape is small and stable, and if it ever drifts, `check:schemas` diffs will surface it alongside any runtime-side change.
- **Why not refactor the route to emit through the event emitter instead.** The route's `complete`/`done`/`error` events are flush-time HTTP-layer concerns, not agent reasoning events. Keeping `WebAgentEventEmitter` strictly for agent-loop events preserves a clean abstraction for subscribers (e.g., `ConsoleLogger.handleTaskComplete`) that already target specific agent events.

## Wire compatibility

Not a breaking change to the wire protocol. Same event names, same JSON payloads — this PR only formalizes the schema to match what's already emitted.

**Breaking at the schema-file level:** any consumer reading the root `$ref` will see it move from `#/definitions/WebAgentEvent` to `#/definitions/AutomateStreamEvent`. The `WebAgentEvent` definition is still in the same file at the same path, so consumers who want the agent-only union can reference it directly. tabs-api is the only known consumer per #395.

At the SDK level, regenerating against the new schema would tighten the Python typing for `complete`/`done`/`error`. Existing Python code that was relying on undeclared camelCase extras on the (currently mis-discriminated) `complete` event would need to switch to the properly-typed snake_case attributes. That's an accidental-workaround being replaced by a documented API.

## Downstream follow-up

tabs-api's overlay generator (`scripts/codegen/events/swag_overlay.go`) needs two small updates after this lands:

1. `generatePiloOverlay` currently calls `payloadMapFromUnionVariants("WebAgentEvent")` — change to `"AutomateStreamEvent"` to pick up the new root.
2. `payloadMapFromUnionVariants` currently expects every `anyOf` variant to carry a `properties.type.const` discriminator value. The new union interleaves one `$ref` variant (pointing to `WebAgentEvent`) with three inline variants, so the extractor needs to dereference `$ref`s to get at their variants.

This is a companion to the docs cleanup in [stainless-sdks/tabstack-api-docs#6](https://github.com/stainless-sdks/tabstack-api-docs/pull/6), which switched the Python interactive-mode samples to `task:completed` as a workaround for the mistyped `complete` event. Once this lands and tabs-api regenerates, the guides can use `complete` cleanly in both languages.

## PR Type

- New Feature (schema addition; no runtime behavior change)

## Related issues

Complements #395 (WebAgentEvent schema release artifact); unblocks SDK typing for the `/automate` stream-terminator events.

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally (`pnpm --filter pilo-core run check:schemas`, `typecheck`, `test` — 658/658 passing; `pnpm run typecheck` across the monorepo clean)
- [x] New and existing tests pass locally
- [ ] I have added tests that prove my fix/feature works — the schema itself is the test artifact; `check:schemas` CI verifies it stays regenerable
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

## AI Usage

Design and implementation done in pairing with Claude Code (Opus 4.7). Human reviewed the design tradeoffs (wire compatibility, layering between core and server, whether to emit stream events through `WebAgentEventEmitter` vs. keep them route-local, whether to keep one or two schema files) before and during implementation.