### PR TITLE
feat(telemetry): opt-in PILO_TELEMETRY_INCLUDE_ERROR_DETAILS for full exception data

### DIFF
--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -262,10 +262,7 @@ export function recordSanitizedException(
     span.setAttribute("pilo.error.code", opts.code);
   }
 
-  if (
-    process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS === "1" &&
-    error instanceof Error
-  ) {
+  if (process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS === "1" && error instanceof Error) {
     // Opt-in unsafe path: OTel's recordException emits message + stacktrace.
     span.recordException(error);
   } else {

--- a/packages/core/src/telemetry/tracing.ts
+++ b/packages/core/src/telemetry/tracing.ts
@@ -241,6 +241,15 @@ async function withSpanAsync<T>(
  * - `pilo.error.class` attribute (same value as `exception.type`) so dashboards
  *   can filter on it without depending on OTel exception-event semantics.
  * - `pilo.error.code` attribute when `opts.code` is provided.
+ *
+ * **Opt-in relaxation for non-customer-facing environments**: setting the
+ * env var `PILO_TELEMETRY_INCLUDE_ERROR_DETAILS=1` falls back to OTel's
+ * standard `span.recordException`, which emits `exception.message` and
+ * `exception.stacktrace`. Intended for staging/eval contexts where the
+ * trace data is consumed by automation, not served to customers. **Never
+ * enable in production** — the trace data may include user task text,
+ * page content, or prompt fragments. Default behaviour (env var unset or
+ * any value other than "1") is fully sanitized.
  */
 export function recordSanitizedException(
   span: Span,
@@ -248,9 +257,19 @@ export function recordSanitizedException(
   opts: { code?: string } = {},
 ): void {
   const errorClass = error instanceof Error ? error.constructor.name : "Unknown";
-  span.addEvent("exception", { "exception.type": errorClass });
   span.setAttribute("pilo.error.class", errorClass);
   if (opts.code) {
     span.setAttribute("pilo.error.code", opts.code);
+  }
+
+  if (
+    process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS === "1" &&
+    error instanceof Error
+  ) {
+    // Opt-in unsafe path: OTel's recordException emits message + stacktrace.
+    span.recordException(error);
+  } else {
+    // Default: only the class name. No message, no stacktrace.
+    span.addEvent("exception", { "exception.type": errorClass });
   }
 }

--- a/packages/core/test/telemetry/tracing.test.ts
+++ b/packages/core/test/telemetry/tracing.test.ts
@@ -264,45 +264,145 @@ describe("tracing helpers", () => {
       expect(mockAddEvent).toHaveBeenCalledWith("exception", { "exception.type": "TypeError" });
     });
 
-    it("never emits exception.message or exception.stacktrace", async () => {
-      const mockAddEvent = vi.fn();
-      const span = {
-        setAttribute: vi.fn().mockReturnThis(),
-        setStatus: vi.fn().mockReturnThis(),
-        recordException: vi.fn(),
-        addEvent: mockAddEvent,
-        end: vi.fn(),
-      };
+    it("by default, never emits exception.message or exception.stacktrace", async () => {
+      const prev = process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      try {
+        const mockAddEvent = vi.fn();
+        const span = {
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: vi.fn(),
+          addEvent: mockAddEvent,
+          end: vi.fn(),
+        };
 
-      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
-      recordSanitizedException(span as any, new Error("DO NOT LOG THIS SENTINEL"));
+        const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+        recordSanitizedException(span as any, new Error("DO NOT LOG THIS SENTINEL"));
 
-      for (const call of mockAddEvent.mock.calls) {
-        const attrs = (call[1] as Record<string, unknown>) ?? {};
-        expect(attrs).not.toHaveProperty("exception.message");
-        expect(attrs).not.toHaveProperty("exception.stacktrace");
+        for (const call of mockAddEvent.mock.calls) {
+          const attrs = (call[1] as Record<string, unknown>) ?? {};
+          expect(attrs).not.toHaveProperty("exception.message");
+          expect(attrs).not.toHaveProperty("exception.stacktrace");
+        }
+        const allCalls = JSON.stringify([
+          mockAddEvent.mock.calls,
+          (span.setAttribute as any).mock.calls,
+        ]);
+        expect(allCalls).not.toContain("DO NOT LOG THIS SENTINEL");
+      } finally {
+        if (prev === undefined) delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+        else process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = prev;
       }
-      const allCalls = JSON.stringify([
-        mockAddEvent.mock.calls,
-        (span.setAttribute as any).mock.calls,
-      ]);
-      expect(allCalls).not.toContain("DO NOT LOG THIS SENTINEL");
     });
 
-    it("never calls span.recordException (avoids OTel's default message+stack emission)", async () => {
-      const mockRecordException = vi.fn();
-      const span = {
-        setAttribute: vi.fn().mockReturnThis(),
-        setStatus: vi.fn().mockReturnThis(),
-        recordException: mockRecordException,
-        addEvent: vi.fn(),
-        end: vi.fn(),
-      };
+    it("by default, never calls span.recordException (avoids OTel's default message+stack emission)", async () => {
+      const prev = process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      try {
+        const mockRecordException = vi.fn();
+        const span = {
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: mockRecordException,
+          addEvent: vi.fn(),
+          end: vi.fn(),
+        };
 
-      const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
-      recordSanitizedException(span as any, new Error("anything"));
+        const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+        recordSanitizedException(span as any, new Error("anything"));
 
-      expect(mockRecordException).not.toHaveBeenCalled();
+        expect(mockRecordException).not.toHaveBeenCalled();
+      } finally {
+        if (prev === undefined) delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+        else process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = prev;
+      }
+    });
+
+    it("when PILO_TELEMETRY_INCLUDE_ERROR_DETAILS=1, calls span.recordException with the full error", async () => {
+      const prev = process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = "1";
+      try {
+        const mockRecordException = vi.fn();
+        const mockAddEvent = vi.fn();
+        const span = {
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: mockRecordException,
+          addEvent: mockAddEvent,
+          end: vi.fn(),
+        };
+
+        const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+        const err = new TypeError("opt-in reveals this");
+        recordSanitizedException(span as any, err);
+
+        // Opt-in: OTel's recordException emits exception.message + stacktrace.
+        expect(mockRecordException).toHaveBeenCalledTimes(1);
+        expect(mockRecordException).toHaveBeenCalledWith(err);
+        // pilo.error.class still set unconditionally for dashboard parity.
+        expect(span.setAttribute).toHaveBeenCalledWith("pilo.error.class", "TypeError");
+        // The sanitized addEvent fallback should NOT also fire on the opt-in
+        // path — avoids double-recording.
+        expect(mockAddEvent).not.toHaveBeenCalled();
+      } finally {
+        if (prev === undefined) delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+        else process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = prev;
+      }
+    });
+
+    it("when PILO_TELEMETRY_INCLUDE_ERROR_DETAILS=1 but throw is non-Error, falls back to sanitized path", async () => {
+      const prev = process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = "1";
+      try {
+        const mockRecordException = vi.fn();
+        const mockAddEvent = vi.fn();
+        const span = {
+          setAttribute: vi.fn().mockReturnThis(),
+          setStatus: vi.fn().mockReturnThis(),
+          recordException: mockRecordException,
+          addEvent: mockAddEvent,
+          end: vi.fn(),
+        };
+
+        const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+        recordSanitizedException(span as any, "a string");
+
+        // Non-Error can't carry message/stack meaningfully; the sanitized
+        // addEvent path is the safety net.
+        expect(mockRecordException).not.toHaveBeenCalled();
+        expect(mockAddEvent).toHaveBeenCalledWith("exception", { "exception.type": "Unknown" });
+      } finally {
+        if (prev === undefined) delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+        else process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = prev;
+      }
+    });
+
+    it("treats env var values other than '1' as default-sanitized", async () => {
+      const prev = process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+      try {
+        for (const val of ["0", "true", "yes", "", "TRUE"]) {
+          process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = val;
+          const mockRecordException = vi.fn();
+          const mockAddEvent = vi.fn();
+          const span = {
+            setAttribute: vi.fn().mockReturnThis(),
+            setStatus: vi.fn().mockReturnThis(),
+            recordException: mockRecordException,
+            addEvent: mockAddEvent,
+            end: vi.fn(),
+          };
+          const { recordSanitizedException } = await import("../../src/telemetry/tracing.js");
+          recordSanitizedException(span as any, new Error("would-leak-if-misparsed"));
+          expect(mockRecordException, `value=${val}`).not.toHaveBeenCalled();
+          expect(mockAddEvent, `value=${val}`).toHaveBeenCalledWith("exception", {
+            "exception.type": "Error",
+          });
+        }
+      } finally {
+        if (prev === undefined) delete process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS;
+        else process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS = prev;
+      }
     });
 
     it("sets class to 'Unknown' for non-Error throws", async () => {


### PR DESCRIPTION
## Summary

Adds an opt-in env var, `PILO_TELEMETRY_INCLUDE_ERROR_DETAILS=1`, that relaxes `recordSanitizedException` to emit OTel's standard `exception.message` and `exception.stacktrace` on the span event. Default (env var unset, or any value other than the literal `"1"`) preserves the current sanitized behaviour — only `pilo.error.class` and the bare `exception.type` event.

## Why

The eval pipeline at https://github.com/Mozilla-Ocho/pilo-evals-judge runs tabstack agents against staging and consumes traces by automation, not customers. Today every span exception goes through `recordSanitizedException`, which deliberately strips message + stack to protect against leaking task text, page content, or prompt fragments into prod telemetry. That's correct for prod, but it means an eval observing `pilo.error.class: ToolExecutionError` has no further detail to feed into a downstream judge or improvement prompt.

This unblocks: an eval report-generator that pulls rich span data via Cloud Trace and synthesizes actionable feedback per task ("agent failed on step 0 because element selector X timed out, then recovered after 4 steps").

## What changes

- **`packages/core/src/telemetry/tracing.ts`** — `recordSanitizedException` now branches on `process.env.PILO_TELEMETRY_INCLUDE_ERROR_DETAILS === "1"`. Strict equality on the literal `"1"` so typos / boolean intent don't accidentally enable the unsafe path. Non-Error throws always fall through to the sanitized path even when opt-in (nothing meaningful to record).
- **`packages/core/test/telemetry/tracing.test.ts`** — existing assertions ("never emits message/stack", "never calls recordException") rescoped to "by default". Added four new tests covering opt-in with Error, opt-in with non-Error, four common misconfigured env values, and preservation of the sentinel assertion in default mode.

## Where the env var needs to land for the eval pipeline

The chain at runtime is:

```
cloud-eval tabstack agent-runner  (tabstack-eval npm package, just a small @tabstack/sdk caller)
    ↓ HTTPS POST /v1/automate
tabs-api  (staging: stage.tabs-api.tabs.nonprod.webservices.mozgcp.net)
    ↓ WebSocket (with traceparent propagation)
pilo-server  ← `recordSanitizedException` lives here
```

`recordSanitizedException` is in `pilo-core`, called by `pilo-server` (and only there for the eval path). So the env var must be set on the **staging pilo-server deployment**, not on the cloud-eval container. The agent-runner container in cloud-eval is just a tiny SDK caller — it doesn't run any pilo code that touches this function.

That deployment lives outside this repo (mozcloud or the equivalent webservices deploy pipeline). Coordinating the env-var addition there is the operational follow-up after this PR merges.

## Safety properties

- Prod pilo-server deployments don't set the env var → behaviour identical to today.
- The "DO NOT LOG THIS SENTINEL" assertion still passes in default mode.
- The console-leak canary from #392 is unaffected — this PR touches span events only, not console output.
- Strict-equal `=== "1"` means a misconfigured `PILO_TELEMETRY_INCLUDE_ERROR_DETAILS=true` falls back to sanitized rather than enabling unsafe.

## Test plan

- [x] `pnpm test` in `packages/core` — 669/669 passing locally
- [x] Verbose run on `tracing.test.ts` — all 30 cases pass including the 4 new ones
- [x] `pnpm format:check` clean (initial CI failure on this; fixed in commit 2)
- [ ] After merge: env var set on the **staging pilo-server** deployment manifest (separate change, lives in mozcloud / webservices deploy). Then submit a tabstack workflow that hits a known error path; verify the resulting Cloud Trace span carries `exception.message` and `exception.stacktrace` events instead of just `exception.type`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)