### PR TITLE
feat(ariaTree): content-derived element refs (E_<hex>)

### DIFF
--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -3409,7 +3409,7 @@
           "type": "array"
         },
         "ref": {
-          "description": "Element ref from the accessibility tree (e.g., \"E42\")",
+          "description": "Element ref from the accessibility tree (e.g., \"E_a3f2\")",
           "type": "string"
         },
         "required": {

--- a/packages/core/src/browser/ariaTree/ariaSnapshot.ts
+++ b/packages/core/src/browser/ariaTree/ariaSnapshot.ts
@@ -14,16 +14,17 @@
  * limitations under the License.
  *
  * ---
- * Adapted for Pilo: stripped to AI-mode only, unified sequential refs (E1, E2, ...),
- * sets data-pilo-ref attribute during tree generation, walks same-origin iframes inline.
+ * Adapted for Pilo: stripped to AI-mode only, content-derived hash refs
+ * (E_<hex>, see refHash.ts), sets data-pilo-ref attribute during tree
+ * generation, walks same-origin iframes inline.
  */
 
 import { normalizeWhiteSpace } from "./stringUtils.js";
 import { box, getElementComputedStyle, isElementVisible } from "./domUtils.js";
 import * as roleUtils from "./roleUtils.js";
 import { yamlEscapeKeyIfNeeded, yamlEscapeValueIfNeeded } from "./yamlUtils.js";
-import type { AriaNode, RefCounter } from "./types.js";
-import { computeNodeHash, gatedAttrsFor, fnv1a32 } from "./refHash.js";
+import type { AriaNode } from "./types.js";
+import { computeNodeHash, gatedAttrsFor, fnv1a32, formatRef, REF_HASH_LENGTH } from "./refHash.js";
 
 function computeRootHash(frameIndex: number): number {
   // Pathname keeps refs stable across re-renders within a page and
@@ -35,7 +36,8 @@ function computeRootHash(frameIndex: number): number {
 /**
  * Generate an ARIA tree from a root element and render it as YAML.
  *
- * Uses a global sequential counter (E1, E2, ...) for refs across the entire page.
+ * Refs are content-derived: each element's ref is computed from its role,
+ * accessible name, structural path, and frameIndex via FNV-1a. See refHash.ts.
  * Sets `data-pilo-ref` attributes on DOM elements during generation for fast lookup.
  *
  * @param root - The root element to start from (typically document.body)
@@ -44,8 +46,6 @@ function computeRootHash(frameIndex: number): number {
  * @returns The YAML string of the accessibility tree
  */
 export function generateAndRenderAriaTree(root: Element, frameIndex: number = 0): string {
-  const refCounter = { value: 0 }; // Temporary; Task 3 removes counter rendering entirely.
-
   // Clean up any existing data-pilo-ref attributes from a previous snapshot
   root.querySelectorAll("[data-pilo-ref]").forEach((el) => {
     el.removeAttribute("data-pilo-ref");
@@ -57,7 +57,7 @@ export function generateAndRenderAriaTree(root: Element, frameIndex: number = 0)
   (globalThis as any).__piloRefMap = new Map<string, Element>();
 
   const ariaTree = generateAriaTree(root, 0, computeRootHash(frameIndex));
-  return renderAriaTree(ariaTree, refCounter);
+  return renderAriaTree(ariaTree);
 }
 
 const MAX_IFRAME_DEPTH = 5;
@@ -493,8 +493,16 @@ function hasPointerCursor(ariaNode: AriaNode): boolean {
   return ariaNode.box.style?.cursor === "pointer";
 }
 
-function renderAriaTree(root: AriaNode, counter: RefCounter): string {
+function renderAriaTree(root: AriaNode): string {
   const lines: string[] = [];
+  const occurrenceByHashHex = new Map<string, number>();
+
+  const assignRef = (ariaNode: AriaNode): string => {
+    const hex = ariaNode.hash.toString(16).padStart(8, "0").slice(-REF_HASH_LENGTH);
+    const occurrence = (occurrenceByHashHex.get(hex) ?? 0) + 1;
+    occurrenceByHashHex.set(hex, occurrence);
+    return formatRef(ariaNode.hash, occurrence);
+  };
 
   const visit = (ariaNode: AriaNode | string, _parentAriaNode: AriaNode | null, indent: string) => {
     if (typeof ariaNode === "string") {
@@ -526,10 +534,12 @@ function renderAriaTree(root: AriaNode, counter: RefCounter): string {
     if (ariaNode.description) key += ` [description=${JSON.stringify(ariaNode.description)}]`;
 
     // Assign ref only for visible, interactable elements.
-    // SECURITY: Refs are counter-generated ("E1", "E2", ...) — never from external input,
-    // since they're used in CSS attribute selectors for element lookup.
+    // SECURITY: refs are derived deterministically from element identity inputs
+    // (role, accessible name, structural path). They are not influenced by
+    // external untrusted input, and consist solely of [0-9a-f_E] characters,
+    // so they remain safe to interpolate into CSS attribute selectors.
     if (nodeReceivesPointerEvents(ariaNode)) {
-      const ref = "E" + ++counter.value;
+      const ref = assignRef(ariaNode);
       const cursor = hasPointerCursor(ariaNode) ? " [cursor=pointer]" : "";
       key += ` [ref=${ref}]${cursor}`;
       ariaNode.element?.setAttribute("data-pilo-ref", ref);

--- a/packages/core/src/browser/ariaTree/ariaSnapshot.ts
+++ b/packages/core/src/browser/ariaTree/ariaSnapshot.ts
@@ -24,7 +24,7 @@ import { box, getElementComputedStyle, isElementVisible } from "./domUtils.js";
 import * as roleUtils from "./roleUtils.js";
 import { yamlEscapeKeyIfNeeded, yamlEscapeValueIfNeeded } from "./yamlUtils.js";
 import type { AriaNode } from "./types.js";
-import { computeNodeHash, gatedAttrsFor, fnv1a32, formatRef, REF_HASH_LENGTH } from "./refHash.js";
+import { computeNodeHash, gatedAttrsFor, fnv1a32, formatRef, hashHex } from "./refHash.js";
 
 function computeRootHash(frameIndex: number): number {
   // Pathname keeps refs stable across re-renders within a page and
@@ -424,7 +424,7 @@ export function isInteractiveElement(el: Element): boolean {
 
 /**
  * Overlay labeled badges on interactive elements that have `data-pilo-ref` attributes.
- * Each badge shows the ref ID (e.g., "E1") positioned at the element's top-left corner
+ * Each badge shows the ref ID (e.g., "E_a3f2") positioned at the element's top-left corner
  * with a colored outline. Only interactive elements get marks — structural containers
  * are skipped to reduce visual noise.
  *
@@ -498,7 +498,7 @@ function renderAriaTree(root: AriaNode): string {
   const occurrenceByHashHex = new Map<string, number>();
 
   const assignRef = (ariaNode: AriaNode): string => {
-    const hex = ariaNode.hash.toString(16).padStart(8, "0").slice(-REF_HASH_LENGTH);
+    const hex = hashHex(ariaNode.hash);
     const occurrence = (occurrenceByHashHex.get(hex) ?? 0) + 1;
     occurrenceByHashHex.set(hex, occurrence);
     return formatRef(ariaNode.hash, occurrence);

--- a/packages/core/src/browser/ariaTree/ariaSnapshot.ts
+++ b/packages/core/src/browser/ariaTree/ariaSnapshot.ts
@@ -158,8 +158,14 @@ function generateAriaTree(rootElement: Element, iframeDepth = 0, initialParentHa
     }
 
     const expectedRole = roleUtils.getAriaRole(element) ?? "generic";
-    const siblingIndex = getSiblingIndex(ariaNode, element.tagName, expectedRole);
-    const childAriaNode = toAriaNode(element, ariaNode.hash, siblingIndex);
+    const childAriaNode =
+      expectedRole === "presentation" || expectedRole === "none"
+        ? null
+        : toAriaNode(
+            element,
+            ariaNode.hash,
+            getSiblingIndex(ariaNode, element.tagName, expectedRole),
+          );
     if (childAriaNode) {
       ariaNode.children.push(childAriaNode);
     }

--- a/packages/core/src/browser/ariaTree/ariaSnapshot.ts
+++ b/packages/core/src/browser/ariaTree/ariaSnapshot.ts
@@ -23,6 +23,14 @@ import { box, getElementComputedStyle, isElementVisible } from "./domUtils.js";
 import * as roleUtils from "./roleUtils.js";
 import { yamlEscapeKeyIfNeeded, yamlEscapeValueIfNeeded } from "./yamlUtils.js";
 import type { AriaNode, RefCounter } from "./types.js";
+import { computeNodeHash, gatedAttrsFor, fnv1a32 } from "./refHash.js";
+
+function computeRootHash(frameIndex: number): number {
+  // Pathname keeps refs stable across re-renders within a page and
+  // invalidates everything on navigation.
+  const path = typeof location !== "undefined" && location?.pathname ? location.pathname : "";
+  return fnv1a32(frameIndex.toString(10) + "@" + path);
+}
 
 /**
  * Generate an ARIA tree from a root element and render it as YAML.
@@ -31,12 +39,12 @@ import type { AriaNode, RefCounter } from "./types.js";
  * Sets `data-pilo-ref` attributes on DOM elements during generation for fast lookup.
  *
  * @param root - The root element to start from (typically document.body)
- * @param counter - Mutable counter for sequential ref numbering across frames.
- *                  If not provided, starts at 0.
+ * @param frameIndex - Numeric index for this frame (0 for main frame, 1+ for iframes).
+ *                     Used to compute stable content-derived hashes per node.
  * @returns The YAML string of the accessibility tree
  */
-export function generateAndRenderAriaTree(root: Element, counter?: RefCounter): string {
-  const refCounter = counter || { value: 0 };
+export function generateAndRenderAriaTree(root: Element, frameIndex: number = 0): string {
+  const refCounter = { value: 0 }; // Temporary; Task 3 removes counter rendering entirely.
 
   // Clean up any existing data-pilo-ref attributes from a previous snapshot
   root.querySelectorAll("[data-pilo-ref]").forEach((el) => {
@@ -48,14 +56,27 @@ export function generateAndRenderAriaTree(root: Element, counter?: RefCounter): 
   // that strip data-pilo-ref attributes, e.g. React reconciliation)
   (globalThis as any).__piloRefMap = new Map<string, Element>();
 
-  const ariaTree = generateAriaTree(root);
+  const ariaTree = generateAriaTree(root, 0, computeRootHash(frameIndex));
   return renderAriaTree(ariaTree, refCounter);
 }
 
 const MAX_IFRAME_DEPTH = 5;
 
-function generateAriaTree(rootElement: Element, iframeDepth = 0): AriaNode {
+function generateAriaTree(rootElement: Element, iframeDepth = 0, initialParentHash = 0): AriaNode {
   const visited = new Set<Node>();
+  const siblingCountersByParent = new WeakMap<AriaNode, Map<string, number>>();
+
+  const getSiblingIndex = (parent: AriaNode, tagName: string, role: string): number => {
+    let map = siblingCountersByParent.get(parent);
+    if (!map) {
+      map = new Map();
+      siblingCountersByParent.set(parent, map);
+    }
+    const key = tagName + "|" + role;
+    const idx = map.get(key) ?? 0;
+    map.set(key, idx + 1);
+    return idx;
+  };
 
   const root: AriaNode = {
     role: "fragment",
@@ -65,6 +86,7 @@ function generateAriaTree(rootElement: Element, iframeDepth = 0): AriaNode {
     props: {},
     box: box(rootElement),
     receivesPointerEvents: true,
+    hash: initialParentHash, // Fragment root carries the frame sentinel; visible children hash off of it.
   };
 
   const visit = (ariaNode: AriaNode, node: Node) => {
@@ -104,7 +126,7 @@ function generateAriaTree(rootElement: Element, iframeDepth = 0): AriaNode {
           iframeDoc.body
             .querySelectorAll("[data-pilo-ref]")
             .forEach((el) => el.removeAttribute("data-pilo-ref"));
-          const iframeTree = generateAriaTree(iframeDoc.body, iframeDepth + 1);
+          const iframeTree = generateAriaTree(iframeDoc.body, iframeDepth + 1, ariaNode.hash);
           // Merge iframe children into current node
           for (const child of iframeTree.children) {
             ariaNode.children.push(child);
@@ -122,12 +144,22 @@ function generateAriaTree(rootElement: Element, iframeDepth = 0): AriaNode {
         element,
         box: box(element),
         receivesPointerEvents: true,
+        hash: computeNodeHash(
+          ariaNode.hash,
+          "IFRAME",
+          "iframe",
+          "",
+          "",
+          getSiblingIndex(ariaNode, "IFRAME", "iframe"),
+        ),
       };
       ariaNode.children.push(iframeNode);
       return;
     }
 
-    const childAriaNode = toAriaNode(element);
+    const expectedRole = roleUtils.getAriaRole(element) ?? "generic";
+    const siblingIndex = getSiblingIndex(ariaNode, element.tagName, expectedRole);
+    const childAriaNode = toAriaNode(element, ariaNode.hash, siblingIndex);
     if (childAriaNode) {
       ariaNode.children.push(childAriaNode);
     }
@@ -181,7 +213,7 @@ function generateAriaTree(rootElement: Element, iframeDepth = 0): AriaNode {
   return root;
 }
 
-function toAriaNode(element: Element): AriaNode | null {
+function toAriaNode(element: Element, parentHash: number, siblingIndex: number): AriaNode | null {
   const role = roleUtils.getAriaRole(element) ?? "generic";
   if (role === "presentation" || role === "none") return null;
 
@@ -196,6 +228,14 @@ function toAriaNode(element: Element): AriaNode | null {
     element,
     box: box(element),
     receivesPointerEvents: pointerEvents,
+    hash: computeNodeHash(
+      parentHash,
+      element.tagName,
+      role,
+      name,
+      gatedAttrsFor(element),
+      siblingIndex,
+    ),
   };
 
   if (roleUtils.kAriaCheckedRoles.includes(role))

--- a/packages/core/src/browser/ariaTree/index.ts
+++ b/packages/core/src/browser/ariaTree/index.ts
@@ -10,4 +10,4 @@
  */
 
 export { generateAndRenderAriaTree, applySetOfMarks, removeSetOfMarks } from "./ariaSnapshot.js";
-export type { AriaNode, AriaRole, AriaProps, Box, RefCounter } from "./types.js";
+export type { AriaNode, AriaRole, AriaProps, Box } from "./types.js";

--- a/packages/core/src/browser/ariaTree/refHash.ts
+++ b/packages/core/src/browser/ariaTree/refHash.ts
@@ -27,7 +27,7 @@ export function fnv1a32(s: string): number {
 // U+001F (ASCII Unit Separator) — a C0 control character. Browsers strip
 // or reject these in attribute values, so user-controlled input strings
 // cannot inject a fake separator and forge a different field layout.
-const FIELD_SEP = "";
+const FIELD_SEP = "\x1f";
 
 /**
  * Compute a 32-bit identity hash for one ariaNode. Inputs delimited so that

--- a/packages/core/src/browser/ariaTree/refHash.ts
+++ b/packages/core/src/browser/ariaTree/refHash.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure, browser-safe utilities for content-derived element refs.
+ * Single source of truth for ref format. No DOM walking, no globals.
+ */
+
+export const REF_HASH_LENGTH = 4;
+export const REF_PREFIX = "E_";
+
+const FNV_OFFSET_BASIS_32 = 0x811c9dc5;
+const FNV_PRIME_32 = 0x01000193;
+
+/**
+ * FNV-1a 32-bit hash over the UTF-16 code units of `s`. Adequate for
+ * deriving short, structurally-keyed element IDs; not cryptographic.
+ */
+export function fnv1a32(s: string): number {
+  let h = FNV_OFFSET_BASIS_32;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    // Multiply with Math.imul to keep within 32-bit signed range, then
+    // mask back to unsigned 32-bit at the end.
+    h = Math.imul(h, FNV_PRIME_32);
+  }
+  return h >>> 0;
+}
+
+const FIELD_SEP = ""; // Unit Separator character, unlikely to appear in tag/role/name
+
+/**
+ * Compute a 32-bit identity hash for one ariaNode. Inputs delimited so that
+ * field-boundary confusion (e.g. tagName "BUTTONbutton" vs tagName "BUTTON" +
+ * role "button") cannot collide.
+ *
+ * `parentHash` propagates the structural path from the root; the root caller
+ * supplies a frame-level sentinel (frameIndex + pathname).
+ */
+export function computeNodeHash(
+  parentHash: number,
+  tagName: string,
+  role: string,
+  accessibleName: string,
+  gatedAttrs: string,
+  siblingIndex: number,
+): number {
+  const payload =
+    parentHash.toString(16) +
+    FIELD_SEP +
+    tagName +
+    FIELD_SEP +
+    role +
+    FIELD_SEP +
+    accessibleName +
+    FIELD_SEP +
+    gatedAttrs +
+    FIELD_SEP +
+    siblingIndex.toString(10);
+  return fnv1a32(payload);
+}
+
+/**
+ * Extract identity-bearing attributes from an element, keyed by tag.
+ * The set is intentionally conservative — adding inputs is a future decision
+ * driven by observed failure modes, not speculation.
+ */
+export function gatedAttrsFor(element: Element): string {
+  const tag = element.tagName;
+  switch (tag) {
+    case "A":
+      return "href=" + (element.getAttribute("href") ?? "");
+    case "BUTTON":
+      return "type=" + (element.getAttribute("type") ?? "");
+    case "INPUT":
+      return (
+        "type=" +
+        (element.getAttribute("type") ?? "") +
+        "|name=" +
+        (element.getAttribute("name") ?? "")
+      );
+    case "SELECT":
+    case "TEXTAREA":
+      return "name=" + (element.getAttribute("name") ?? "");
+    default:
+      return "";
+  }
+}
+
+/**
+ * Format a hash + occurrence number into a rendered ref string.
+ * `occurrence` is 1-based: the first node with a given hash is `1` (no suffix),
+ * the second is `2` (rendered `_2`), and so on.
+ */
+export function formatRef(hash: number, occurrence: number): string {
+  const hex = hash.toString(16).padStart(REF_HASH_LENGTH, "0").slice(-REF_HASH_LENGTH);
+  const base = REF_PREFIX + hex;
+  return occurrence > 1 ? `${base}_${occurrence}` : base;
+}

--- a/packages/core/src/browser/ariaTree/refHash.ts
+++ b/packages/core/src/browser/ariaTree/refHash.ts
@@ -17,14 +17,17 @@ export function fnv1a32(s: string): number {
   let h = FNV_OFFSET_BASIS_32;
   for (let i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i);
-    // Multiply with Math.imul to keep within 32-bit signed range, then
-    // mask back to unsigned 32-bit at the end.
+    // Math.imul avoids JS's default `*` promoting to float64, which would
+    // silently lose precision on 32-bit wrap-around.
     h = Math.imul(h, FNV_PRIME_32);
   }
   return h >>> 0;
 }
 
-const FIELD_SEP = ""; // Unit Separator character, unlikely to appear in tag/role/name
+// U+001F (ASCII Unit Separator) — a C0 control character. Browsers strip
+// or reject these in attribute values, so user-controlled input strings
+// cannot inject a fake separator and forge a different field layout.
+const FIELD_SEP = "";
 
 /**
  * Compute a 32-bit identity hash for one ariaNode. Inputs delimited so that
@@ -90,7 +93,13 @@ export function gatedAttrsFor(element: Element): string {
  * the second is `2` (rendered `_2`), and so on.
  */
 export function formatRef(hash: number, occurrence: number): string {
-  const hex = hash.toString(16).padStart(REF_HASH_LENGTH, "0").slice(-REF_HASH_LENGTH);
+  // Format the 32-bit hash as exactly 8 hex chars (zero-padded), then keep
+  // the trailing REF_HASH_LENGTH chars. The low nibbles are kept; FNV-1a
+  // mixes uniformly across the whole word, so any contiguous slice is
+  // equally well-distributed. The two-step form makes the truncation
+  // explicit and works for any REF_HASH_LENGTH in [1, 8].
+  const fullHex = hash.toString(16).padStart(8, "0");
+  const hex = fullHex.slice(-REF_HASH_LENGTH);
   const base = REF_PREFIX + hex;
   return occurrence > 1 ? `${base}_${occurrence}` : base;
 }

--- a/packages/core/src/browser/ariaTree/refHash.ts
+++ b/packages/core/src/browser/ariaTree/refHash.ts
@@ -88,18 +88,22 @@ export function gatedAttrsFor(element: Element): string {
 }
 
 /**
+ * Compute the lowercase, zero-padded hex prefix used as the lookup key for
+ * ref formatting and collision tracking. The prefix is the trailing
+ * REF_HASH_LENGTH hex chars of the 32-bit hash. Exposed so consumers that
+ * need to key on the ref's hex prefix (e.g. collision-suffix bookkeeping)
+ * agree with formatRef on which bits are kept.
+ */
+export function hashHex(hash: number): string {
+  return hash.toString(16).padStart(8, "0").slice(-REF_HASH_LENGTH);
+}
+
+/**
  * Format a hash + occurrence number into a rendered ref string.
  * `occurrence` is 1-based: the first node with a given hash is `1` (no suffix),
  * the second is `2` (rendered `_2`), and so on.
  */
 export function formatRef(hash: number, occurrence: number): string {
-  // Format the 32-bit hash as exactly 8 hex chars (zero-padded), then keep
-  // the trailing REF_HASH_LENGTH chars. The low nibbles are kept; FNV-1a
-  // mixes uniformly across the whole word, so any contiguous slice is
-  // equally well-distributed. The two-step form makes the truncation
-  // explicit and works for any REF_HASH_LENGTH in [1, 8].
-  const fullHex = hash.toString(16).padStart(8, "0");
-  const hex = fullHex.slice(-REF_HASH_LENGTH);
-  const base = REF_PREFIX + hex;
+  const base = REF_PREFIX + hashHex(hash);
   return occurrence > 1 ? `${base}_${occurrence}` : base;
 }

--- a/packages/core/src/browser/ariaTree/types.ts
+++ b/packages/core/src/browser/ariaTree/types.ts
@@ -130,6 +130,3 @@ export type Box = {
   rect?: DOMRect;
   style?: CSSStyleDeclaration;
 };
-
-/** Mutable counter passed through frame boundaries for sequential refs */
-export type RefCounter = { value: number };

--- a/packages/core/src/browser/ariaTree/types.ts
+++ b/packages/core/src/browser/ariaTree/types.ts
@@ -116,6 +116,7 @@ export type AriaProps = {
 export type AriaNode = AriaProps & {
   role: AriaRole | "fragment" | "iframe";
   name: string;
+  hash: number;
   ref?: string;
   children: (AriaNode | string)[];
   element: Element;

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -606,9 +606,8 @@ export class PlaywrightBrowser implements AriaBrowser {
           fn();
           win.__piloAriaTree = (globalThis as any).__piloAriaTree;
         }
-        const counter = { value: 0 };
-        const yaml: string = win.__piloAriaTree.generateAndRenderAriaTree(document.body, counter);
-        return { yaml, counterValue: counter.value };
+        const yaml: string = win.__piloAriaTree.generateAndRenderAriaTree(document.body, 0);
+        return { yaml };
       },
       { script: ARIA_TREE_SCRIPT },
     );
@@ -616,7 +615,7 @@ export class PlaywrightBrowser implements AriaBrowser {
     // Handle cross-origin iframes via Playwright's frame API
     const frames = this.page!.frames();
     const childYamls: string[] = [];
-    let counter = mainResult.counterValue;
+    let frameIndex = 1;
 
     for (const frame of frames) {
       // Skip the main frame
@@ -624,28 +623,29 @@ export class PlaywrightBrowser implements AriaBrowser {
 
       try {
         const frameResult = await frame.evaluate(
-          ({ script, counterStart }) => {
+          ({ script, frameIdx }) => {
             const win = window as any;
             if (!win.__piloAriaTree) {
               const fn = new Function(script);
               fn();
               win.__piloAriaTree = (globalThis as any).__piloAriaTree;
             }
-            const counter = { value: counterStart };
             const yaml: string = win.__piloAriaTree.generateAndRenderAriaTree(
               document.body,
-              counter,
+              frameIdx,
             );
-            return { yaml, counterValue: counter.value };
+            return { yaml };
           },
-          { script: ARIA_TREE_SCRIPT, counterStart: counter },
+          { script: ARIA_TREE_SCRIPT, frameIdx: frameIndex },
         );
         if (frameResult.yaml) {
           childYamls.push(frameResult.yaml);
-          counter = frameResult.counterValue;
         }
+        frameIndex++;
       } catch {
-        // Cross-origin or detached frame, skip
+        // Cross-origin or detached frame, skip — but still bump frameIndex so
+        // a successful next frame gets a stable distinct index.
+        frameIndex++;
       }
     }
 

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -12,8 +12,8 @@ export const TOOL_STRINGS = {
   webActions: {
     /** Common parameter descriptions used across multiple tools */
     common: {
-      elementRefExample: "E###",
-      elementRef: "Element reference from page snapshot (e.g., E###)",
+      elementRefExample: "E_a3f2",
+      elementRef: "Element reference from page snapshot (e.g., E_a3f2)",
       textValue: "Text to enter into the field",
     },
     /** Individual tool descriptions */
@@ -481,18 +481,18 @@ Today's Date: {{ currentDate }}
 The above accessibility tree shows page elements in a hierarchical text format. Each line represents an element with:
 - Element type (button, link, textbox, generic, etc.)
 - Text content in quotes or description
-- Reference ID in brackets like [ref=E###] - use these exact IDs when interacting with elements
+- Reference ID in brackets like [ref=E_a3f2] - use these exact IDs when interacting with elements
 - Properties like [cursor=pointer] or [disabled]
-Example: button "Submit Form" [ref=E455] [cursor=pointer]
+Example: button "Submit Form" [ref=E_b9c1] [cursor=pointer]
 
-This shows the complete current page content.{% if hasScreenshot %} A labeled screenshot is included. The screenshot marks interactive elements (links, buttons, inputs) with colored badges showing their ref IDs (E1, E2, etc.). The tree above includes refs on all visible elements for structural context — only the interactive ones are labeled in the screenshot.{% endif %}
+This shows the complete current page content.{% if hasScreenshot %} A labeled screenshot is included. The screenshot marks interactive elements (links, buttons, inputs) with colored badges showing their ref IDs (E_a3f2, E_b9c1, etc.). The tree above includes refs on all visible elements for structural context — only the interactive ones are labeled in the screenshot.{% endif %}
 
 **Your task:**
 - Analyze the current state and select your next action
 - Target the most relevant elements for your objective
 - If an action fails, adapt immediately—don't repeat failed attempts
 - Find alternative approaches when planned steps aren't viable
-{% if hasScreenshot %}- Use the labeled screenshot to visually locate interactive elements and match them to [ref=E###] IDs in the tree{% endif %}
+{% if hasScreenshot %}- Use the labeled screenshot to visually locate interactive elements and match them to [ref=E_a3f2] IDs in the tree{% endif %}
 - Follow all guardrails
 
 ${toolCallInstruction}

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -197,7 +197,7 @@ function buildToolExamples(
 
   if (hasInteractive) {
     lines.push(
-      `- request_user_data({"reason": "initial", "formDescription": "Account signup form", "fields": [{"ref": "E42", "label": "Email", "fieldType": "email", "required": true}]}) - ${TOOL_STRINGS.webActions.requestUserData.description}`,
+      `- request_user_data({"reason": "initial", "formDescription": "Account signup form", "fields": [{"ref": "E_a3f2", "label": "Email", "fieldType": "email", "required": true}]}) - ${TOOL_STRINGS.webActions.requestUserData.description}`,
     );
   }
 

--- a/packages/core/src/tools/interactiveTools.ts
+++ b/packages/core/src/tools/interactiveTools.ts
@@ -107,7 +107,7 @@ export function createInteractiveTools(context: InteractiveToolContext) {
         fields: z
           .array(
             z.object({
-              ref: z.string().describe("Element reference from page snapshot (e.g., E###)"),
+              ref: z.string().describe("Element reference from page snapshot (e.g., E_a3f2)"),
               label: z.string().describe("The field's visible label"),
               fieldType: z.enum([
                 "text",

--- a/packages/core/src/types/interactive.ts
+++ b/packages/core/src/types/interactive.ts
@@ -8,7 +8,7 @@
 
 /** A single form field the agent needs data for. */
 export interface FormFieldRequest {
-  /** Element ref from the accessibility tree (e.g., "E42") */
+  /** Element ref from the accessibility tree (e.g., "E_a3f2") */
   ref: string;
   /** The field's visible label */
   label: string;

--- a/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
+++ b/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
@@ -96,19 +96,17 @@ describe("ariaTree module", () => {
       expect(btn.getAttribute("data-pilo-role")).toBeNull();
     });
 
-    it("should accept a counter parameter for cross-frame numbering", async () => {
-      // In jsdom, no elements are visible so counter won't advance.
-      // This test verifies the counter parameter is accepted without error.
+    it("should accept a frameIndex parameter for cross-frame numbering", async () => {
+      // In jsdom, no elements are visible so the frame index doesn't affect output.
+      // This test verifies the frameIndex parameter is accepted without error.
       setupDOM("<html><body><button>A</button></body></html>");
 
       const { generateAndRenderAriaTree } =
         await import("../../../src/browser/ariaTree/ariaSnapshot.js");
 
-      const counter = { value: 100 };
-      generateAndRenderAriaTree(document.body, counter);
-
-      // Counter stays at 100 since no elements are visible in jsdom
-      expect(counter.value).toBe(100);
+      // Should not throw when called with a numeric frameIndex
+      expect(() => generateAndRenderAriaTree(document.body, 0)).not.toThrow();
+      expect(() => generateAndRenderAriaTree(document.body, 5)).not.toThrow();
     });
 
     it("should handle links with href", async () => {
@@ -571,6 +569,43 @@ describe("ariaTree module", () => {
       // for any elements. This is expected behavior - marks are skipped for
       // invisible elements. The test verifies the container still gets created.
       expect(container).not.toBeNull();
+    });
+  });
+
+  describe("hash propagation", () => {
+    it("computes the same ariaNode hashes for the same DOM across two snapshots", async () => {
+      setupDOM("<html><body></body></html>");
+
+      const { generateAndRenderAriaTree } =
+        await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+      document.body.innerHTML = `
+        <button>Save</button>
+        <button>Delete</button>
+      `;
+      const yaml1 = generateAndRenderAriaTree(document.body, 0);
+      // Snapshot a second time without changes
+      document.body.innerHTML = `
+        <button>Save</button>
+        <button>Delete</button>
+      `;
+      const yaml2 = generateAndRenderAriaTree(document.body, 0);
+      expect(yaml1).toBe(yaml2);
+    });
+
+    it("accepts a numeric frameIndex parameter", async () => {
+      setupDOM("<html><body><button>Save</button></body></html>");
+
+      const { generateAndRenderAriaTree } =
+        await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+      const yamlA = generateAndRenderAriaTree(document.body, 0);
+      const yamlB = generateAndRenderAriaTree(document.body, 1);
+      // Task 2 keeps the counter-based display, so we just verify both
+      // generations succeed with the numeric parameter. Task 3 asserts the
+      // actual divergence in rendered refs.
+      expect(yamlA).toContain("button");
+      expect(yamlB).toContain("button");
     });
   });
 });

--- a/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
+++ b/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { JSDOM, VirtualConsole } from "jsdom";
+import { REF_HASH_LENGTH, REF_PREFIX } from "../../../src/browser/ariaTree/refHash.js";
 
 // We test the ariaSnapshot module by importing it directly and running in jsdom.
 // NOTE: jsdom lacks a layout engine, so getBoundingClientRect() returns 0x0 rects.
@@ -178,8 +179,8 @@ describe("ariaTree module", () => {
         await import("../../../src/browser/ariaTree/ariaSnapshot.js");
 
       const yaml = generateAndRenderAriaTree(document.body);
-      // No bare [E\d+] — if refs appeared they'd be [ref=E\d+]
-      expect(yaml).not.toMatch(/\[E\d+\]/);
+      // No bare [E_...] — if refs appeared they'd be [ref=E_xxxx]
+      expect(yaml).not.toMatch(/\[E_[0-9a-f]+\]/);
     });
 
     it("should not set data-pilo-ref in jsdom (no layout engine)", async () => {
@@ -592,20 +593,177 @@ describe("ariaTree module", () => {
       const yaml2 = generateAndRenderAriaTree(document.body, 0);
       expect(yaml1).toBe(yaml2);
     });
+  });
+});
 
-    it("produces identical counter-based YAML regardless of frameIndex (display unchanged in Task 2)", async () => {
-      setupDOM("<html><body><button>Save</button></body></html>");
+// Helpers used in content-derived refs tests.
+// These are defined at module scope so both describe blocks can use them.
+const refPattern = new RegExp(
+  `${REF_PREFIX.replace("_", "\\_")}[0-9a-f]{${REF_HASH_LENGTH}}(_\\d+)?`,
+);
 
-      const { generateAndRenderAriaTree } =
-        await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+const extractRefs = (yaml: string): string[] => {
+  const out: string[] = [];
+  const re = new RegExp(
+    `\\[ref=(${REF_PREFIX.replace("_", "\\_")}[0-9a-f]{${REF_HASH_LENGTH}}(?:_\\d+)?)\\]`,
+    "g",
+  );
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(yaml)) !== null) out.push(m[1]);
+  return out;
+};
 
-      const yamlA = generateAndRenderAriaTree(document.body, 0);
-      const yamlB = generateAndRenderAriaTree(document.body, 1);
-      // The hash inputs differ (different frameIndex → different root sentinel),
-      // but the rendered refs are still counter-based in Task 2. So the YAMLs
-      // are byte-for-byte identical. Task 3 changes this — when it lands, this
-      // test must be updated to assert divergence.
-      expect(yamlA).toBe(yamlB);
-    });
+describe("content-derived refs", () => {
+  // jsdom has no layout engine: getBoundingClientRect() always returns 0x0, so
+  // nodeReceivesPointerEvents() returns false and no refs appear in YAML.
+  // We patch the prototype to return a non-zero rect so elements are treated as
+  // visible, which is the case we actually want to test.
+  let origGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+
+  beforeEach(() => {
+    setupDOM("<html><body></body></html>");
+    origGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function () {
+      return {
+        width: 100,
+        height: 30,
+        top: 0,
+        left: 0,
+        bottom: 30,
+        right: 100,
+        x: 0,
+        y: 0,
+        toJSON() {
+          return this;
+        },
+      } as DOMRect;
+    };
+  });
+
+  afterEach(() => {
+    Element.prototype.getBoundingClientRect = origGetBoundingClientRect;
+  });
+
+  it("locality: inserting a sibling of a different type leaves original refs unchanged", async () => {
+    // Sibling indices are keyed by tagName|role, so inserting an element of a
+    // different type (e.g. a link before a button) does NOT shift the button's
+    // sibling index and therefore preserves its ref.
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    document.body.innerHTML = `<button>Save</button>`;
+    const before = generateAndRenderAriaTree(document.body, 0);
+    const saveRefBefore = extractRefs(before).find((r) =>
+      before.includes(`button "Save" [ref=${r}]`),
+    );
+
+    // Insert a link before the button — different tagName|role, so the button
+    // stays at BUTTON|button sibling index 0 and its hash is unchanged.
+    document.body.innerHTML = `<a href="/somewhere">Link</a><button>Save</button>`;
+    const after = generateAndRenderAriaTree(document.body, 0);
+    const saveRefAfter = extractRefs(after).find((r) => after.includes(`button "Save" [ref=${r}]`));
+
+    expect(saveRefAfter).toBe(saveRefBefore);
+  });
+
+  it("rename invalidation: changing accessible name changes the ref", async () => {
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    document.body.innerHTML = `<button>Save</button>`;
+    const refBefore = extractRefs(generateAndRenderAriaTree(document.body, 0))[0];
+
+    document.body.innerHTML = `<button>Saving...</button>`;
+    const refAfter = extractRefs(generateAndRenderAriaTree(document.body, 0))[0];
+
+    expect(refAfter).not.toBe(refBefore);
+  });
+
+  it("distinguishable reorder: refs change, set stays unique", async () => {
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    document.body.innerHTML = `
+      <button>Edit</button>
+      <button>Delete</button>
+      <button>Share</button>
+    `;
+    const before = generateAndRenderAriaTree(document.body, 0);
+    const refsBefore = extractRefs(before);
+
+    document.body.innerHTML = `
+      <button>Share</button>
+      <button>Edit</button>
+      <button>Delete</button>
+    `;
+    const after = generateAndRenderAriaTree(document.body, 0);
+    const refsAfter = extractRefs(after);
+
+    // All refs in the new snapshot are unique (no two elements share a ref).
+    expect(new Set(refsAfter).size).toBe(refsAfter.length);
+    // The overall sets differ — every sibling index changed so every hash changed.
+    // (Per-position equality could still hold due to hash truncation collisions
+    // at REF_HASH_LENGTH=4, so we compare the full sorted sets instead.)
+    expect([...refsAfter].sort()).not.toEqual([...refsBefore].sort());
+  });
+
+  it("indistinguishable reorder (known limit): hash set is structural, not identity-bearing", async () => {
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    const buttonRefsFrom = (yaml: string): string[] => {
+      // Extract only refs that appear on button lines (not on containing elements)
+      const out: string[] = [];
+      const re = new RegExp(
+        `button "Delete" \\[ref=(${REF_PREFIX.replace("_", "\\_")}[0-9a-f]{${REF_HASH_LENGTH}}(?:_\\d+)?)\\]`,
+        "g",
+      );
+      let m: RegExpExecArray | null;
+      while ((m = re.exec(yaml)) !== null) out.push(m[1]);
+      return out;
+    };
+
+    document.body.innerHTML = `
+      <button>Delete</button>
+      <button>Delete</button>
+      <button>Delete</button>
+    `;
+    const refsBefore = buttonRefsFrom(generateAndRenderAriaTree(document.body, 0));
+    expect(new Set(refsBefore).size).toBe(3); // three distinct refs via sibling index
+
+    // Rebuild identical DOM. The hash set is purely a function of structure,
+    // so it's preserved across rebuilds. After a real reorder of three
+    // accessibly-identical siblings, the same set would result — meaning
+    // identity tracks DOM position, not the original element. This is the
+    // documented limit; refs of identical siblings should not be relied on
+    // for cross-snapshot identity.
+    document.body.innerHTML = `
+      <button>Delete</button>
+      <button>Delete</button>
+      <button>Delete</button>
+    `;
+    const refsAfter = buttonRefsFrom(generateAndRenderAriaTree(document.body, 0));
+    expect(new Set(refsAfter)).toEqual(new Set(refsBefore));
+  });
+
+  it("cross-frame uniqueness: same DOM, different frameIndex => different refs", async () => {
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    document.body.innerHTML = `<button>Save</button>`;
+    const refA = extractRefs(generateAndRenderAriaTree(document.body, 0))[0];
+    const refB = extractRefs(generateAndRenderAriaTree(document.body, 1))[0];
+    expect(refA).not.toBe(refB);
+  });
+
+  it("emits refs matching the documented format", async () => {
+    const { generateAndRenderAriaTree } =
+      await import("../../../src/browser/ariaTree/ariaSnapshot.js");
+
+    document.body.innerHTML = `<button>Save</button>`;
+    const yaml = generateAndRenderAriaTree(document.body, 0);
+    const refs = extractRefs(yaml);
+    expect(refs.length).toBeGreaterThan(0);
+    for (const ref of refs) expect(ref).toMatch(refPattern);
   });
 });

--- a/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
+++ b/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
@@ -172,7 +172,7 @@ describe("ariaTree module", () => {
     it("should use ref= prefix format in YAML (not bare refs)", async () => {
       // NOTE: jsdom has no layout engine so refs don't appear in YAML output
       // (nodeReceivesPointerEvents returns false). We verify the format rule:
-      // the YAML should never contain bare [E###] without the ref= prefix.
+      // the YAML should never contain bare [E_xxxx] without the ref= prefix.
       setupDOM("<html><body><button>Click</button></body></html>");
 
       const { generateAndRenderAriaTree } =

--- a/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
+++ b/packages/core/test/browser/ariaTree/ariaSnapshot.test.ts
@@ -593,7 +593,7 @@ describe("ariaTree module", () => {
       expect(yaml1).toBe(yaml2);
     });
 
-    it("accepts a numeric frameIndex parameter", async () => {
+    it("produces identical counter-based YAML regardless of frameIndex (display unchanged in Task 2)", async () => {
       setupDOM("<html><body><button>Save</button></body></html>");
 
       const { generateAndRenderAriaTree } =
@@ -601,11 +601,11 @@ describe("ariaTree module", () => {
 
       const yamlA = generateAndRenderAriaTree(document.body, 0);
       const yamlB = generateAndRenderAriaTree(document.body, 1);
-      // Task 2 keeps the counter-based display, so we just verify both
-      // generations succeed with the numeric parameter. Task 3 asserts the
-      // actual divergence in rendered refs.
-      expect(yamlA).toContain("button");
-      expect(yamlB).toContain("button");
+      // The hash inputs differ (different frameIndex → different root sentinel),
+      // but the rendered refs are still counter-based in Task 2. So the YAMLs
+      // are byte-for-byte identical. Task 3 changes this — when it lands, this
+      // test must be updated to assert divergence.
+      expect(yamlA).toBe(yamlB);
     });
   });
 });

--- a/packages/core/test/browser/ariaTree/refHash.test.ts
+++ b/packages/core/test/browser/ariaTree/refHash.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from "vitest";
+import {
+  REF_HASH_LENGTH,
+  REF_PREFIX,
+  computeNodeHash,
+  fnv1a32,
+  formatRef,
+  gatedAttrsFor,
+} from "../../../src/browser/ariaTree/refHash.js";
+
+describe("fnv1a32", () => {
+  it("returns the FNV-1a 32-bit offset basis for empty input", () => {
+    // FNV-1a 32-bit offset basis is 0x811c9dc5 — the only mechanical check
+    // we need that the algorithm constants are correct.
+    expect(fnv1a32("")).toBe(0x811c9dc5);
+  });
+
+  it("is deterministic", () => {
+    expect(fnv1a32("hello")).toBe(fnv1a32("hello"));
+  });
+
+  it("produces different output for different inputs", () => {
+    expect(fnv1a32("hello")).not.toBe(fnv1a32("world"));
+  });
+
+  it("produces an unsigned 32-bit result", () => {
+    const h = fnv1a32("any input");
+    expect(h).toBeGreaterThanOrEqual(0);
+    expect(h).toBeLessThanOrEqual(0xffffffff);
+  });
+});
+
+describe("computeNodeHash", () => {
+  const baseArgs = {
+    parentHash: 0,
+    tagName: "BUTTON",
+    role: "button",
+    accessibleName: "Save",
+    gatedAttrs: "type=submit",
+    siblingIndex: 0,
+  };
+  const call = (overrides: Partial<typeof baseArgs> = {}) => {
+    const a = { ...baseArgs, ...overrides };
+    return computeNodeHash(
+      a.parentHash,
+      a.tagName,
+      a.role,
+      a.accessibleName,
+      a.gatedAttrs,
+      a.siblingIndex,
+    );
+  };
+
+  it("is deterministic for identical inputs", () => {
+    expect(call()).toBe(call());
+  });
+
+  it("changes when parentHash changes", () => {
+    expect(call({ parentHash: 1 })).not.toBe(call({ parentHash: 2 }));
+  });
+
+  it("changes when tagName changes", () => {
+    expect(call({ tagName: "A" })).not.toBe(call({ tagName: "BUTTON" }));
+  });
+
+  it("changes when role changes", () => {
+    expect(call({ role: "link" })).not.toBe(call({ role: "button" }));
+  });
+
+  it("changes when accessibleName changes", () => {
+    expect(call({ accessibleName: "Save" })).not.toBe(call({ accessibleName: "Saving..." }));
+  });
+
+  it("changes when gatedAttrs changes", () => {
+    expect(call({ gatedAttrs: "type=submit" })).not.toBe(call({ gatedAttrs: "type=button" }));
+  });
+
+  it("changes when siblingIndex changes", () => {
+    expect(call({ siblingIndex: 0 })).not.toBe(call({ siblingIndex: 1 }));
+  });
+
+  it("is not vulnerable to field-boundary confusion (delimiter present)", () => {
+    // e.g. tagName 'BUTTONbutton' vs ('BUTTON' + 'button') must hash differently
+    expect(call({ tagName: "BUTTONbutton", role: "" })).not.toBe(
+      call({ tagName: "BUTTON", role: "button" }),
+    );
+  });
+});
+
+describe("gatedAttrsFor", () => {
+  // We use simple stand-in objects shaped like Element to avoid jsdom setup
+  // for these specific tests; ariaSnapshot.test.ts will exercise real DOM paths.
+  const makeEl = (tag: string, attrs: Record<string, string>): Element => {
+    return {
+      tagName: tag.toUpperCase(),
+      getAttribute: (k: string) => (k in attrs ? attrs[k] : null),
+    } as unknown as Element;
+  };
+
+  it("extracts href for anchors", () => {
+    expect(gatedAttrsFor(makeEl("a", { href: "/foo" }))).toBe("href=/foo");
+  });
+
+  it("extracts type for buttons", () => {
+    expect(gatedAttrsFor(makeEl("button", { type: "submit" }))).toBe("type=submit");
+  });
+
+  it("extracts type and name for inputs", () => {
+    expect(gatedAttrsFor(makeEl("input", { type: "text", name: "email" }))).toBe(
+      "type=text|name=email",
+    );
+  });
+
+  it("extracts name for selects", () => {
+    expect(gatedAttrsFor(makeEl("select", { name: "country" }))).toBe("name=country");
+  });
+
+  it("returns empty string for unrelated tags", () => {
+    expect(gatedAttrsFor(makeEl("div", { foo: "bar" }))).toBe("");
+  });
+
+  it("returns empty string for inputs without gated attrs", () => {
+    expect(gatedAttrsFor(makeEl("input", {}))).toBe("type=|name=");
+  });
+});
+
+describe("formatRef", () => {
+  it("emits prefix + hex of REF_HASH_LENGTH chars with no suffix on first occurrence", () => {
+    const ref = formatRef(0xa3f2c1d8, 1);
+    expect(ref.startsWith(REF_PREFIX)).toBe(true);
+    expect(ref.slice(REF_PREFIX.length)).toMatch(new RegExp(`^[0-9a-f]{${REF_HASH_LENGTH}}$`));
+  });
+
+  it("appends _2, _3, ... for occurrences > 1", () => {
+    const a = formatRef(0x1234abcd, 1);
+    const b = formatRef(0x1234abcd, 2);
+    const c = formatRef(0x1234abcd, 3);
+    expect(b).toBe(a + "_2");
+    expect(c).toBe(a + "_3");
+  });
+
+  it("uses lowercase hex", () => {
+    const ref = formatRef(0xabcdef01, 1);
+    expect(ref.slice(REF_PREFIX.length)).toBe(ref.slice(REF_PREFIX.length).toLowerCase());
+  });
+
+  it("pads hex with leading zeros when needed", () => {
+    const ref = formatRef(0x00000001, 1);
+    // Whatever REF_HASH_LENGTH is, the hex portion should be exactly that length.
+    expect(ref.slice(REF_PREFIX.length)).toHaveLength(REF_HASH_LENGTH);
+  });
+});

--- a/packages/core/test/browser/ariaTree/refHash.test.ts
+++ b/packages/core/test/browser/ariaTree/refHash.test.ts
@@ -6,6 +6,7 @@ import {
   fnv1a32,
   formatRef,
   gatedAttrsFor,
+  hashHex,
 } from "../../../src/browser/ariaTree/refHash.js";
 
 describe("fnv1a32", () => {
@@ -122,6 +123,22 @@ describe("gatedAttrsFor", () => {
 
   it("emits keys with empty values for inputs missing gated attrs", () => {
     expect(gatedAttrsFor(makeEl("input", {}))).toBe("type=|name=");
+  });
+});
+
+describe("hashHex", () => {
+  it("returns the trailing REF_HASH_LENGTH hex chars of the 32-bit hash", () => {
+    expect(hashHex(0xabcdef01)).toBe("ef01");
+  });
+
+  it("zero-pads small hashes to REF_HASH_LENGTH chars", () => {
+    expect(hashHex(0x00000001)).toHaveLength(REF_HASH_LENGTH);
+    expect(hashHex(0)).toHaveLength(REF_HASH_LENGTH);
+  });
+
+  it("agrees with formatRef on the displayed hex prefix", () => {
+    const ref = formatRef(0xabcdef01, 1);
+    expect(ref).toBe(REF_PREFIX + hashHex(0xabcdef01));
   });
 });
 

--- a/packages/core/test/browser/ariaTree/refHash.test.ts
+++ b/packages/core/test/browser/ariaTree/refHash.test.ts
@@ -80,10 +80,11 @@ describe("computeNodeHash", () => {
   });
 
   it("is not vulnerable to field-boundary confusion (delimiter present)", () => {
-    // e.g. tagName 'BUTTONbutton' vs ('BUTTON' + 'button') must hash differently
-    expect(call({ tagName: "BUTTONbutton", role: "" })).not.toBe(
-      call({ tagName: "BUTTON", role: "button" }),
-    );
+    // Without a field separator, these two inputs would concatenate to identical
+    // payloads ("AB" + "C" === "A" + "BC"). With FIELD_SEP between fields, the
+    // payloads diverge ("AB\x1fC" vs "A\x1fBC"). This test fails if FIELD_SEP
+    // is removed or set to "".
+    expect(call({ tagName: "AB", role: "C" })).not.toBe(call({ tagName: "A", role: "BC" }));
   });
 });
 
@@ -119,7 +120,7 @@ describe("gatedAttrsFor", () => {
     expect(gatedAttrsFor(makeEl("div", { foo: "bar" }))).toBe("");
   });
 
-  it("returns empty string for inputs without gated attrs", () => {
+  it("emits keys with empty values for inputs missing gated attrs", () => {
     expect(gatedAttrsFor(makeEl("input", {}))).toBe("type=|name=");
   });
 });
@@ -148,5 +149,11 @@ describe("formatRef", () => {
     const ref = formatRef(0x00000001, 1);
     // Whatever REF_HASH_LENGTH is, the hex portion should be exactly that length.
     expect(ref.slice(REF_PREFIX.length)).toHaveLength(REF_HASH_LENGTH);
+  });
+
+  it("keeps the low REF_HASH_LENGTH hex digits of the 32-bit hash", () => {
+    // 0xabcdef01 with REF_HASH_LENGTH=4 should keep "ef01" (the low 16 bits).
+    // This pins the truncation policy: low nibbles, not high.
+    expect(formatRef(0xabcdef01, 1)).toBe(REF_PREFIX + "ef01");
   });
 });

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -227,7 +227,7 @@ describe("prompts", () => {
     });
 
     it("should include ref format examples", () => {
-      expect(actionLoopSystemPrompt).toContain("ref=E###");
+      expect(actionLoopSystemPrompt).toContain("ref=E_a3f2");
       expect(actionLoopSystemPrompt).toContain("element refs from page snapshot");
     });
 

--- a/packages/core/test/snapshotCompressor.test.ts
+++ b/packages/core/test/snapshotCompressor.test.ts
@@ -40,21 +40,21 @@ describe("SnapshotCompressor", () => {
 
     it("should preserve ref= prefix in refs", () => {
       const compressor = new SnapshotCompressor();
-      const snapshot = '- button "Click" [ref=E1] [cursor=pointer]';
+      const snapshot = '- button "Click" [ref=E_a3f2] [cursor=pointer]';
       const result = compressor.compress(snapshot);
-      expect(result).toContain("[ref=E1]");
+      expect(result).toContain("[ref=E_a3f2]");
       expect(result).toContain("[cursor=pointer]");
     });
 
     it("should preserve ref= in multiple refs across lines", () => {
       const compressor = new SnapshotCompressor();
-      const snapshot = `- button "Submit" [ref=E1]
-- button "Cancel" [ref=E2]
-- link "Help" [ref=E3]`;
+      const snapshot = `- button "Submit" [ref=E_a3f2]
+- button "Cancel" [ref=E_b9c1]
+- link "Help" [ref=E_c4d5]`;
       const result = compressor.compress(snapshot);
-      expect(result).toContain("[ref=E1]");
-      expect(result).toContain("[ref=E2]");
-      expect(result).toContain("[ref=E3]");
+      expect(result).toContain("[ref=E_a3f2]");
+      expect(result).toContain("[ref=E_b9c1]");
+      expect(result).toContain("[ref=E_c4d5]");
     });
 
     it("should deduplicate consecutive identical quoted text", () => {

--- a/packages/extension/src/background/ExtensionBrowser.ts
+++ b/packages/extension/src/background/ExtensionBrowser.ts
@@ -127,7 +127,8 @@ export class ExtensionBrowser implements AriaBrowser {
           }
 
           // generateAndRenderAriaTree handles everything:
-          // - tree generation, ref assignment (E1, E2, ...), setAttribute('data-pilo-ref', ref), YAML rendering
+          // - tree generation, content-derived ref assignment (E_<hex>, see refHash.ts),
+          //   setAttribute('data-pilo-ref', ref), YAML rendering
           return win.generateAndRenderAriaTree(document.body, 0);
         },
       });

--- a/packages/extension/src/background/ExtensionBrowser.ts
+++ b/packages/extension/src/background/ExtensionBrowser.ts
@@ -12,7 +12,7 @@ interface ActionResult {
 }
 
 interface AriaSnapshotWindow {
-  generateAndRenderAriaTree: (root: Element, counter?: { value: number }) => string;
+  generateAndRenderAriaTree: (root: Element, frameIndex?: number) => string;
 }
 
 /**
@@ -128,7 +128,7 @@ export class ExtensionBrowser implements AriaBrowser {
 
           // generateAndRenderAriaTree handles everything:
           // - tree generation, ref assignment (E1, E2, ...), setAttribute('data-pilo-ref', ref), YAML rendering
-          return win.generateAndRenderAriaTree(document.body);
+          return win.generateAndRenderAriaTree(document.body, 0);
         },
       });
 


### PR DESCRIPTION
## Summary

- Replaces sequential counter refs (`E1`, `E2`, ...) in the ariaTree YAML snapshot with content-derived hash refs (`E_<hex>`), so an element that preserves its structural identity across re-renders keeps the same ref. The hash inputs are parent hash, tagName, role, accessible name, a small set of identity-bearing attributes (`href`, `type`, `name`), and the sibling index among same-`(tagName, role)` siblings.
- Refs carry ~16 bits of entropy at the default `REF_HASH_LENGTH=4`, so hallucinated refs almost always miss the snapshot's ref map — easier to distinguish "DOM mutated between snapshot and action" from "LLM made up a ref" in failure logs.
- Cross-origin iframe uniqueness now via a host-supplied `frameIndex` per `evaluate()` call instead of a chained counter. Same-origin iframe children hash against their visible parent ariaNode rather than a fresh fragment root.

## Design notes

- New module `packages/core/src/browser/ariaTree/refHash.ts` is the single source of truth for ref format and identity-input policy. `formatRef` and `renderAriaTree`'s collision-suffix bookkeeping both go through `hashHex` so the truncation rule lives in one place.
- The root sentinel is `frameIndex + "@" + location.pathname`, so navigation invalidates everything (correct) and a same-page re-render preserves identity.
- `RefCounter` is fully removed — `generateAndRenderAriaTree`'s second arg is now `frameIndex: number = 0`.
- Single coordinated cutover: no flag, no fallback. The `data-pilo-ref` query selectors used by tool dispatch are format-agnostic, so the cutover is invisible to consumers.

## Test plan

- [x] Unit tests in `refHash.test.ts`: FNV-1a correctness (offset basis), `computeNodeHash` determinism + per-input sensitivity, field-boundary delimiter exercised, `gatedAttrsFor` per tag, `hashHex`/`formatRef` agreement.
- [x] Integration tests in `ariaSnapshot.test.ts`: determinism, locality (unrelated subtree doesn't change a sibling's ref), rename invalidation, distinguishable-sibling reorder invalidates all refs, indistinguishable-sibling reorder documents the known limit (set-stable, identity not), cross-frame uniqueness.
- [x] Updated `prompts.ts` example refs (`elementRefExample`, screenshot legend, tool-call samples) so the LLM sees the new format consistently.
- [x] `pnpm run check` passes locally (typecheck + format:check + all package tests across core/cli/server/extension).
- [ ] Eval run via `evals/partial/stable-element-refs` (this branch was pushed there too).
- [ ] Spot-check on a React-heavy demo page (e.g. TodoMVC) — take two snapshots back-to-back with a trivial state change, confirm refs of unaffected interactive elements are byte-identical.

## Known follow-ups

The original spec called out two test cases that ended up covered at unit-level rather than integration-level; final review judged this acceptable but worth flagging:

1. **`playwrightBrowser.test.ts` cross-frame coordination test.** Spec called for an integration test asserting that `frameIndex` is passed into each frame's `evaluate` and cross-frame refs don't collide. Currently covered at unit level in `ariaSnapshot.test.ts` via the cross-frame uniqueness test (different `frameIndex` → different refs for the same DOM).
2. **Forced collision-suffix integration test.** Spec called for mocking `computeNodeHash` to force a collision and asserting `_2`, `_3` suffixes appear in traversal order. Currently covered at unit level via `formatRef` and `hashHex` tests; the integration-level assertion is implicit.

## Post-merge observability

Once this lands, classify `ref not found` incidents in logs by whether the failing ref appears anywhere in the YAML snapshot the LLM saw:

- **Ref in snapshot, absent from page** → DOM mutated between snapshot and action.
- **Ref absent from snapshot** → hallucination → consider bumping `REF_HASH_LENGTH` from 4 to 6.

The 4-hex default is a guess; this measurement tells us whether it's right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)