### PR TITLE
feat(server): drain in-flight tasks on SIGTERM before shutdown

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -20,6 +20,19 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Server port
 PORT=3000
 
+# Maximum number of concurrent tasks per server instance (default: 3)
+# Increase for servers with more resources. When at capacity the server
+# returns CONCURRENCY_LIMIT and stops accepting new tasks via /ready.
+# MAX_CONCURRENT_TASKS=3
+
+# How long (ms) to wait for in-flight tasks to finish after SIGTERM before
+# forcing shutdown (default: 60000). Increase for workloads with longer
+# task durations so pods don't kill running tasks during rolling deploys.
+# PILO_DRAIN_TIMEOUT_MS=60000
+
+# Sentry DSN for error reporting (optional)
+# SENTRY_DSN=https://your-key@sentry.io/project-id
+
 # =============================================================================
 # AI PROVIDER CONFIGURATION
 # =============================================================================

--- a/packages/server/src/concurrencyGuard.ts
+++ b/packages/server/src/concurrencyGuard.ts
@@ -1,19 +1,32 @@
 const getMax = () => Number(process.env.MAX_CONCURRENT_TASKS ?? 3);
 
 let activeTasks = 0;
+let draining = false;
 
 export const isAtCapacity = () => activeTasks >= getMax();
 
 export const getMaxConcurrentTasks = getMax;
 
+/** Returns the number of tasks currently executing. */
+export const getActiveTasks = (): number => activeTasks;
+
+/**
+ * Enter drain mode. Once set, acquireSlot() always returns false so no new
+ * tasks are accepted. Intended for graceful shutdown.
+ */
+export const setDraining = (): void => {
+  draining = true;
+};
+
 /**
  * Atomically check capacity and claim a slot. Returns true if the slot was
- * acquired (caller must call releaseSlot when done), false if at capacity.
+ * acquired (caller must call releaseSlot when done), false if at capacity or
+ * draining.
  * Safe to call from synchronous event handlers — no await between check and
  * increment means no TOCTOU race across concurrent connections.
  */
 export const acquireSlot = (): boolean => {
-  if (isAtCapacity()) return false;
+  if (draining || isAtCapacity()) return false;
   activeTasks++;
   return true;
 };
@@ -25,4 +38,5 @@ export const releaseSlot = (): void => {
 /** Exposed for unit tests only. */
 export const _resetActiveTasksForTesting = (): void => {
   activeTasks = 0;
+  draining = false;
 };

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,7 @@ import { createNodeWebSocket } from "@hono/node-ws";
 import { cors } from "hono/cors";
 import { sentry } from "@hono/sentry";
 import piloRoutes from "./routes/pilo.js";
-import { isAtCapacity } from "./concurrencyGuard.js";
+import { isAtCapacity, setDraining, getActiveTasks } from "./concurrencyGuard.js";
 import { createPiloWsRoute, type ActiveWS } from "./routes/piloWs.js";
 
 const app = new Hono();
@@ -87,10 +87,12 @@ const server = serve({
 // Inject WebSocket support into the HTTP server
 injectWebSocket(server);
 
-// Graceful shutdown: send close frames to all active WebSocket connections before exiting
-// so that clients (e.g. tabs-api) receive code 1001 rather than an abrupt 1006.
-process.on("SIGTERM", () => {
-  console.log("[pilo] SIGTERM received, closing active WebSocket connections...");
+// How long to wait for in-flight tasks to complete before forcing shutdown.
+// Override via PILO_DRAIN_TIMEOUT_MS. Default is 60s, suitable for most
+// deployments. Increase for workloads with longer task durations.
+const DRAIN_TIMEOUT_MS = Number(process.env.PILO_DRAIN_TIMEOUT_MS ?? 60_000);
+
+function closeActiveConnections() {
   for (const ws of activeConnections) {
     try {
       ws.close(1001, "Server shutting down");
@@ -98,7 +100,35 @@ process.on("SIGTERM", () => {
       // ignore errors on already-closed connections
     }
   }
-  server.close();
-  // Safety valve: if the event loop hasn't drained after 10s, exit cleanly.
-  setTimeout(() => process.exit(0), 10_000).unref();
+}
+
+// Graceful shutdown: stop accepting new tasks, wait for in-flight tasks to
+// finish, then close remaining connections and exit.
+process.on("SIGTERM", () => {
+  console.log(
+    `[pilo] SIGTERM received, draining in-flight tasks (timeout: ${DRAIN_TIMEOUT_MS}ms)...`,
+  );
+
+  setDraining(); // refuse new task:details messages
+  server.close(); // stop accepting new HTTP/WS connections
+
+  const deadline = Date.now() + DRAIN_TIMEOUT_MS;
+
+  const poll = setInterval(() => {
+    const remaining = getActiveTasks();
+    if (remaining === 0) {
+      clearInterval(poll);
+      console.log("[pilo] All tasks complete, shutting down.");
+      process.exit(0);
+    }
+    if (Date.now() >= deadline) {
+      clearInterval(poll);
+      console.log(
+        `[pilo] Drain timeout reached with ${remaining} task(s) still active, shutting down.`,
+      );
+      closeActiveConnections();
+      process.exit(0);
+    }
+    console.log(`[pilo] Draining... ${remaining} task(s) remaining.`);
+  }, 1_000);
 });

--- a/packages/server/src/routes/piloWs.test.ts
+++ b/packages/server/src/routes/piloWs.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { _resetActiveTasksForTesting } from "../concurrencyGuard.js";
+import { _resetActiveTasksForTesting, setDraining, acquireSlot } from "../concurrencyGuard.js";
 
 // Mock pilo-core before any imports that use it
 vi.mock("pilo-core", () => ({
@@ -666,6 +666,28 @@ describe("piloWs", () => {
 
       h.triggerError();
       expect(connections.size).toBe(0);
+    });
+  });
+
+  describe("drain mode", () => {
+    it("should reject new tasks when draining", () => {
+      const h = createTestHarness();
+      h.triggerOpen();
+      setDraining();
+
+      h.sendMessage({ event: "task:details", data: { task: "test task" } });
+
+      const errorMsg = h.sentMessages.find((m) => m.event === "error");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg?.data?.error?.code).toBe("CONCURRENCY_LIMIT");
+    });
+
+    it("setDraining prevents acquireSlot from succeeding", () => {
+      expect(acquireSlot()).toBe(true);
+      _resetActiveTasksForTesting();
+
+      setDraining();
+      expect(acquireSlot()).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

SIGTERM immediately closed all active WebSocket connections with code 1001, killing any running tasks. This caused task failures during pod replacement and HPA scale-down.

## Solution

On SIGTERM:
1. Enter drain mode — `acquireSlot()` returns false, no new tasks accepted
2. Stop accepting new HTTP/WS connections (`server.close()`)
3. Poll active task count every second until it reaches 0 or the drain timeout expires
4. Close any remaining connections and exit

## Configuration

`PILO_DRAIN_TIMEOUT_MS` — how long to wait for tasks to finish before forcing shutdown. Defaults to `60000` (60s). Increase for workloads with longer task durations.

## Changes

- `concurrencyGuard.ts` — add `setDraining()`, `getActiveTasks()`, drain flag in `acquireSlot()`; `_resetActiveTasksForTesting()` also resets drain flag
- `index.ts` — replace immediate-close SIGTERM handler with drain loop
- `piloWs.test.ts` — add drain mode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)