### PR TITLE
fix(server): wire concurrency cap into WebSocket route (TAB-966)

### DIFF
--- a/packages/server/src/concurrencyGuard.ts
+++ b/packages/server/src/concurrencyGuard.ts
@@ -1,0 +1,28 @@
+const getMax = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 3);
+
+let activeTasks = 0;
+
+export const isAtCapacity = () => activeTasks >= getMax();
+
+export const getMaxConcurrentTasks = getMax;
+
+/**
+ * Atomically check capacity and claim a slot. Returns true if the slot was
+ * acquired (caller must call releaseSlot when done), false if at capacity.
+ * Safe to call from synchronous event handlers — no await between check and
+ * increment means no TOCTOU race across concurrent connections.
+ */
+export const acquireSlot = (): boolean => {
+  if (isAtCapacity()) return false;
+  activeTasks++;
+  return true;
+};
+
+export const releaseSlot = (): void => {
+  activeTasks--;
+};
+
+/** Exposed for unit tests only. */
+export const _resetActiveTasksForTesting = (): void => {
+  activeTasks = 0;
+};

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -54,7 +54,7 @@ describe("Server Application", () => {
     });
 
     it("should return 200 when below capacity", async () => {
-      const { isAtCapacity } = await import("./routes/pilo.js");
+      const { isAtCapacity } = await import("./concurrencyGuard.js");
       const app = new Hono();
       app.get("/ready", (c) =>
         isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),
@@ -68,7 +68,7 @@ describe("Server Application", () => {
 
     it("should return 503 when at capacity", async () => {
       process.env.MAX_CONCURRENT_TASKS = "0";
-      const { isAtCapacity } = await import("./routes/pilo.js");
+      const { isAtCapacity } = await import("./concurrencyGuard.js");
       const app = new Hono();
       app.get("/ready", (c) =>
         isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,7 +9,8 @@ import { serve } from "@hono/node-server";
 import { createNodeWebSocket } from "@hono/node-ws";
 import { cors } from "hono/cors";
 import { sentry } from "@hono/sentry";
-import piloRoutes, { isAtCapacity } from "./routes/pilo.js";
+import piloRoutes from "./routes/pilo.js";
+import { isAtCapacity } from "./concurrencyGuard.js";
 import { createPiloWsRoute, type ActiveWS } from "./routes/piloWs.js";
 
 const app = new Hono();

--- a/packages/server/src/routes/pilo.test.ts
+++ b/packages/server/src/routes/pilo.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
-import piloRoutes, { _resetActiveTasksForTesting } from "./pilo.js";
+import piloRoutes from "./pilo.js";
+import { _resetActiveTasksForTesting } from "../concurrencyGuard.js";
 
 // Mock the pilo library
 vi.mock("pilo-core", () => ({
@@ -101,6 +102,30 @@ describe("Pilo Routes", () => {
       const data = await res.json();
       expect(data.success).toBe(false);
       expect(data.error.code).toBe("CONCURRENCY_LIMIT");
+    });
+
+    it("should enforce the cap under concurrent arrivals without a TOCTOU race", async () => {
+      // Cap at 2. Fire 5 requests simultaneously. Without the synchronous
+      // check+increment, all 5 could read activeTasks=0 before any increments
+      // and all pass — this test guards against that regression.
+      process.env.MAX_CONCURRENT_TASKS = "2";
+
+      const requests = Array.from({ length: 5 }, () =>
+        app.request("/pilo/run", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ task: "test task" }),
+        }),
+      );
+
+      const responses = await Promise.all(requests);
+      const statuses = responses.map((r) => r.status);
+
+      const accepted = statuses.filter((s) => s !== 503).length;
+      const shed = statuses.filter((s) => s === 503).length;
+
+      expect(accepted).toBeLessThanOrEqual(2);
+      expect(shed).toBeGreaterThanOrEqual(3);
     });
 
     it("should reject requests without task with new error shape", async () => {

--- a/packages/server/src/routes/pilo.ts
+++ b/packages/server/src/routes/pilo.ts
@@ -8,17 +8,14 @@ import {
   errorResponseFromError,
 } from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
+import {
+  acquireSlot,
+  releaseSlot,
+  isAtCapacity,
+  getMaxConcurrentTasks,
+} from "../concurrencyGuard.js";
 
-const getMaxConcurrentTasks = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 3);
-let activeTasks = 0;
-
-/** Returns true when the pod is at or above its concurrency limit. Used by the /ready endpoint. */
-export const isAtCapacity = () => activeTasks >= getMaxConcurrentTasks();
-
-/** Exposed for unit tests only — resets the in-process concurrency counter. */
-export const _resetActiveTasksForTesting = () => {
-  activeTasks = 0;
-};
+export { isAtCapacity };
 
 const pilo = new Hono();
 
@@ -26,30 +23,35 @@ const pilo = new Hono();
 pilo.post("/run", async (c) => {
   const taskId = randomUUID();
   c.header("x-pilo-task-id", taskId);
+
+  // Guard and reserve slot before any await — keeps the check+increment in
+  // the same synchronous turn of the event loop so concurrent requests can't
+  // all slip past with activeTasks=0.
+  if (!acquireSlot()) {
+    return c.json(
+      createErrorResponse({
+        message: `Server at capacity (${getMaxConcurrentTasks()} concurrent tasks). Retry shortly.`,
+        code: "CONCURRENCY_LIMIT",
+        reason: "INTERNAL_ERROR",
+        phase: "setup",
+        taskId,
+      }),
+      503,
+    );
+  }
+
   try {
     const body = (await c.req.json()) as PiloTaskRequest;
 
     const validationError = validateTaskRequest(body);
     if (validationError) {
+      releaseSlot();
       return c.json(
         {
           ...validationError.response,
           error: { ...validationError.response.error, taskId },
         },
         validationError.status as any,
-      );
-    }
-
-    if (isAtCapacity()) {
-      return c.json(
-        createErrorResponse({
-          message: `Server at capacity (${getMaxConcurrentTasks()} concurrent tasks). Retry shortly.`,
-          code: "CONCURRENCY_LIMIT",
-          reason: "INTERNAL_ERROR",
-          phase: "setup",
-          taskId,
-        }),
-        503,
       );
     }
 
@@ -61,7 +63,6 @@ pilo.post("/run", async (c) => {
         abortController.abort();
       });
 
-      activeTasks++;
       try {
         await stream.writeSSE({
           event: "start",
@@ -109,10 +110,11 @@ pilo.post("/run", async (c) => {
           });
         }
       } finally {
-        activeTasks--;
+        releaseSlot();
       }
     });
   } catch (error) {
+    releaseSlot();
     console.error("[pilo-server] task setup failed", {
       taskId,
       phase: "setup",

--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { _resetActiveTasksForTesting } from "../concurrencyGuard.js";
 
 // Mock pilo-core before any imports that use it
 vi.mock("pilo-core", () => ({
@@ -181,10 +182,13 @@ describe("piloWs", () => {
     mockRunTask.mockReset();
     mockValidateTaskRequest.mockReset().mockReturnValue(null);
     mockRunTask.mockResolvedValue({ success: true, stats: { actions: 1 } });
+    _resetActiveTasksForTesting();
   });
 
   afterEach(() => {
     vi.useRealTimers();
+    _resetActiveTasksForTesting();
+    delete process.env.MAX_CONCURRENT_TASKS;
   });
 
   describe("message parsing", () => {
@@ -299,6 +303,37 @@ describe("piloWs", () => {
 
       expect(h.closeCalled).toBe(true);
       expect(h.closeCode).toBe(1000);
+    });
+
+    it("should return CONCURRENCY_LIMIT error when pod is at capacity", () => {
+      process.env.MAX_CONCURRENT_TASKS = "0";
+
+      const h = createTestHarness();
+      h.sendMessage({ event: "task:details", data: { task: "test" } });
+
+      const errorMsg = h.sentMessages.find((m) => m.data?.error?.code === "CONCURRENCY_LIMIT");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg?.data.success).toBe(false);
+    });
+
+    it("should enforce cap across concurrent WebSocket connections", () => {
+      process.env.MAX_CONCURRENT_TASKS = "2";
+
+      // Make tasks hang so slots stay occupied
+      mockRunTask.mockReturnValue(new Promise(() => {}));
+
+      const connections = Array.from({ length: 4 }, () => createTestHarness());
+      connections.forEach((h) => h.sendMessage({ event: "task:details", data: { task: "test" } }));
+
+      const shed = connections.filter((h) =>
+        h.sentMessages.some((m) => m.data?.error?.code === "CONCURRENCY_LIMIT"),
+      );
+      const accepted = connections.filter((h) =>
+        h.sentMessages.some((m) => m.event === "task:accepted"),
+      );
+
+      expect(accepted.length).toBeLessThanOrEqual(2);
+      expect(shed.length).toBeGreaterThanOrEqual(2);
     });
 
     it("should reject a second task while one is running", async () => {

--- a/packages/server/src/routes/piloWs.ts
+++ b/packages/server/src/routes/piloWs.ts
@@ -28,6 +28,7 @@ import {
   errorResponseFromError,
 } from "../taskRunner.js";
 import type { PiloTaskRequest } from "../taskRunner.js";
+import { acquireSlot, releaseSlot, getMaxConcurrentTasks } from "../concurrencyGuard.js";
 
 /** Default timeout for waiting on a user data response (5 minutes). */
 const USER_DATA_TIMEOUT_MS = 5 * 60 * 1000;
@@ -115,9 +116,28 @@ export function createPiloWsRoute(
               return;
             }
 
+            // Claim a concurrency slot synchronously before any async work.
+            // onMessage is a synchronous event callback so there is no await
+            // between the check and increment — no TOCTOU race possible.
+            if (!acquireSlot()) {
+              send(
+                ws,
+                "error",
+                createErrorResponse({
+                  message: `Server at capacity (${getMaxConcurrentTasks()} concurrent tasks). Retry shortly.`,
+                  code: "CONCURRENCY_LIMIT",
+                  reason: "INTERNAL_ERROR",
+                  phase: "setup",
+                }),
+              );
+              return;
+            }
+
             const body = msg.data as PiloTaskRequest;
             const taskId = randomUUID();
+
             if (!body) {
+              releaseSlot();
               send(
                 ws,
                 "error",
@@ -134,6 +154,7 @@ export function createPiloWsRoute(
 
             const validationError = validateTaskRequest(body);
             if (validationError) {
+              releaseSlot();
               send(ws, "error", {
                 ...validationError.response,
                 error: { ...validationError.response.error, taskId },
@@ -188,6 +209,7 @@ export function createPiloWsRoute(
                   );
                 }
               } finally {
+                releaseSlot();
                 taskRunning = false;
                 for (const [id, pending] of pendingRequests) {
                   clearTimeout(pending.timer);


### PR DESCRIPTION
## Description

The per-pod concurrency cap added in TAB-964 only covered the SSE route (`POST /pilo/run`). The tabs-api calls pilo exclusively via WebSocket, so every production request bypassed the cap entirely. The `/ready` readiness probe never reflected real load because it used the SSE-only counter.

This PR:
- Extracts shared concurrency state into `concurrencyGuard.ts` (`acquireSlot` / `releaseSlot` / `isAtCapacity`) so both routes and `/ready` share a single counter
- Wires the cap into the WebSocket `task:details` handler — `onMessage` is synchronous so `acquireSlot()` is TOCTOU-safe with no await between check and increment; all early-exit paths call `releaseSlot()` to keep the counter balanced
- Fixes the pre-existing TOCTOU race in the SSE route: check+increment now happens before `await c.req.json()`, so concurrent HTTP arrivals can't all read `activeTasks=0` before any of them increments

## PR Type

- Bug Fix

## Related issues

Fixes TAB-966
Related to TAB-964

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`)
- [x] I have added tests that prove my fix/feature works (if applicable)
- [ ] Documentation was updated where necessary
- [x] I have read and followed the [contribution guidelines](CONTRIBUTING.md)

### How this was tested

- Confirmed via staging load test (20 concurrent requests via tabs-api `/v1/automate`) that before this fix all 20 bypassed the cap and ran concurrently
- After fix: `acquireSlot` in `onMessage` fires synchronously, so concurrent WS connections are properly serialized at the cap limit
- 3 new regression tests: TOCTOU race on SSE, `CONCURRENCY_LIMIT` error on WebSocket, cap enforcement across multiple concurrent WebSocket connections

## AI Usage

- [x] AI was used for drafting/refactoring

<!-- Claude Sonnet 4.6 (1M context) via Claude Code -->