### PR TITLE
fix(release): build before packing to ensure dist/ is included

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,13 @@ jobs:
           npm pkg set version="$TAG_VERSION"
           echo "Set package.json version to $TAG_VERSION"
 
+      - name: Build
+        run: pnpm run build
+
       - name: Create package tarball
         id: tarball
         run: |
-          npm pack
+          npm pack --ignore-scripts
           echo "filename=$(ls *.tgz)" >> $GITHUB_OUTPUT
 
       - name: Upload tarball to release


### PR DESCRIPTION
## Problem

The published package is missing its `dist/` directory entirely, making the installed CLI non-functional. `npm install -g @tabstack/pilo` installs only `LICENSE`, `README.md`, and `package.json`.

## Root cause

`npm pack` does not run `prepublishOnly` — it runs `prepare` and `prepack`. The `prepare` script only builds the core package (`pnpm --filter pilo-core run build`), not the root tsup build that produces `dist/cli/` and `dist/core/`. So the tarball was created before the build artifacts existed.

## Fix

Add an explicit `pnpm run build` step before `npm pack`, and use `--ignore-scripts` on `npm pack` to avoid re-running lifecycle hooks after the build has already completed.

## Verification

Run `npm pack --dry-run` after this change and confirm `dist/` entries appear in the tarball contents.