### PR TITLE
feat(server): bump MAX_CONCURRENT_TASKS default 3 → 5 (TAB-966)

### DIFF
--- a/packages/server/src/concurrencyGuard.test.ts
+++ b/packages/server/src/concurrencyGuard.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { getMaxConcurrentTasks } from "./concurrencyGuard.js";
+
+describe("concurrencyGuard default cap", () => {
+  afterEach(() => {
+    delete process.env.MAX_CONCURRENT_TASKS;
+  });
+
+  it("defaults to 5 when MAX_CONCURRENT_TASKS is unset", () => {
+    delete process.env.MAX_CONCURRENT_TASKS;
+    expect(getMaxConcurrentTasks()).toBe(5);
+  });
+
+  it("honors MAX_CONCURRENT_TASKS env override", () => {
+    process.env.MAX_CONCURRENT_TASKS = "12";
+    expect(getMaxConcurrentTasks()).toBe(12);
+  });
+});

--- a/packages/server/src/concurrencyGuard.ts
+++ b/packages/server/src/concurrencyGuard.ts
@@ -1,4 +1,4 @@
-const getMax = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 3);
+const getMax = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 5);
 
 let activeTasks = 0;
 


### PR DESCRIPTION
## Summary

Bumps the in-code default `MAX_CONCURRENT_TASKS` from 3 to 5.

The previous default of 3 was sized against the memory math in TAB-964, which framed per-task memory as `~300-400MB` assuming in-pod Chromium browsers. In practice the pod connects to a **remote browser pool over CDP** — per-task memory in the pilo pod is much smaller (JS heap, CDP buffers, ARIA snapshots, LLM context). 5 is comfortable on the 2Gi pod limit that the companion infra change lands.

## Companion change

`webservices-infra` branch `sbrooke/tab-966-pilo-scale-on-cap-utilization`:
- bumps prod and stage pod memory limit/request to 2Gi
- replaces the unreachable `averageValue: 1600Mi` HPA threshold with `averageUtilization: 40` so HPA actually fires before the cap is hit
- lowers CPU threshold 80 → 60
- adds `behavior.scaleUp` for fast burst response
- pins `MAX_CONCURRENT_TASKS=5` in the configmap so deploys are explicit rather than relying on this code default

## Deploy ordering

Land the infra change first so cap=5 has memory headroom before the pilo image rolls out.

## Test plan

- [x] `pnpm run check` passes — 8 server test files, 96 tests; cli/extension/core all green
- [ ] Deploy infra change first (2Gi memory)
- [ ] Deploy this PR to stage
- [ ] Drive synthetic load and confirm HPA scales as memory utilization crosses 40% on the 2Gi pods

Refs: TAB-966, TAB-964