### PR TITLE
feat(server): per-pod concurrency cap with readiness-based load shedding

### DIFF
--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 
@@ -42,6 +42,43 @@ describe("Server Application", () => {
     expect(data.name).toBe("Pilo Server");
     expect(data.version).toBe("0.1.0");
     expect(data.description).toBe("Web server for Pilo AI-powered web automation");
+  });
+
+  describe("GET /ready", () => {
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
+    afterEach(() => {
+      delete process.env.MAX_CONCURRENT_TASKS;
+    });
+
+    it("should return 200 when below capacity", async () => {
+      const { isAtCapacity } = await import("./routes/pilo.js");
+      const app = new Hono();
+      app.get("/ready", (c) =>
+        isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),
+      );
+
+      const res = await app.request("/ready");
+      expect(res.status).toBe(200);
+      const data = await res.json();
+      expect(data.status).toBe("ok");
+    });
+
+    it("should return 503 when at capacity", async () => {
+      process.env.MAX_CONCURRENT_TASKS = "0";
+      const { isAtCapacity } = await import("./routes/pilo.js");
+      const app = new Hono();
+      app.get("/ready", (c) =>
+        isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),
+      );
+
+      const res = await app.request("/ready");
+      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(data.status).toBe("at capacity");
+    });
   });
 
   it("should set CORS headers correctly", async () => {

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,7 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { cors } from "hono/cors";
 import { sentry } from "@hono/sentry";
-import piloRoutes from "./routes/pilo.js";
+import piloRoutes, { isAtCapacity } from "./routes/pilo.js";
 import { createPiloWsRoute, type ActiveWS } from "./routes/piloWs.js";
 
 const app = new Hono();
@@ -42,9 +42,18 @@ app.use(
   }),
 );
 
-// Health check endpoint
+// Liveness: is the process alive?
 app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });
+});
+
+// Readiness: should this pod receive traffic?
+// Returns 503 when at concurrency limit so the load balancer stops routing here.
+app.get("/ready", (c) => {
+  if (isAtCapacity()) {
+    return c.json({ status: "at capacity" }, 503);
+  }
+  return c.json({ status: "ok" });
 });
 
 // Basic info endpoint

--- a/packages/server/src/routes/pilo.test.ts
+++ b/packages/server/src/routes/pilo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
-import piloRoutes from "./pilo.js";
+import piloRoutes, { _resetActiveTasksForTesting } from "./pilo.js";
 
 // Mock the pilo library
 vi.mock("pilo-core", () => ({
@@ -66,9 +66,7 @@ describe("Pilo Routes", () => {
   beforeEach(() => {
     app = new Hono();
     app.route("/pilo", piloRoutes);
-
-    // Don't clear mocks - it breaks our mock setup
-    // vi.clearAllMocks();
+    _resetActiveTasksForTesting();
   });
 
   describe("POST /pilo/run", () => {
@@ -87,6 +85,22 @@ describe("Pilo Routes", () => {
 
     afterEach(() => {
       delete process.env.OPENAI_API_KEY;
+      delete process.env.MAX_CONCURRENT_TASKS;
+    });
+
+    it("should return 503 when at concurrency limit", async () => {
+      process.env.MAX_CONCURRENT_TASKS = "0";
+
+      const res = await app.request("/pilo/run", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ task: "test task" }),
+      });
+
+      expect(res.status).toBe(503);
+      const data = await res.json();
+      expect(data.success).toBe(false);
+      expect(data.error.code).toBe("CONCURRENCY_LIMIT");
     });
 
     it("should reject requests without task with new error shape", async () => {

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -9,6 +9,17 @@ import {
 } from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
 
+const getMaxConcurrentTasks = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 3);
+let activeTasks = 0;
+
+/** Returns true when the pod is at or above its concurrency limit. Used by the /ready endpoint. */
+export const isAtCapacity = () => activeTasks >= getMaxConcurrentTasks();
+
+/** Exposed for unit tests only — resets the in-process concurrency counter. */
+export const _resetActiveTasksForTesting = () => {
+  activeTasks = 0;
+};
+
 const pilo = new Hono();
 
 // POST /pilo/run - Execute a Pilo task with real-time SSE streaming (non-interactive)
@@ -29,6 +40,19 @@ pilo.post("/run", async (c) => {
       );
     }
 
+    if (isAtCapacity()) {
+      return c.json(
+        createErrorResponse({
+          message: `Server at capacity (${getMaxConcurrentTasks()} concurrent tasks). Retry shortly.`,
+          code: "CONCURRENCY_LIMIT",
+          reason: "INTERNAL_ERROR",
+          phase: "setup",
+          taskId,
+        }),
+        503,
+      );
+    }
+
     return streamSSE(c, async (stream) => {
       const abortController = new AbortController();
 
@@ -37,6 +61,7 @@ pilo.post("/run", async (c) => {
         abortController.abort();
       });
 
+      activeTasks++;
       try {
         await stream.writeSSE({
           event: "start",
@@ -83,6 +108,8 @@ pilo.post("/run", async (c) => {
             ),
           });
         }
+      } finally {
+        activeTasks--;
       }
     });
   } catch (error) {


### PR DESCRIPTION
## Summary

- Adds `MAX_CONCURRENT_TASKS` limit (default 3) per pod — prevents simultaneous Playwright browser instances from exhausting the 2Gi memory limit
- Adds `/ready` endpoint that returns 503 when at capacity, so the Kubernetes readiness probe removes a full pod from the load balancer within ~5s
- Adds a 503 guard directly in `/run` as defence-in-depth during the probe polling window
- Tests: 91 passing across all server test files

## Root cause (TAB-964)

The morning batch sends many requests simultaneously. With no concurrency limit, each pod accepted all of them and spawned a Playwright browser per request (~200-400MB each). At 2Gi per pod, 5–6 concurrent browsers triggered OOMKill. All 5 pods died within ~80 seconds of each other, killing in-flight jobs silently.

## How it works

When a pod reaches `MAX_CONCURRENT_TASKS` active tasks:
1. `GET /ready` → 503, Kubernetes marks the pod NotReady within one probe interval (5s)
2. Load balancer stops routing new requests to the full pod
3. New requests go to pods still below capacity
4. When a task completes (`activeTasks--` in `finally`), `/ready` returns 200 and the pod re-enters rotation

## Deployment note

Set `MAX_CONCURRENT_TASKS` in the pod env (via ConfigMap). With 2Gi and ~300-400MB per browser, 3 is a conservative default — tune up if profiling shows headroom.

The companion `webservices-infra` PR updates the readiness probe to use `/ready` (periodSeconds: 5, failureThreshold: 1) and fixes broken HPA memory autoscaling.

Fixes TAB-964

🤖 Generated with [Claude Code](https://claude.com/claude-code)