### PR TITLE
fix(server): prevent pilo crash on WebSocket send after close (TAB-949)

### DIFF
--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -518,6 +518,65 @@ describe("piloWs", () => {
     });
   });
 
+  describe("send guards", () => {
+    it("drops messages when the socket is no longer OPEN", async () => {
+      let resumeEmit!: () => void;
+      const emitGate = new Promise<void>((resolve) => {
+        resumeEmit = resolve;
+      });
+
+      mockRunTask.mockImplementation(async ({ sendEvent }) => {
+        // Agent waits for the test to disconnect the client, then emits.
+        await emitGate;
+        await sendEvent("agent:action", { foo: "bar" });
+        return { success: true };
+      });
+
+      const h = createTestHarness();
+      h.sendMessage({ event: "task:details", data: { task: "test" } });
+
+      // Mid-task: simulate client disconnect, then let the agent emit.
+      (h.mockWs as any).readyState = 3;
+      resumeEmit();
+
+      await vi.runAllTimersAsync();
+
+      const sentEvents = h.mockRawSend.mock.calls.map((c) => JSON.parse(c[0]).event);
+      expect(sentEvents).not.toContain("agent:action");
+      expect(sentEvents).not.toContain("complete");
+    });
+
+    it("swallows raw.send errors so they cannot escape as unhandled rejections", async () => {
+      let sendEventOutcome: "resolved" | "rejected" = "rejected";
+      mockRunTask.mockImplementation(async ({ sendEvent }) => {
+        try {
+          await sendEvent("agent:action", { foo: "bar" });
+          sendEventOutcome = "resolved";
+        } catch {
+          sendEventOutcome = "rejected";
+        }
+        return { success: true };
+      });
+
+      const h = createTestHarness();
+      // Simulate ws@8 reporting a post-close failure via the callback for the
+      // agent:action event only (other events still succeed).
+      h.mockRawSend.mockImplementation((data, cb) => {
+        const parsed = JSON.parse(data);
+        if (parsed.event === "agent:action") {
+          cb?.(new Error("WebSocket is not open: readyState 3 (CLOSED)"));
+          return;
+        }
+        cb?.();
+      });
+
+      h.sendMessage({ event: "task:details", data: { task: "test" } });
+      await vi.runAllTimersAsync();
+
+      expect(sendEventOutcome).toBe("resolved");
+    });
+  });
+
   describe("onError", () => {
     it("should abort the task on WebSocket error", async () => {
       let receivedSignal: AbortSignal | undefined;

--- a/packages/server/src/routes/piloWs.ts
+++ b/packages/server/src/routes/piloWs.ts
@@ -38,13 +38,20 @@ interface PendingRequest {
   timer: ReturnType<typeof setTimeout>;
 }
 
+/**
+ * Send a flat { event, data } message to the client.
+ *
+ * Always resolves: if the socket is not OPEN we drop the message, and if the
+ * underlying ws.send fails (e.g. the client disconnected mid-send) we swallow
+ * the error. The connection's onClose handler is the source of truth for
+ * teardown; surfacing a rejection here would only produce unhandled promise
+ * rejections at the many non-awaited call sites and crash the process.
+ */
 function send(ws: WSContext, event: string, data: any): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
+  if (ws.readyState !== 1 /* OPEN */) return Promise.resolve();
+  return new Promise<void>((resolve) => {
     const raw = ws.raw as { send(data: string, cb?: (err?: Error) => void): void };
-    raw.send(JSON.stringify({ event, data }), (err?: Error) => {
-      if (err) reject(err);
-      else resolve();
-    });
+    raw.send(JSON.stringify({ event, data }), () => resolve());
   });
 }
 


### PR DESCRIPTION
## Summary
Fixes [TAB-949](https://linear.app/mozilla-np/issue/TAB-949/pilo-uncaught-exception-when-sending-websocket-event-after-close). The interactive Pilo WebSocket route (`packages/server/src/routes/piloWs.ts`) crashes the Node process when an agent event fires after the client has disconnected. `ws.send()` on a CLOSED socket throws synchronously, the rejection escapes the EventEmitter, and the pod restarts. Production has hit this twice in the last week.

## Changes
- `packages/server/src/routes/piloWs.ts` — the `send` helper now:
  - short-circuits when `ws.readyState !== 1 (OPEN)` so we never call `raw.send` on a closed socket;
  - resolves (rather than rejects) when `raw.send` reports an error via callback. `send()` is invoked fire-and-forget at six call sites, so a rejection would surface as an unhandled promise rejection and still crash under Node 22's default mode. The WS lifecycle is owned by `onClose` / `onError`; the helper has no useful action to take if a write fails.
- `packages/server/src/routes/piloWs.test.ts` — two new tests under `send guards`:
  - drops `agent:action` and `complete` events when `ws.readyState` flips to `CLOSED` mid-task;
  - resolves rather than rejects when `raw.send` reports an error via callback.

## Why
The race: `WebAgent` emits an event → `StreamLogger`'s wildcard listener calls `sendEvent` → `send` calls `ws.send`. Between the listener registration and the event firing, the client can disconnect. The existing `onClose` handler aborts the controller and rejects pending user-data requests but does not synchronously stop events already in flight through the emitter, so `send` ends up writing to a CLOSED socket. Adding the readyState guard makes that race benign.

## Result
No more uncaught \`WebSocket is not open: readyState 3\` crashes from the interactive WS route. Disconnected clients are silently ignored; in-flight task work continues to be torn down by the existing abort path.

## Test plan
- [x] \`pnpm --filter pilo-server run test\` — 85/85 passing locally
- [x] \`pnpm run typecheck\` — clean across all packages
- [x] \`pnpm run format:check\` — clean
- [ ] CI green