### PR TITLE
feat(core): add local skill cache

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,6 +13,7 @@ import {
   WebAgentEventEmitter,
   MetricsCollector,
   SecretsRedactor,
+  createSkillStoreFromConfig,
 } from "pilo-core";
 import type { Logger, UserDataCallback, UserDataRequest, UserDataResponse } from "pilo-core";
 import { validateBrowser, getValidBrowsers, parseJsonData, parseResourcesList } from "../utils.js";
@@ -279,6 +280,11 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       });
     }
 
+    // Build a skill store from config (null when skills_enabled is false).
+    // The WebAgent reads / writes through this store; passing null keeps the
+    // skills feature inert.
+    const skillStore = createSkillStoreFromConfig(cfg);
+
     // Create WebAgent
     const webAgent = new WebAgent(browser, {
       debug: debugMode,
@@ -298,6 +304,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       logger,
       eventEmitter,
       onUserDataRequired: options.interactive ? createTerminalPromptCallback() : undefined,
+      skillStore,
     });
 
     // Execute the task

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -47,7 +47,8 @@ export type ConfigCategory =
   | "navigation"
   | "action"
   | "search"
-  | "tabstack";
+  | "tabstack"
+  | "skills";
 
 // =============================================================================
 // PiloConfig Interface (Manual for Readability)
@@ -120,6 +121,11 @@ export interface PiloConfig {
   // Tabstack Configuration
   tabstack_api_key?: string;
   tabstack_api_url?: string;
+
+  // Skills Configuration
+  skills_enabled?: boolean;
+  skills_cache_dir?: string;
+  skills_max_host_tokens?: number;
 }
 
 /** PiloConfigResolved type - output type (defaults applied) */
@@ -189,6 +195,11 @@ export interface PiloConfigResolved {
   // Tabstack Configuration
   tabstack_api_key?: string;
   tabstack_api_url?: string;
+
+  // Skills Configuration
+  skills_enabled: boolean;
+  skills_cache_dir?: string;
+  skills_max_host_tokens: number;
 }
 
 export type ConfigKey = keyof PiloConfigResolved;
@@ -625,6 +636,30 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     description: "Tabstack API base URL (default: https://api.tabstack.ai)",
     category: "tabstack",
   },
+
+  // Skills Configuration
+  skills_enabled: {
+    default: false,
+    type: "boolean",
+    env: ["PILO_SKILLS_ENABLED"],
+    description:
+      "Enable local skill cache: store NL hints from successful tasks and inject them on future runs",
+    category: "skills",
+  },
+  skills_cache_dir: {
+    type: "string",
+    env: ["PILO_SKILLS_CACHE_DIR"],
+    description: "Directory for skill cache files (default: platform cache dir + /pilo/skills)",
+    category: "skills",
+  },
+  skills_max_host_tokens: {
+    default: 4000,
+    type: "number",
+    env: ["PILO_SKILLS_MAX_HOST_TOKENS"],
+    description:
+      "Approximate token budget per host's skill file (oldest entries trimmed when over budget)",
+    category: "skills",
+  },
 };
 
 // =============================================================================
@@ -664,6 +699,8 @@ function buildDefaults(): PiloConfigResolved {
     "navigation_timeout_multiplier",
     "action_timeout_ms",
     "search_provider",
+    "skills_enabled",
+    "skills_max_host_tokens",
   ];
 
   for (const field of requiredFields) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,3 +69,10 @@ export type { ProviderConfig } from "./provider.js";
 
 // Config merge utilities
 export { mergeWithDefaults, createNavigationRetryConfig } from "./utils/configMerge.js";
+
+// Skill cache (Node-only — performs disk I/O)
+export { SkillStore } from "./skills/store.js";
+export type { SkillEntry, SkillStoreOptions } from "./skills/store.js";
+export { resolveHost } from "./skills/host.js";
+export { getDefaultSkillsCacheDir } from "./skills/paths.js";
+export { createSkillStoreFromConfig } from "./skills/factory.js";

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -378,6 +378,10 @@ Provide your final answer:
 🚨 **GUARDRAIL COMPLIANCE:** Any action violating the provided guardrails is FORBIDDEN.
 {% endif %}
 
+{% if hasSkills %}
+{{ skillsBlock }}
+{% endif %}
+
 {% if hasInteractive %}
 🔒 **INTERACTIVE MODE (MANDATORY):**
 You MUST use request_user_data() for any form field that requires the user's personal or business data. This tool collects the data AND fills the fields directly. Do NOT use fill/select/check on these fields afterward. Generating, guessing, or fabricating personal data is a **privacy violation** and is strictly forbidden.
@@ -410,13 +414,15 @@ ${toolCallInstruction}
 `.trim(),
 );
 
-/** Build action system prompt with optional guardrails, web search, Tabstack, and interactive tools. */
+/** Build action system prompt with optional guardrails, web search, Tabstack, interactive tools, and skills. */
 const buildActionLoopSystemPrompt = (
   hasGuardrails: boolean,
   hasWebSearch: boolean = false,
   hasTabstack: boolean = false,
   hasStartingUrl: boolean = false,
   hasInteractive: boolean = false,
+  hasSkills: boolean = false,
+  skillsBlock: string = "",
 ) =>
   actionLoopSystemPromptTemplate({
     hasGuardrails,
@@ -424,6 +430,8 @@ const buildActionLoopSystemPrompt = (
     hasTabstack,
     hasStartingUrl,
     hasInteractive,
+    hasSkills,
+    skillsBlock,
     toolExamples: buildToolExamples(hasWebSearch, hasTabstack, hasInteractive),
     currentDate: getCurrentFormattedDate(),
   });

--- a/packages/core/src/skills/extractionPrompt.ts
+++ b/packages/core/src/skills/extractionPrompt.ts
@@ -1,0 +1,39 @@
+import { buildPromptTemplate } from "../utils/template.js";
+
+const extractionTemplate = buildPromptTemplate(
+  `
+You are reviewing a successful web automation task to extract reusable knowledge
+for future agents working on the same site.
+
+**Site (host):** {{ host }}
+**Task that was just completed:**
+{{ task }}
+
+**What the agent did (trajectory summary):**
+{{ trajectorySummary }}
+
+Write a short note (≤200 words) that a future agent visiting {{ host }} could
+use to work more effectively. Focus on:
+- Site quirks worth knowing (where things live, what didn't work, what did)
+- Stable observations about the site's structure or navigation
+- Pitfalls to avoid
+
+Do NOT include:
+- The specific task details (the next task will be different)
+- Element references (E1, E2, ...) — they change between snapshots
+- CSS selectors or DOM details — write in natural language
+- Personally identifying information from the task
+- Lines that start with "## " (this would be parsed as a section header by the store)
+
+Write in the second person ("when you log in, ..."). Be concise.
+If there is nothing site-specific worth saving, respond with the single word: SKIP
+`.trim(),
+);
+
+export function buildSkillExtractionPrompt(args: {
+  host: string;
+  task: string;
+  trajectorySummary: string;
+}): string {
+  return extractionTemplate(args);
+}

--- a/packages/core/src/skills/extractor.ts
+++ b/packages/core/src/skills/extractor.ts
@@ -1,0 +1,127 @@
+import type { ModelMessage } from "ai";
+import type { ProviderConfig } from "../provider.js";
+import { ExternalContentLabel, wrapExternalContentWithWarning } from "../utils/promptSecurity.js";
+import { generateTextWithRetry } from "../utils/retry.js";
+import { buildSkillExtractionPrompt } from "./extractionPrompt.js";
+
+const DEFAULT_EXTRACTION_MAX_TOKENS = 600;
+const TRAJECTORY_PART_MAX_CHARS = 200;
+const TRAJECTORY_RESULT_MAX_CHARS = 100;
+const MAX_HEADLINE_CHARS = 80;
+
+export interface ExtractSkillInput {
+  task: string;
+  host: string;
+  messages: ModelMessage[];
+  providerConfig: ProviderConfig;
+  /** Max output tokens for the extraction call. Default 600 (~ ≤200 words). */
+  maxOutputTokens?: number;
+  abortSignal?: AbortSignal;
+}
+
+export interface ExtractedSkill {
+  hint: string;
+  taskHeadline: string;
+}
+
+/**
+ * Summarize a successful task trajectory into a short NL hint about the site.
+ * Returns null on any failure (caller logs and skips).
+ */
+export async function extractSkill(input: ExtractSkillInput): Promise<ExtractedSkill | null> {
+  try {
+    const trajectorySummary = summarizeTrajectory(input.messages);
+    // Trajectory summary contains content derived from web pages (tool results,
+    // user messages with snapshot fragments). Wrap with the external-content
+    // warning so the LLM treats it as page-derived text, not instructions.
+    // PageMarkdown is the closest existing label; no perfect fit for "trajectory".
+    const wrappedTrajectory = wrapExternalContentWithWarning(
+      trajectorySummary,
+      ExternalContentLabel.PageMarkdown,
+    );
+    const prompt = buildSkillExtractionPrompt({
+      host: input.host,
+      task: input.task,
+      trajectorySummary: wrappedTrajectory,
+    });
+
+    const response = await generateTextWithRetry(
+      {
+        ...input.providerConfig,
+        prompt,
+        maxOutputTokens: input.maxOutputTokens ?? DEFAULT_EXTRACTION_MAX_TOKENS,
+        abortSignal: input.abortSignal,
+      },
+      { maxAttempts: 2 },
+    );
+
+    const text = (response.text ?? "").trim();
+    if (!text || text === "SKIP") return null;
+
+    return {
+      hint: text,
+      taskHeadline: truncateHeadline(input.task),
+    };
+  } catch (err) {
+    console.warn("[skills] extractSkill failed:", err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Compress the message history into a short summary the extraction prompt can
+ * fit in its context. We don't ship the full transcript — we drop snapshot
+ * bodies and keep tool calls + reasoning.
+ */
+function summarizeTrajectory(messages: ModelMessage[]): string {
+  const lines: string[] = [];
+  // Note: role: "system" messages are intentionally not handled — system prompts
+  // are boilerplate, not signal for skill extraction.
+  for (const m of messages) {
+    if (m.role === "user") {
+      // Skip large page snapshots; keep first TRAJECTORY_PART_MAX_CHARS chars of any user content
+      const content = typeof m.content === "string" ? m.content : "[non-text content]";
+      lines.push(
+        `USER: ${content.slice(0, TRAJECTORY_PART_MAX_CHARS)}${content.length > TRAJECTORY_PART_MAX_CHARS ? "..." : ""}`,
+      );
+    } else if (m.role === "assistant") {
+      if (typeof m.content === "string") {
+        lines.push(
+          `ASSISTANT: ${m.content.slice(0, TRAJECTORY_PART_MAX_CHARS)}${m.content.length > TRAJECTORY_PART_MAX_CHARS ? "..." : ""}`,
+        );
+      } else if (Array.isArray(m.content)) {
+        for (const part of m.content) {
+          if (part.type === "tool-call") {
+            const args = JSON.stringify(part.input).slice(0, TRAJECTORY_PART_MAX_CHARS);
+            lines.push(`TOOL: ${part.toolName}(${args})`);
+          } else if (part.type === "text") {
+            // Assistant-spoken text — not reasoning. The `reasoning` part type
+            // below is the actual think-out-loud channel; this is the model's
+            // user-facing output.
+            lines.push(`ASSISTANT: ${part.text.slice(0, TRAJECTORY_PART_MAX_CHARS)}`);
+          } else if (part.type === "reasoning") {
+            lines.push(`REASONING: ${part.text.slice(0, TRAJECTORY_PART_MAX_CHARS)}`);
+          }
+        }
+      }
+    } else if (m.role === "tool") {
+      // Tool results — keep the action name and a snippet of output
+      if (Array.isArray(m.content)) {
+        for (const part of m.content) {
+          if (part.type === "tool-result") {
+            const out = JSON.stringify(part.output).slice(0, TRAJECTORY_RESULT_MAX_CHARS);
+            lines.push(`RESULT: ${part.toolName} → ${out}`);
+          }
+        }
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+function truncateHeadline(task: string): string {
+  const oneLine = task.replace(/\s+/g, " ").trim();
+  return oneLine.length > MAX_HEADLINE_CHARS
+    ? oneLine.slice(0, MAX_HEADLINE_CHARS - 3) + "..."
+    : oneLine;
+}

--- a/packages/core/src/skills/factory.ts
+++ b/packages/core/src/skills/factory.ts
@@ -1,0 +1,27 @@
+/**
+ * Skill cache - config -> SkillStore factory (Node-only)
+ *
+ * Bridges a resolved Pilo config to a constructed SkillStore. Lives in a
+ * separate file (rather than directly in `index.ts`) so the dependency on
+ * `./store.js` and `./paths.js` — both Node-only — stays cleanly isolated
+ * from the browser-safe `core.ts` boundary.
+ */
+import type { PiloConfigResolved } from "../config/defaults.js";
+import { SkillStore } from "./store.js";
+import { getDefaultSkillsCacheDir } from "./paths.js";
+
+/**
+ * Construct a SkillStore from a resolved Pilo config, or return null if
+ * skills are disabled. Use this when wiring `WebAgent` from CLI / server.
+ *
+ * Not available from the browser-safe `core.ts` boundary — disk I/O requires
+ * Node fs/path/os.
+ */
+export function createSkillStoreFromConfig(config: PiloConfigResolved): SkillStore | null {
+  if (!config.skills_enabled) return null;
+  const cacheDir = config.skills_cache_dir ?? getDefaultSkillsCacheDir();
+  return new SkillStore({
+    cacheDir,
+    maxHostTokens: config.skills_max_host_tokens,
+  });
+}

--- a/packages/core/src/skills/host.ts
+++ b/packages/core/src/skills/host.ts
@@ -1,0 +1,19 @@
+/**
+ * Skill cache - host resolver
+ *
+ * Resolves a URL string to a canonical host string suitable for use as a
+ * skill cache key. Returns null for non-http(s) URLs or malformed input.
+ *
+ * The host string follows WHATWG URL semantics: includes the port for
+ * non-default ports (e.g., "localhost:3000"), lowercased automatically,
+ * and excludes any userinfo (username:password@) component.
+ */
+export function resolveHost(url: string): string | null {
+  try {
+    const u = new URL(url);
+    if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+    return u.host; // includes port for non-default ports (e.g., "localhost:3000")
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/skills/injector.ts
+++ b/packages/core/src/skills/injector.ts
@@ -1,0 +1,22 @@
+/**
+ * Skill cache - prompt injector
+ *
+ * Wraps the raw markdown read from a host's skill file with framing text that
+ * instructs the model to treat the notes as advisory hints from prior runs.
+ * The model is reminded to verify against the live snapshot before acting on
+ * any specific claim.
+ *
+ * Returns an empty string when there is nothing to inject (null, empty, or
+ * whitespace-only input) so callers can use the result to gate the prompt
+ * block without a separate boolean.
+ */
+export function formatSkillSection(hostMarkdown: string | null): string {
+  if (!hostMarkdown || !hostMarkdown.trim()) return "";
+  return `<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->
+You have visited this site before. Below are notes from prior successful runs.
+Use what is relevant to the current task; the page may have changed, so verify
+against the live snapshot before acting on any specific claim.
+
+${hostMarkdown.trim()}
+<!-- END NOTES -->`;
+}

--- a/packages/core/src/skills/paths.ts
+++ b/packages/core/src/skills/paths.ts
@@ -1,0 +1,31 @@
+/**
+ * Skill cache - default paths (Node-only)
+ *
+ * Resolves the default cache directory for skill files. Honors XDG_CACHE_HOME
+ * on Linux/macOS and LOCALAPPDATA on Windows, falling back to platform-typical
+ * locations otherwise.
+ *
+ * IMPORTANT: This module depends on Node.js `path` and `os` and must not be
+ * imported from browser-safe contexts.
+ */
+import { join } from "path";
+import { homedir } from "os";
+
+/**
+ * Returns the platform-appropriate default directory for the skill cache.
+ *
+ * Use this when constructing a `SkillStore` without a user-configured
+ * `skills_cache_dir` (the `WebAgent` integration calls this to resolve the
+ * default).
+ *
+ * - Linux/macOS: `$XDG_CACHE_HOME/pilo/skills` (falls back to `~/.cache/pilo/skills`)
+ * - Windows: `%LOCALAPPDATA%/pilo/skills` (falls back to `~/AppData/Local/pilo/skills`)
+ */
+export function getDefaultSkillsCacheDir(): string {
+  if (process.platform === "win32") {
+    const base = process.env.LOCALAPPDATA || join(homedir(), "AppData", "Local");
+    return join(base, "pilo", "skills");
+  }
+  const xdg = process.env.XDG_CACHE_HOME || join(homedir(), ".cache");
+  return join(xdg, "pilo", "skills");
+}

--- a/packages/core/src/skills/store.ts
+++ b/packages/core/src/skills/store.ts
@@ -1,0 +1,147 @@
+/**
+ * Skill cache - per-host storage (Node-only)
+ *
+ * Stores natural-language skill hints in one markdown file per host. Each
+ * call to `append()` writes a dated section, trimming the oldest sections
+ * once the file exceeds an approximate token budget. The most recently
+ * written section is never trimmed.
+ *
+ * IMPORTANT: This module performs disk I/O via Node.js `fs` and must not be
+ * imported from browser-safe contexts.
+ */
+import {
+  readFileSync,
+  writeFileSync,
+  existsSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  readdirSync,
+} from "fs";
+import { randomUUID } from "node:crypto";
+import { join } from "path";
+
+/** Approximate chars-per-token heuristic for the trim budget. Replace with a
+ *  real tokenizer if precision becomes important. */
+const CHARS_PER_TOKEN_APPROX = 4;
+
+export interface SkillEntry {
+  /** ISO date string, YYYY-MM-DD */
+  date: string;
+  /** Short task headline (truncated to ~80 chars) */
+  taskHeadline: string;
+  /** The NL hint body */
+  hint: string;
+}
+
+export interface SkillStoreOptions {
+  cacheDir: string;
+  /** Approximate token budget per host file. Default 4000. */
+  maxHostTokens?: number;
+}
+
+export class SkillStore {
+  constructor(private readonly options: SkillStoreOptions) {}
+
+  /** Returns the host file's raw markdown, or null if absent. */
+  async read(host: string): Promise<string | null> {
+    const path = this.pathFor(host);
+    if (!existsSync(path)) return null;
+    try {
+      return readFileSync(path, "utf-8");
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Appends a new section, then trims oldest sections if over the token budget.
+   *
+   * **Not safe for concurrent calls on the same host.** Calls are not
+   * serialized — two appends in flight will both read the pre-append content
+   * and one will overwrite the other. The agent's extraction path serializes
+   * naturally (one await call per run), so this is fine for v1. If a future
+   * consumer needs concurrent writes, add per-host serialization (e.g., a
+   * `Map<host, Promise<void>>` chain).
+   */
+  async append(host: string, entry: SkillEntry): Promise<void> {
+    const path = this.pathFor(host);
+    if (!existsSync(this.options.cacheDir)) {
+      mkdirSync(this.options.cacheDir, { recursive: true });
+    }
+    const existing = (await this.read(host)) ?? "";
+    const section = this.formatEntry(entry);
+    const updated = existing ? `${existing}\n\n${section}` : section;
+    const trimmed = this.trimToBudget(updated);
+    this.atomicWrite(path, trimmed);
+  }
+
+  /** Remove one host's file, or (with no arg) the whole cache dir's *.md. */
+  async clear(host?: string): Promise<void> {
+    if (host !== undefined) {
+      // pathFor() validates the host; an empty/invalid string throws here
+      // rather than silently falling through to the clear-all path.
+      const path = this.pathFor(host);
+      if (existsSync(path)) unlinkSync(path);
+      return;
+    }
+    if (!existsSync(this.options.cacheDir)) return;
+    for (const file of readdirSync(this.options.cacheDir)) {
+      if (file.endsWith(".md")) unlinkSync(join(this.options.cacheDir, file));
+    }
+  }
+
+  private pathFor(host: string): string {
+    // SkillStore is part of the public API; typical callers go through
+    // WebAgent and have already passed through resolveHost(), but external
+    // callers might not. We defend against path traversal here rather than
+    // trusting the input shape.
+    //
+    // We intentionally allow underscores (some dev/staging/CDN hosts have
+    // them) and IPv6 literals (e.g. "[::1]:3000") — both are valid WHATWG
+    // host shapes that a stricter regex would reject. The list below is the
+    // minimum set of characters that would let an attacker escape the cache
+    // directory or smuggle a filename across newlines.
+    if (
+      typeof host !== "string" ||
+      host.length === 0 ||
+      host.includes("/") ||
+      host.includes("\\") ||
+      host.includes("..") ||
+      host.includes("\0") ||
+      host.includes("\n") ||
+      host.includes("\r")
+    ) {
+      throw new Error(`Invalid host: ${JSON.stringify(host)}`);
+    }
+    // encodeURIComponent handles ":", "[", "]", and other URL-safe-but-not-FS-safe
+    // characters. The result is deterministic and reversible (not that we need
+    // to reverse it — the host is always passed back in by the caller).
+    const safe = encodeURIComponent(host);
+    return join(this.options.cacheDir, `${safe}.md`);
+  }
+
+  private formatEntry(entry: SkillEntry): string {
+    return `## ${entry.date} — ${entry.taskHeadline}\n\n${entry.hint.trim()}`;
+  }
+
+  private trimToBudget(content: string): string {
+    const max = this.options.maxHostTokens ?? 4000;
+    // Approximate: CHARS_PER_TOKEN_APPROX chars per token. Cheap, no tokenizer dependency.
+    const maxChars = max * CHARS_PER_TOKEN_APPROX;
+    if (content.length <= maxChars) return content;
+    // Drop oldest sections (sections start with "## "). Keep the newest entry
+    // even if it alone exceeds the budget — never truncate the just-written one.
+    const sections = content.split(/\n(?=## )/);
+    while (sections.length > 1 && sections.join("\n").length > maxChars) {
+      sections.shift();
+    }
+    return sections.join("\n");
+  }
+
+  private atomicWrite(path: string, content: string): void {
+    const tmp = `${path}.tmp.${randomUUID()}`;
+    writeFileSync(tmp, content, "utf-8");
+    renameSync(tmp, path);
+  }
+}

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -60,6 +60,14 @@ import {
   SpanName,
   recordSanitizedException,
 } from "./telemetry/tracing.js";
+// Skill store type — `import type` keeps the (Node-only) `./skills/store.js`
+// module out of the runtime import graph, so this file stays browser-safe.
+// Callers wire a SkillStore via the `skillStore` option; constructing one
+// requires Node fs/path/os, which the extension's bundle can't provide.
+import type { SkillStore as SkillStoreType } from "./skills/store.js";
+import { resolveHost } from "./skills/host.js";
+import { formatSkillSection } from "./skills/injector.js";
+import { extractSkill } from "./skills/extractor.js";
 
 // === Type Definitions ===
 
@@ -100,6 +108,17 @@ export interface WebAgentOptions {
   onUserDataRequired?: UserDataCallback;
   /** Correlation ID for this task, propagated to logs and traces. */
   taskId?: string;
+  /**
+   * Optional skill cache store. When provided, the agent reads per-host skill
+   * notes from this store at task start and writes new ones on excellent
+   * completion. When null / omitted, the skills feature is inert (no reads,
+   * no writes, no extraction LLM calls).
+   *
+   * Constructing a SkillStore requires Node fs/path/os; do not pass one from
+   * browser contexts. Use `createSkillStoreFromConfig(config)` from the
+   * Node-only `index.ts` entry to build one from a resolved Pilo config.
+   */
+  skillStore?: SkillStoreType | null;
 }
 
 export interface ExecuteOptions {
@@ -110,6 +129,14 @@ export interface ExecuteOptions {
   /** Abort signal for cancellation */
   abortSignal?: AbortSignal;
 }
+
+/**
+ * Validator-assigned quality of a `done()` answer. Mirrors the four-level
+ * enum returned by the validation tool. Skill extraction only fires on
+ * `"excellent"`, so getting this typed (not `string`) catches typos at
+ * compile time.
+ */
+type CompletionQuality = "failed" | "partial" | "complete" | "excellent";
 
 /** Error codes for task failures */
 export enum TaskErrorCode {
@@ -158,6 +185,8 @@ interface ExecutionState {
   lastAction?: string;
   actionRepeatCount: number;
   validationAttempts: number;
+  completionQuality?: CompletionQuality;
+  forceAccept?: boolean;
 }
 
 interface PlanOutput {
@@ -229,6 +258,7 @@ export class WebAgent {
   private readonly tabstackApiUrl: string | undefined;
   private readonly onUserDataRequired: UserDataCallback | undefined;
   private readonly taskId: string | undefined;
+  private readonly skillStore: SkillStoreType | null;
 
   constructor(
     private browser: AriaBrowser,
@@ -253,6 +283,7 @@ export class WebAgent {
     this.tabstackApiUrl = options.tabstackApiUrl;
     this.onUserDataRequired = options.onUserDataRequired;
     this.taskId = options.taskId;
+    this.skillStore = options.skillStore ?? null;
 
     if (this.searchProvider === "parallel-api" && !this.searchApiKey) {
       throw new Error("parallel_api_key is required when search_provider is 'parallel-api'");
@@ -329,12 +360,23 @@ export class WebAgent {
             // 5. Navigation phase (with retry on recoverable errors)
             await this.navigateToStartWithRetry(task);
 
-            this.initializeSystemPromptAndTask(task);
+            await this.initializeSystemPromptAndTask(task);
 
             // 6. Main execution loop
             const loopOutcome = await this.runMainLoop(task, executionState);
 
-            // 7. Return results
+            // 7. Post-loop skill extraction (silent failures; only when accepted
+            //    on quality, not when force-accepted at the validation cap).
+            if (
+              loopOutcome.success &&
+              loopOutcome.completionQuality === "excellent" &&
+              !loopOutcome.forceAccept &&
+              this.skillStore
+            ) {
+              await this.extractAndStoreSkill(task);
+            }
+
+            // 8. Return results
             const result = this.buildResult(loopOutcome, executionState);
             span.setAttribute("pilo.task.success", result.success);
             return result;
@@ -387,7 +429,13 @@ export class WebAgent {
   private async runMainLoop(
     task: string,
     executionState: ExecutionState,
-  ): Promise<{ success: boolean; finalAnswer: string | null; error?: TaskError }> {
+  ): Promise<{
+    success: boolean;
+    finalAnswer: string | null;
+    error?: TaskError;
+    completionQuality?: CompletionQuality;
+    forceAccept?: boolean;
+  }> {
     // Setup tools once
     const webActionTools = createWebActionTools({
       browser: this.browser,
@@ -525,6 +573,8 @@ export class WebAgent {
               executionState.success = result.success;
               executionState.finalAnswer = result.finalAnswer;
               executionState.error = result.error;
+              executionState.completionQuality = result.completionQuality;
+              executionState.forceAccept = result.forceAccept;
               return { flow: "break" as const };
             }
 
@@ -622,6 +672,8 @@ export class WebAgent {
         success: executionState.success,
         finalAnswer: executionState.finalAnswer,
         error: executionState.error,
+        completionQuality: executionState.completionQuality,
+        forceAccept: executionState.forceAccept,
       };
     }
 
@@ -889,6 +941,8 @@ export class WebAgent {
     pageChanged: boolean;
     actionExecuted: boolean;
     error?: TaskError;
+    completionQuality?: CompletionQuality;
+    forceAccept?: boolean;
   }> {
     // Start processing - hasScreenshot is true if we're in vision mode and just captured a screenshot
     this.emit(WebAgentEventType.AGENT_PROCESSING, {
@@ -1091,6 +1145,8 @@ export class WebAgent {
             finalAnswer: actionOutput.result,
             pageChanged: false,
             actionExecuted: true,
+            completionQuality: validationResult.completionQuality,
+            forceAccept: validationResult.forceAccept,
           };
         } else {
           // Validation failed - the feedback has been added to messages
@@ -1233,7 +1289,7 @@ export class WebAgent {
     task: string,
     finalAnswer: string,
     executionState: ExecutionState,
-  ): Promise<{ isAccepted: boolean }> {
+  ): Promise<{ isAccepted: boolean; completionQuality: CompletionQuality; forceAccept: boolean }> {
     executionState.validationAttempts++;
 
     return withSpan(
@@ -1287,7 +1343,11 @@ export class WebAgent {
             throw new Error("Failed to validate task completion");
           }
 
-          const validationResult = validationResponse.toolResults[0].output as any;
+          const validationResult = validationResponse.toolResults[0].output as {
+            taskAssessment: string;
+            completionQuality: CompletionQuality;
+            feedback?: string;
+          };
           const { taskAssessment, completionQuality, feedback } = validationResult;
 
           // Emit validation event
@@ -1310,7 +1370,7 @@ export class WebAgent {
             const feedbackMessage = buildValidationFeedbackPrompt(
               executionState.validationAttempts,
               taskAssessment,
-              feedback,
+              feedback ?? null,
             );
 
             this.messages.push({ role: "user", content: feedbackMessage });
@@ -1339,6 +1399,8 @@ export class WebAgent {
 
           return {
             isAccepted: isAccepted || forceAccept,
+            completionQuality,
+            forceAccept,
           };
         } catch (error) {
           span.setStatus({
@@ -1347,9 +1409,11 @@ export class WebAgent {
           });
           recordSanitizedException(span, error);
 
-          // On validation error, accept the result if we've hit max attempts
+          // On validation error, accept the result if we've hit max attempts.
+          // forceAccept: true because we're only accepting due to the cap, not
+          // because validation succeeded.
           if (executionState.validationAttempts >= this.maxValidationAttempts) {
-            return { isAccepted: true };
+            return { isAccepted: true, completionQuality: "failed", forceAccept: true };
           }
 
           // Otherwise, continue execution
@@ -1360,10 +1424,47 @@ export class WebAgent {
             iterationId: this.currentIterationId,
           });
 
-          return { isAccepted: false };
+          return { isAccepted: false, completionQuality: "failed", forceAccept: false };
         }
       },
     );
+  }
+
+  /**
+   * Extract a per-host skill hint from the just-completed task trajectory and
+   * append it to the cached host file. Called only on excellent completion.
+   *
+   * Uses the live page URL (where the task ended) over the originally-planned
+   * URL because the agent may have navigated to a different host mid-task —
+   * the ending host is the most likely starting point for a similar task next
+   * time.
+   *
+   * Failures are swallowed (with a warning); skill extraction must never fail
+   * an otherwise-successful task.
+   */
+  private async extractAndStoreSkill(task: string): Promise<void> {
+    const host = resolveHost(this.currentPage.url || this.url);
+    if (!host || !this.skillStore) return;
+
+    try {
+      const extracted = await extractSkill({
+        task,
+        host,
+        messages: this.messages,
+        providerConfig: this.providerConfig,
+        abortSignal: this.abortSignal,
+      });
+      if (!extracted) return;
+
+      const today = new Date().toISOString().slice(0, 10);
+      await this.skillStore.append(host, {
+        date: today,
+        taskHeadline: extracted.taskHeadline,
+        hint: extracted.hint,
+      });
+    } catch (err) {
+      console.warn(`[skills] extraction failed for ${host}:`, err);
+    }
   }
 
   /**
@@ -1661,12 +1762,32 @@ export class WebAgent {
     });
   }
 
-  private initializeSystemPromptAndTask(task: string): void {
+  private async initializeSystemPromptAndTask(task: string): Promise<void> {
     const hasGuardrails = Boolean(this.guardrails);
     const hasWebSearch = this.searchProvider !== "none";
     const hasTabstack = Boolean(this.tabstackApiKey);
     const hasStartingUrl = Boolean(this.url && this.url !== "about:blank");
     const hasInteractive = Boolean(this.onUserDataRequired);
+
+    let hasSkills = false;
+    let skillsBlock = "";
+    if (this.skillStore) {
+      // Read uses the starting URL because the loop hasn't navigated yet.
+      // Compare with extractAndStoreSkill, which uses the ending URL.
+      const host = resolveHost(this.url);
+      if (host) {
+        try {
+          const content = await this.skillStore.read(host);
+          const rendered = formatSkillSection(content);
+          if (rendered) {
+            hasSkills = true;
+            skillsBlock = rendered;
+          }
+        } catch (err) {
+          console.warn(`[skills] failed to read host file for ${host}:`, err);
+        }
+      }
+    }
 
     const taskPromptContent = buildTaskAndPlanPrompt(
       task,
@@ -1682,6 +1803,8 @@ export class WebAgent {
       hasTabstack,
       hasStartingUrl,
       hasInteractive,
+      hasSkills,
+      skillsBlock,
     );
 
     this.messages = [
@@ -1821,7 +1944,7 @@ export class WebAgent {
 
         // Re-initialize messages: stale DOM snapshots from the old browser would
         // confuse the agent and may trigger false repetition-abort logic.
-        this.initializeSystemPromptAndTask(task);
+        await this.initializeSystemPromptAndTask(task);
 
         // Reset repetition tracking to avoid false "stuck in loop" detection.
         executionState.actionRepeatCount = 0;

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -191,6 +191,9 @@ describe("ConfigManager", () => {
         "parallel_api_key",
         "tabstack_api_key",
         "tabstack_api_url",
+        "skills_enabled",
+        "skills_cache_dir",
+        "skills_max_host_tokens",
       ];
 
       // Check that schema has all PiloConfig keys

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -271,6 +271,42 @@ describe("prompts", () => {
       expect(prompt).toContain("GUARDRAIL COMPLIANCE");
       expect(prompt).toContain("webSearch(");
     });
+
+    describe("skills block", () => {
+      const SKILLS_MARKER = "<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->";
+      const skillsSample = `${SKILLS_MARKER}\nsample notes\n<!-- END NOTES -->`;
+
+      it("does NOT include the skills block when hasSkills=false", () => {
+        const prompt = buildActionLoopSystemPrompt(false, false, false, false, false, false, "");
+        expect(prompt).not.toContain(SKILLS_MARKER);
+      });
+
+      it("does NOT include the skills block when hasSkills=true but skillsBlock is empty", () => {
+        // Defensive: the {% if hasSkills %} branch may render an empty {{ skillsBlock }}.
+        // Either way, the marker must not appear since the block has no content.
+        const prompt = buildActionLoopSystemPrompt(false, false, false, false, false, true, "");
+        expect(prompt).not.toContain(SKILLS_MARKER);
+      });
+
+      it("includes the skillsBlock content verbatim when hasSkills=true and skillsBlock has content", () => {
+        const prompt = buildActionLoopSystemPrompt(
+          false,
+          false,
+          false,
+          false,
+          false,
+          true,
+          skillsSample,
+        );
+        expect(prompt).toContain(skillsSample);
+      });
+
+      it("preserves backward compatibility for the original 5-argument signature", () => {
+        // Existing callers pass 5 booleans; defaults must keep the skills block out.
+        const prompt = buildActionLoopSystemPrompt(false, false, false, false, false);
+        expect(prompt).not.toContain(SKILLS_MARKER);
+      });
+    });
   });
 
   describe("buildTaskAndPlanPrompt", () => {

--- a/packages/core/test/skills/extractionPrompt.test.ts
+++ b/packages/core/test/skills/extractionPrompt.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { buildSkillExtractionPrompt } from "../../src/skills/extractionPrompt.js";
+
+describe("skills/extractionPrompt", () => {
+  it("renders host, task, and trajectorySummary into the template", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "example.com",
+      task: "Buy a widget from the store",
+      trajectorySummary: "USER: open page\nTOOL: click(button)",
+    });
+
+    expect(prompt).toContain("example.com");
+    expect(prompt).toContain("Buy a widget from the store");
+    expect(prompt).toContain("USER: open page");
+    expect(prompt).toContain("TOOL: click(button)");
+  });
+
+  it("produces a string for typical inputs", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "shop.example.com",
+      task: "Find a thing",
+      trajectorySummary: "USER: hello",
+    });
+    expect(typeof prompt).toBe("string");
+    expect(prompt.length).toBeGreaterThan(0);
+  });
+
+  it("includes the SKIP instruction", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "example.com",
+      task: "Task",
+      trajectorySummary: "summary",
+    });
+    expect(prompt).toContain("SKIP");
+  });
+
+  it("includes the section-header guard", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "example.com",
+      task: "Task",
+      trajectorySummary: "summary",
+    });
+    expect(prompt).toContain('Lines that start with "## "');
+  });
+
+  it("includes the second-person guidance", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "example.com",
+      task: "Task",
+      trajectorySummary: "summary",
+    });
+    expect(prompt).toContain("second person");
+  });
+
+  it("produces a renderable prompt for empty task and trajectory", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "example.com",
+      task: "",
+      trajectorySummary: "",
+    });
+    expect(typeof prompt).toBe("string");
+    expect(prompt).toContain("example.com");
+    // Should still include the structural instructions
+    expect(prompt).toContain("SKIP");
+  });
+
+  it("renders the host string in multiple positions", () => {
+    const prompt = buildSkillExtractionPrompt({
+      host: "unique-host.test",
+      task: "Task",
+      trajectorySummary: "summary",
+    });
+    // The host appears at least twice in the template (Site header + future-agent reference)
+    const occurrences = prompt.split("unique-host.test").length - 1;
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/core/test/skills/extractor.test.ts
+++ b/packages/core/test/skills/extractor.test.ts
@@ -1,0 +1,437 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ModelMessage } from "ai";
+import { generateTextWithRetry } from "../../src/utils/retry.js";
+import { extractSkill } from "../../src/skills/extractor.js";
+import type { ProviderConfig } from "../../src/provider.js";
+
+vi.mock("../../src/utils/retry.js", () => ({
+  generateTextWithRetry: vi.fn(),
+}));
+
+const mockGenerateTextWithRetry = vi.mocked(generateTextWithRetry);
+
+// Minimal provider config stub — only the spread shape matters for these tests.
+const providerConfig = {
+  model: "stub-model" as any,
+  providerOptions: { foo: "bar" },
+} as unknown as ProviderConfig;
+
+function mockResponse(text: string) {
+  // generateText returns many fields; we only use `.text` in the extractor.
+  return { text } as any;
+}
+
+describe("skills/extractor", () => {
+  beforeEach(() => {
+    mockGenerateTextWithRetry.mockReset();
+  });
+
+  describe("happy path", () => {
+    it("returns hint and taskHeadline on a normal LLM response", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(
+        mockResponse("When you visit example.com, the search bar is in the top nav."),
+      );
+
+      const result = await extractSkill({
+        task: "Find a product",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toEqual({
+        hint: "When you visit example.com, the search bar is in the top nav.",
+        taskHeadline: "Find a product",
+      });
+    });
+
+    it("trims whitespace from the LLM response", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("  some hint\n\n  "));
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result?.hint).toBe("some hint");
+    });
+  });
+
+  describe("null / skip cases", () => {
+    it("returns null when LLM responds with exact 'SKIP'", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("SKIP"));
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when LLM responds with SKIP after trim", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("  SKIP  \n"));
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when LLM responds with whitespace-only text", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("   \n\t  "));
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when LLM response has no text field", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce({} as any);
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null (does not throw) when generateTextWithRetry throws", async () => {
+      mockGenerateTextWithRetry.mockRejectedValueOnce(new Error("LLM exploded"));
+
+      const result = await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("headline handling", () => {
+    it("truncates a task longer than 80 chars with '...' ending", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const longTask =
+        "This is a very long task description that goes on and on and on and exceeds the limit for sure";
+      const result = await extractSkill({
+        task: longTask,
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result?.taskHeadline.length).toBe(80);
+      expect(result?.taskHeadline.endsWith("...")).toBe(true);
+      expect(result?.taskHeadline.startsWith("This is a very long task")).toBe(true);
+    });
+
+    it("collapses multi-line task into a single line", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const result = await extractSkill({
+        task: "First line\n\nSecond line   with   spaces\n\tThird line",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result?.taskHeadline).toBe("First line Second line with spaces Third line");
+      expect(result?.taskHeadline).not.toContain("\n");
+      expect(result?.taskHeadline).not.toContain("\t");
+    });
+
+    it("does not truncate a short task", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const result = await extractSkill({
+        task: "Short task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result?.taskHeadline).toBe("Short task");
+    });
+
+    it("treats exactly 80 chars as no truncation", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const eightyCharTask = "a".repeat(80);
+      const result = await extractSkill({
+        task: eightyCharTask,
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      expect(result?.taskHeadline).toBe(eightyCharTask);
+      expect(result?.taskHeadline.endsWith("...")).toBe(false);
+    });
+  });
+
+  describe("call params", () => {
+    it("passes provider config, prompt, default maxOutputTokens, and abortSignal", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+      const abortController = new AbortController();
+
+      await extractSkill({
+        task: "Find a thing",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+        abortSignal: abortController.signal,
+      });
+
+      expect(mockGenerateTextWithRetry).toHaveBeenCalledTimes(1);
+      const [params, retryOpts] = mockGenerateTextWithRetry.mock.calls[0];
+
+      expect(params).toMatchObject({
+        model: "stub-model",
+        providerOptions: { foo: "bar" },
+        maxOutputTokens: 600,
+        abortSignal: abortController.signal,
+      });
+      expect(typeof params.prompt).toBe("string");
+      expect(params.prompt).toContain("example.com");
+      expect(params.prompt).toContain("Find a thing");
+
+      expect(retryOpts).toEqual({ maxAttempts: 2 });
+    });
+
+    it("passes custom maxOutputTokens when provided", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+        maxOutputTokens: 1200,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      expect(params.maxOutputTokens).toBe(1200);
+    });
+  });
+
+  describe("trajectory summarization", () => {
+    it("compresses user, assistant tool-call, and tool result messages", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const messages: ModelMessage[] = [
+        { role: "user", content: "Open the store page" },
+        {
+          role: "assistant",
+          content: [
+            { type: "text", text: "I will click the search button." },
+            {
+              type: "tool-call",
+              toolCallId: "1",
+              toolName: "click",
+              input: { ref: "E5" },
+            },
+          ],
+        },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "1",
+              toolName: "click",
+              output: { type: "json", value: { ok: true } },
+            },
+          ],
+        },
+      ];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).toContain("USER: Open the store page");
+      // Assistant `type: "text"` parts are spoken text, not reasoning.
+      expect(prompt).toContain("ASSISTANT: I will click the search button.");
+      expect(prompt).toContain('TOOL: click({"ref":"E5"})');
+      expect(prompt).toContain("RESULT: click");
+    });
+
+    it("renders an empty messages array as an empty trajectory in the prompt", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages: [],
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      // No USER:/TOOL:/RESULT: lines should appear
+      expect(prompt).not.toContain("USER:");
+      expect(prompt).not.toContain("TOOL:");
+      expect(prompt).not.toContain("RESULT:");
+      // Still has the structural template instructions
+      expect(prompt).toContain("SKIP");
+    });
+
+    it("truncates user content longer than 200 chars with '...'", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const longUserContent = "x".repeat(500);
+      const messages: ModelMessage[] = [{ role: "user", content: longUserContent }];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      // Should contain a truncated USER: line with exactly 200 x's + "..."
+      expect(prompt).toContain(`USER: ${"x".repeat(200)}...`);
+      // Should not contain the full 500-char string
+      expect(prompt).not.toContain("x".repeat(201));
+    });
+
+    it("represents non-string user content as a placeholder", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const messages: ModelMessage[] = [
+        {
+          role: "user",
+          content: [{ type: "text", text: "some text" }],
+        },
+      ];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).toContain("USER: [non-text content]");
+    });
+
+    it("renders an assistant message with content: string as an ASSISTANT: line", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const messages: ModelMessage[] = [
+        { role: "assistant", content: "Here is the final answer." },
+      ];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).toContain("ASSISTANT: Here is the final answer.");
+    });
+
+    it("truncates assistant string content longer than 200 chars with '...'", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const longContent = "y".repeat(500);
+      const messages: ModelMessage[] = [{ role: "assistant", content: longContent }];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).toContain(`ASSISTANT: ${"y".repeat(200)}...`);
+      expect(prompt).not.toContain("y".repeat(201));
+    });
+
+    it("renders assistant 'reasoning' parts as REASONING: lines", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const messages: ModelMessage[] = [
+        {
+          role: "assistant",
+          content: [{ type: "reasoning", text: "Thinking about the next step." } as any],
+        },
+      ];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).toContain("REASONING: Thinking about the next step.");
+    });
+
+    it("silently drops role: 'system' messages", async () => {
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockResponse("hint"));
+
+      const messages: ModelMessage[] = [
+        { role: "system", content: "You are a helpful agent." },
+        { role: "user", content: "Open the page" },
+      ];
+
+      await extractSkill({
+        task: "Task",
+        host: "example.com",
+        messages,
+        providerConfig,
+      });
+
+      const [params] = mockGenerateTextWithRetry.mock.calls[0];
+      const prompt = params.prompt as string;
+
+      expect(prompt).not.toContain("SYSTEM:");
+      expect(prompt).not.toContain("You are a helpful agent.");
+      // The user line should still be present so we know we ran the loop.
+      expect(prompt).toContain("USER: Open the page");
+    });
+  });
+});

--- a/packages/core/test/skills/host.test.ts
+++ b/packages/core/test/skills/host.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { resolveHost } from "../../src/skills/host.js";
+
+describe("skills/host", () => {
+  describe("resolveHost", () => {
+    it("returns the hostname for a valid http URL", () => {
+      expect(resolveHost("http://example.com/path")).toBe("example.com");
+    });
+
+    it("returns the hostname for a valid https URL", () => {
+      expect(resolveHost("https://example.com/path")).toBe("example.com");
+    });
+
+    it("includes the port for non-default ports", () => {
+      expect(resolveHost("http://localhost:3000/")).toBe("localhost:3000");
+      expect(resolveHost("https://example.com:8443/foo")).toBe("example.com:8443");
+    });
+
+    it("omits the port for default ports", () => {
+      // WHATWG URL drops default ports (80 for http, 443 for https)
+      expect(resolveHost("http://example.com:80/")).toBe("example.com");
+      expect(resolveHost("https://example.com:443/")).toBe("example.com");
+    });
+
+    it("lowercases the hostname (WHATWG URL normalizes automatically)", () => {
+      expect(resolveHost("https://EXAMPLE.COM/")).toBe("example.com");
+      expect(resolveHost("https://MixedCase.Example.ORG/")).toBe("mixedcase.example.org");
+    });
+
+    it("strips userinfo from the host", () => {
+      expect(resolveHost("https://user:pass@example.com/")).toBe("example.com");
+      expect(resolveHost("http://user@example.com:8080/")).toBe("example.com:8080");
+    });
+
+    it("returns null for file:// URLs", () => {
+      expect(resolveHost("file:///etc/hosts")).toBe(null);
+    });
+
+    it("returns null for about: URLs", () => {
+      expect(resolveHost("about:blank")).toBe(null);
+    });
+
+    it("returns null for data: URLs", () => {
+      expect(resolveHost("data:text/plain,hello")).toBe(null);
+    });
+
+    it("returns null for chrome-extension:// URLs", () => {
+      expect(resolveHost("chrome-extension://abcd1234/popup.html")).toBe(null);
+    });
+
+    it("returns null for ftp URLs", () => {
+      expect(resolveHost("ftp://example.com/file.txt")).toBe(null);
+    });
+
+    it("returns null for malformed URLs", () => {
+      expect(resolveHost("not a url")).toBe(null);
+      expect(resolveHost("://example.com")).toBe(null);
+      expect(resolveHost("http//example.com")).toBe(null);
+    });
+
+    it("returns null for empty strings", () => {
+      expect(resolveHost("")).toBe(null);
+    });
+
+    it("handles URLs with query strings and fragments", () => {
+      expect(resolveHost("https://example.com/path?q=1#frag")).toBe("example.com");
+    });
+
+    it("handles IDN/punycode hostnames", () => {
+      // WHATWG URL converts unicode hostnames to punycode automatically
+      const result = resolveHost("https://例え.jp/");
+      expect(result).toBe("xn--r8jz45g.jp");
+    });
+  });
+});

--- a/packages/core/test/skills/injector.test.ts
+++ b/packages/core/test/skills/injector.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { formatSkillSection } from "../../src/skills/injector.js";
+
+describe("skills/injector", () => {
+  describe("formatSkillSection", () => {
+    it("returns an empty string when input is null", () => {
+      expect(formatSkillSection(null)).toBe("");
+    });
+
+    it("returns an empty string when input is an empty string", () => {
+      expect(formatSkillSection("")).toBe("");
+    });
+
+    it("returns an empty string when input is whitespace-only", () => {
+      expect(formatSkillSection("  \n\t  ")).toBe("");
+    });
+
+    it("includes the input content when input has real content", () => {
+      const input = "## 2026-01-01 — search task\n\nUse the search box at the top.";
+      const result = formatSkillSection(input);
+      expect(result).toContain(input);
+    });
+
+    it("wraps the content with the opening and closing framing comments", () => {
+      const input = "## 2026-01-01 — example\n\nA hint.";
+      const result = formatSkillSection(input);
+      expect(result.startsWith("<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->")).toBe(true);
+      expect(result.endsWith("<!-- END NOTES -->")).toBe(true);
+    });
+
+    it("includes guidance to verify against the live snapshot", () => {
+      const input = "## 2026-01-01 — example\n\nA hint.";
+      const result = formatSkillSection(input);
+      expect(result).toContain("verify");
+      expect(result).toContain("live snapshot");
+    });
+
+    it("trims leading and trailing whitespace from the input", () => {
+      const input = "\n\n   ## 2026-01-01 — example\n\nA hint.   \n\n";
+      const result = formatSkillSection(input);
+      // Trimmed input should appear without the leading/trailing whitespace.
+      expect(result).toContain("## 2026-01-01 — example\n\nA hint.");
+      // And the raw padded version should NOT appear.
+      expect(result).not.toContain("\n\n   ## 2026-01-01");
+      expect(result).not.toContain("A hint.   \n\n");
+    });
+  });
+});

--- a/packages/core/test/skills/integration.test.ts
+++ b/packages/core/test/skills/integration.test.ts
@@ -1,0 +1,379 @@
+/**
+ * Skill cache end-to-end integration test.
+ *
+ * Unlike webAgent.test.ts (which mocks SkillStore and extractSkill at module
+ * level), this file exercises the real skill-cache code paths:
+ *   - real SkillStore reads/writes against a real temp directory
+ *   - real injector formatting
+ *   - real extractor (with its real prompt building) calling a mocked LLM
+ *
+ * Only the outermost seams are mocked: the AI SDK (streamText) and our
+ * provider-agnostic retry helper (generateTextWithRetry), plus SearchService
+ * to keep the search provider out of the picture.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { streamText, type LanguageModel } from "ai";
+import { WebAgent, type WebAgentOptions } from "../../src/webAgent.js";
+import { AriaBrowser, PageAction } from "../../src/browser/ariaBrowser.js";
+import { WebAgentEventEmitter } from "../../src/events.js";
+import { generateTextWithRetry } from "../../src/utils/retry.js";
+import { SkillStore } from "../../src/skills/store.js";
+
+vi.mock("ai", () => ({
+  streamText: vi.fn(),
+  tool: vi.fn((schema: any) => ({
+    description: schema.description,
+    parameters: schema.parameters,
+  })),
+}));
+
+vi.mock("../../src/utils/retry.js", () => ({
+  generateTextWithRetry: vi.fn(),
+}));
+
+// Defensive mock: with default `search_provider: "none"` SearchService.create
+// is never called by these tests, but keep it stubbed in case the default
+// changes so the search provider stays out of the picture.
+vi.mock("../../src/search/searchService.js", () => ({
+  SearchService: {
+    create: vi.fn().mockResolvedValue({
+      search: vi.fn().mockResolvedValue("# Mock Results"),
+    }),
+  },
+}));
+
+const mockStreamText = vi.mocked(streamText);
+const mockGenerateTextWithRetry = vi.mocked(generateTextWithRetry);
+
+// Minimal mock browser that returns example.com as its URL so resolveHost()
+// produces a stable host filename across runs.
+class MockBrowser implements AriaBrowser {
+  browserName = "mock-browser";
+  private url = "https://example.com/";
+  private title = "Example";
+  private pageSnapshot = "<div><button [ref=btn1]>Click me</button></div>";
+  private markdown = "# Example";
+
+  async start(): Promise<void> {}
+  async shutdown(): Promise<void> {}
+
+  async goto(newUrl: string): Promise<void> {
+    this.url = newUrl;
+    this.title = `Page at ${newUrl}`;
+  }
+
+  async goBack(): Promise<void> {}
+  async goForward(): Promise<void> {}
+
+  async getUrl(): Promise<string> {
+    return this.url;
+  }
+
+  async getTitle(): Promise<string> {
+    return this.title;
+  }
+
+  async getTreeWithRefs(): Promise<string> {
+    return this.pageSnapshot;
+  }
+
+  async getMarkdown(): Promise<string> {
+    return this.markdown;
+  }
+
+  async getScreenshot(): Promise<Buffer> {
+    return Buffer.from("mock-screenshot");
+  }
+
+  async performAction(_ref: string, _action: PageAction, _value?: string): Promise<void> {}
+
+  async waitForLoadState(): Promise<void> {}
+
+  async runInTemporaryTab<T>(fn: (tab: any) => Promise<T>): Promise<T> {
+    const mockTab = {
+      goto: async () => {},
+      waitForLoadState: async () => {},
+      getMarkdown: async () => "# Mock",
+    };
+    return fn(mockTab);
+  }
+}
+
+// Mimics the AI SDK's streamText response shape just enough for WebAgent.
+function createMockStreamResponse(response: any): any {
+  const fullStream = {
+    async *[Symbol.asyncIterator]() {
+      yield { type: "start" };
+      yield { type: "start-step" };
+      if (response.toolResults) {
+        for (const r of response.toolResults) {
+          yield { type: "tool-call", toolName: r.toolName };
+          yield { type: "tool-result", toolName: r.toolName };
+        }
+      }
+      yield { type: "finish-step" };
+      yield { type: "finish" };
+    },
+  };
+  const emptyAsyncIterator = { [Symbol.asyncIterator]: async function* () {} };
+  return {
+    fullStream,
+    text: Promise.resolve(response.text || ""),
+    reasoning: Promise.resolve(response.reasoning || []),
+    toolResults: Promise.resolve(response.toolResults || []),
+    response: Promise.resolve(response.response || { messages: [] }),
+    finishReason: Promise.resolve(response.finishReason || "stop"),
+    usage: Promise.resolve(response.usage || {}),
+    warnings: Promise.resolve(response.warnings || []),
+    providerMetadata: Promise.resolve(response.providerMetadata || {}),
+    content: Promise.resolve([]),
+    reasoningText: Promise.resolve(""),
+    files: Promise.resolve([]),
+    sources: Promise.resolve([]),
+    toolCalls: Promise.resolve([]),
+    request: Promise.resolve({}),
+    totalUsage: Promise.resolve({}),
+    steps: Promise.resolve([]),
+    experimental_output: Promise.resolve(undefined),
+    contentStream: emptyAsyncIterator,
+    textStream: emptyAsyncIterator,
+    reasoningStream: emptyAsyncIterator,
+    fileStream: emptyAsyncIterator,
+    sourceStream: emptyAsyncIterator,
+    toDataStreamResponse: () => new Response(),
+    toUIMessageStreamResponse: () => new Response(),
+    toTextStreamResponse: () => new Response(),
+    pipeDataStreamToResponse: () => {},
+    pipeUIMessageStreamToResponse: () => {},
+    pipeTextStreamToResponse: () => {},
+  };
+}
+
+function planningResponse(): any {
+  return {
+    text: "Planning",
+    toolResults: [
+      {
+        type: "tool-result",
+        toolCallId: "plan_1",
+        toolName: "create_plan",
+        input: { successCriteria: "Done", plan: "1. Done" },
+        output: { successCriteria: "Done", plan: "1. Done" },
+      },
+    ],
+  };
+}
+
+function doneStreamResponse(): any {
+  return createMockStreamResponse({
+    text: "Done",
+    toolResults: [
+      {
+        type: "tool-result",
+        toolCallId: "done_1",
+        toolName: "done",
+        input: { result: "ok" },
+        output: { action: "done", result: "ok", isTerminal: true },
+      },
+    ],
+    response: {
+      messages: [
+        { role: "assistant", content: "Done" },
+        {
+          role: "tool",
+          content: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              output: { action: "done", result: "ok" },
+            },
+          ],
+        },
+      ],
+    },
+  });
+}
+
+function validationResponse(
+  quality: "failed" | "partial" | "complete" | "excellent" = "excellent",
+): any {
+  return {
+    text: "Validation",
+    toolResults: [
+      {
+        type: "tool-result",
+        toolCallId: "validate_1",
+        toolName: "validate_task",
+        input: {
+          taskAssessment: "Task completed successfully",
+          completionQuality: quality,
+        },
+        output: {
+          taskAssessment: "Task completed successfully",
+          completionQuality: quality,
+        },
+      },
+    ],
+  };
+}
+
+/** Wire one full successful agent cycle: planning -> done -> validation -> extraction. */
+function wireRunWithExtraction(extractionText: string, quality: "excellent" = "excellent"): void {
+  mockGenerateTextWithRetry.mockResolvedValueOnce(planningResponse());
+  mockStreamText.mockReturnValueOnce(doneStreamResponse());
+  mockGenerateTextWithRetry.mockResolvedValueOnce(validationResponse(quality));
+  // The extractor calls generateTextWithRetry with prompt + reads response.text.
+  mockGenerateTextWithRetry.mockResolvedValueOnce({ text: extractionText } as any);
+}
+
+function buildAgent(cacheDir: string | undefined, opts: Partial<WebAgentOptions> = {}): WebAgent {
+  const browser = new MockBrowser();
+  const mockProvider = { specificationVersion: "v1" } as unknown as LanguageModel;
+  // Construct a real SkillStore against the temp cacheDir when one is
+  // provided. Passing `cacheDir: undefined` mirrors the production "feature
+  // off" path: no skillStore option, so all reads/writes are inert.
+  const options: WebAgentOptions = {
+    providerConfig: { model: mockProvider },
+    eventEmitter: new WebAgentEventEmitter(),
+    debug: false,
+    vision: false,
+    maxIterations: 10,
+    maxConsecutiveErrors: 5,
+    maxTotalErrors: 15,
+    guardrails: null,
+    ...(cacheDir !== undefined ? { skillStore: new SkillStore({ cacheDir }) } : {}),
+    ...opts,
+  };
+  return new WebAgent(browser, options);
+}
+
+describe("skill cache end-to-end", () => {
+  let cacheDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Reset queued `mockResolvedValueOnce` / `mockReturnValueOnce` implementations
+    // so unused mocks from a previous test don't leak into the next one.
+    mockGenerateTextWithRetry.mockReset();
+    mockStreamText.mockReset();
+    cacheDir = mkdtempSync(join(tmpdir(), "pilo-skills-integration-"));
+  });
+
+  afterEach(() => {
+    rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  it("first run on a host writes a skill; second run reads it back into the prompt", async () => {
+    // --- Run 1: empty cache -> task succeeds at "excellent" -> extractor writes a hint ---
+    const RUN1_HINT =
+      "On example.com, the buy button is in the top-right corner of every product page.";
+    wireRunWithExtraction(RUN1_HINT);
+
+    const agent1 = buildAgent(cacheDir);
+    try {
+      const result1 = await agent1.execute("first task", {
+        startingUrl: "https://example.com",
+      });
+      expect(result1.success).toBe(true);
+    } finally {
+      await agent1.close();
+    }
+
+    // The host file should now exist with the extractor's hint baked in.
+    const hostFile = join(cacheDir, "example.com.md");
+    expect(existsSync(hostFile)).toBe(true);
+    const stored = readFileSync(hostFile, "utf-8");
+    expect(stored).toContain(RUN1_HINT);
+    expect(stored).toContain("first task");
+
+    // --- Run 2: cache populated -> retrieval injects the run-1 hint into the system prompt ---
+    vi.clearAllMocks();
+    wireRunWithExtraction("Second-run hint that doesn't matter for this assertion.");
+
+    const agent2 = buildAgent(cacheDir);
+    try {
+      const result2 = await agent2.execute("second task", {
+        startingUrl: "https://example.com",
+      });
+      expect(result2.success).toBe(true);
+    } finally {
+      await agent2.close();
+    }
+
+    // The action-loop streamText call's system prompt should carry the run-1 hint.
+    const actionCall = mockStreamText.mock.calls[0]?.[0];
+    expect(actionCall).toBeDefined();
+    const systemPrompt = String(actionCall!.system);
+    expect(systemPrompt).toContain("<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->");
+    expect(systemPrompt).toContain("<!-- END NOTES -->");
+    expect(systemPrompt).toContain(RUN1_HINT);
+  });
+
+  it("disabled cache neither writes nor reads", async () => {
+    // Wire a successful "excellent" run — the path that would normally trigger
+    // extraction. The only thing preventing a host file write here is the
+    // absence of a `skillStore` on WebAgentOptions. If extraction ran anyway,
+    // the host file would appear; if it doesn't, that proves the missing
+    // store is the gate.
+    wireRunWithExtraction("Hint that should never be written because skills are disabled.");
+
+    // No cacheDir / no skillStore means the agent should never touch disk.
+    const agent = buildAgent(undefined);
+    try {
+      const result = await agent.execute("task", { startingUrl: "https://example.com" });
+      expect(result.success).toBe(true);
+    } finally {
+      await agent.close();
+    }
+
+    // Cache dir should be untouched. Quality was "excellent", so the ONLY
+    // reason no file exists is that no `skillStore` was passed and the
+    // extractor was therefore never called.
+    expect(existsSync(join(cacheDir, "example.com.md"))).toBe(false);
+
+    // Stronger: confirm the extractor was never invoked. The extractor would
+    // be a 3rd generateTextWithRetry call (after planning + validation). If
+    // the disable path leaked, we'd see 3 calls and the queued extraction
+    // mock would have been consumed.
+    expect(mockGenerateTextWithRetry).toHaveBeenCalledTimes(2);
+
+    // The system prompt should not contain the skills framing block, proving
+    // retrieval also no-ops when skills are disabled.
+    const actionCall = mockStreamText.mock.calls[0]?.[0];
+    expect(actionCall).toBeDefined();
+    const systemPrompt = String(actionCall!.system);
+    expect(systemPrompt).not.toContain("<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->");
+    expect(systemPrompt).not.toContain("<!-- END NOTES -->");
+  });
+
+  it("survives a corrupted host file without failing the task", async () => {
+    // Pre-populate the host file with malformed content (no section headers).
+    writeFileSync(
+      join(cacheDir, "example.com.md"),
+      "this is not well-formed skill markdown\njust some junk\n",
+      "utf-8",
+    );
+
+    const NEW_HINT = "Fresh extraction text written on top of the corrupted file.";
+    wireRunWithExtraction(NEW_HINT);
+
+    const agent = buildAgent(cacheDir);
+    try {
+      const result = await agent.execute("task on corrupted cache", {
+        startingUrl: "https://example.com",
+      });
+      // Task must still succeed — the corrupted file should not poison the agent.
+      expect(result.success).toBe(true);
+    } finally {
+      await agent.close();
+    }
+
+    // The new hint should be appended to whatever was there.
+    const after = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+    expect(after).toContain(NEW_HINT);
+  });
+});

--- a/packages/core/test/skills/paths.test.ts
+++ b/packages/core/test/skills/paths.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "path";
+import { homedir } from "os";
+import { getDefaultSkillsCacheDir } from "../../src/skills/paths.js";
+
+/**
+ * Tests for getDefaultSkillsCacheDir. process.platform is non-writable on
+ * some Node builds, so we use Object.defineProperty with configurable:true
+ * to temporarily override it. Env vars are mutated directly and restored
+ * in afterEach (vi.stubEnv is unavailable for delete semantics, so manual).
+ */
+describe("skills/paths", () => {
+  describe("getDefaultSkillsCacheDir", () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, "platform");
+    const originalXdg = process.env.XDG_CACHE_HOME;
+    const originalLocalAppData = process.env.LOCALAPPDATA;
+
+    function setPlatform(platform: NodeJS.Platform): void {
+      Object.defineProperty(process, "platform", {
+        value: platform,
+        configurable: true,
+        writable: true,
+      });
+    }
+
+    beforeEach(() => {
+      delete process.env.XDG_CACHE_HOME;
+      delete process.env.LOCALAPPDATA;
+    });
+
+    afterEach(() => {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, "platform", originalPlatformDescriptor);
+      }
+      if (originalXdg === undefined) {
+        delete process.env.XDG_CACHE_HOME;
+      } else {
+        process.env.XDG_CACHE_HOME = originalXdg;
+      }
+      if (originalLocalAppData === undefined) {
+        delete process.env.LOCALAPPDATA;
+      } else {
+        process.env.LOCALAPPDATA = originalLocalAppData;
+      }
+    });
+
+    it("uses XDG_CACHE_HOME on Linux when set", () => {
+      setPlatform("linux");
+      process.env.XDG_CACHE_HOME = "/tmp/test-xdg";
+      expect(getDefaultSkillsCacheDir()).toBe("/tmp/test-xdg/pilo/skills");
+    });
+
+    it("uses XDG_CACHE_HOME on macOS when set", () => {
+      setPlatform("darwin");
+      process.env.XDG_CACHE_HOME = "/tmp/test-xdg-mac";
+      expect(getDefaultSkillsCacheDir()).toBe("/tmp/test-xdg-mac/pilo/skills");
+    });
+
+    it("falls back to ~/.cache/pilo/skills on Linux when XDG_CACHE_HOME is unset", () => {
+      setPlatform("linux");
+      expect(getDefaultSkillsCacheDir()).toBe(join(homedir(), ".cache", "pilo", "skills"));
+    });
+
+    it("falls back to ~/.cache/pilo/skills on macOS when XDG_CACHE_HOME is unset", () => {
+      setPlatform("darwin");
+      expect(getDefaultSkillsCacheDir()).toBe(join(homedir(), ".cache", "pilo", "skills"));
+    });
+
+    it("uses LOCALAPPDATA on Windows when set", () => {
+      setPlatform("win32");
+      process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local";
+      expect(getDefaultSkillsCacheDir()).toBe(
+        join("C:\\Users\\Test\\AppData\\Local", "pilo", "skills"),
+      );
+    });
+
+    it("falls back to ~/AppData/Local/pilo/skills on Windows when LOCALAPPDATA is unset", () => {
+      setPlatform("win32");
+      expect(getDefaultSkillsCacheDir()).toBe(
+        join(homedir(), "AppData", "Local", "pilo", "skills"),
+      );
+    });
+
+    it("ignores XDG_CACHE_HOME on Windows", () => {
+      setPlatform("win32");
+      process.env.XDG_CACHE_HOME = "/tmp/should-be-ignored";
+      process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local";
+      const result = getDefaultSkillsCacheDir();
+      expect(result).toBe(join("C:\\Users\\Test\\AppData\\Local", "pilo", "skills"));
+      expect(result).not.toContain("should-be-ignored");
+    });
+
+    it("ignores LOCALAPPDATA on non-Windows platforms", () => {
+      setPlatform("linux");
+      process.env.LOCALAPPDATA = "C:\\Users\\Test\\AppData\\Local";
+      const result = getDefaultSkillsCacheDir();
+      expect(result).toBe(join(homedir(), ".cache", "pilo", "skills"));
+      expect(result).not.toContain("AppData");
+    });
+  });
+});

--- a/packages/core/test/skills/store.test.ts
+++ b/packages/core/test/skills/store.test.ts
@@ -1,0 +1,341 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { SkillStore, type SkillEntry } from "../../src/skills/store.js";
+
+describe("skills/store", () => {
+  let tempDir: string;
+  let cacheDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pilo-skills-test-"));
+    cacheDir = join(tempDir, "skills");
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function makeStore(maxHostTokens?: number): SkillStore {
+    return new SkillStore({ cacheDir, maxHostTokens });
+  }
+
+  function entry(overrides: Partial<SkillEntry> = {}): SkillEntry {
+    return {
+      date: "2026-05-19",
+      taskHeadline: "Buy a widget",
+      hint: "Click the Buy Now button on the product page.",
+      ...overrides,
+    };
+  }
+
+  describe("read", () => {
+    it("returns null when the host file does not exist", async () => {
+      const store = makeStore();
+      expect(await store.read("example.com")).toBe(null);
+    });
+
+    it("returns the file contents when the host file exists", async () => {
+      const store = makeStore();
+      await store.append("example.com", entry());
+      const result = await store.read("example.com");
+      expect(result).not.toBe(null);
+      expect(result).toContain("Buy a widget");
+      expect(result).toContain("Click the Buy Now button");
+    });
+
+    it("returns null when the cache dir does not exist", async () => {
+      const store = makeStore();
+      expect(existsSync(cacheDir)).toBe(false);
+      expect(await store.read("example.com")).toBe(null);
+    });
+  });
+
+  describe("append", () => {
+    it("creates the cache dir lazily on first write", async () => {
+      const store = makeStore();
+      expect(existsSync(cacheDir)).toBe(false);
+      await store.append("example.com", entry());
+      expect(existsSync(cacheDir)).toBe(true);
+    });
+
+    it("creates a file with the correct entry format when none exists", async () => {
+      const store = makeStore();
+      await store.append("example.com", entry());
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      expect(content).toBe(
+        "## 2026-05-19 — Buy a widget\n\nClick the Buy Now button on the product page.",
+      );
+    });
+
+    it("appends a new section separated by a blank line", async () => {
+      const store = makeStore();
+      await store.append(
+        "example.com",
+        entry({ date: "2026-05-18", taskHeadline: "First task", hint: "First hint." }),
+      );
+      await store.append(
+        "example.com",
+        entry({ date: "2026-05-19", taskHeadline: "Second task", hint: "Second hint." }),
+      );
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      expect(content).toBe(
+        "## 2026-05-18 — First task\n\nFirst hint.\n\n## 2026-05-19 — Second task\n\nSecond hint.",
+      );
+    });
+
+    it("trims leading/trailing whitespace from hint body", async () => {
+      const store = makeStore();
+      await store.append("example.com", entry({ hint: "  \n  Body with whitespace  \n\n" }));
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      expect(content).toBe("## 2026-05-19 — Buy a widget\n\nBody with whitespace");
+    });
+
+    it("enforces the token budget by trimming oldest sections", async () => {
+      // 50 tokens * 4 chars = 200 char budget.
+      const store = makeStore(50);
+      // Each section is roughly 50 chars.
+      for (let i = 0; i < 10; i++) {
+        await store.append(
+          "example.com",
+          entry({
+            date: `2026-05-${String(i + 1).padStart(2, "0")}`,
+            taskHeadline: `Task ${i}`,
+            hint: `Hint body number ${i} with some filler content.`,
+          }),
+        );
+      }
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      // File should be at or under 200 chars (best-effort — see note in store).
+      expect(content.length).toBeLessThanOrEqual(200);
+      // The most recent section must be present.
+      expect(content).toContain("Task 9");
+      // The oldest section should have been dropped.
+      expect(content).not.toContain("Task 0");
+    });
+
+    it("never trims the just-written newest entry, even if it alone exceeds the budget", async () => {
+      // 10 tokens * 4 chars = 40 char budget. A single entry will exceed this.
+      const store = makeStore(10);
+      const bigEntry = entry({
+        taskHeadline: "Big task with a long headline that exceeds budget alone",
+        hint: "This hint body is intentionally longer than the 40 char budget so we can verify retention.",
+      });
+      await store.append("example.com", bigEntry);
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      // The single newest entry must be retained in full.
+      expect(content).toContain("Big task with a long headline");
+      expect(content).toContain("intentionally longer than the 40 char budget");
+    });
+
+    it("uses the default token budget when none is provided", async () => {
+      const store = makeStore();
+      // Add a small entry; should fit comfortably in the default 4000-token budget.
+      await store.append("example.com", entry());
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      expect(content.length).toBeLessThan(4000 * 4);
+      expect(content).toContain("Buy a widget");
+    });
+  });
+
+  describe("clear", () => {
+    it("removes only the specified host's file when host is given", async () => {
+      const store = makeStore();
+      await store.append("a.example.com", entry({ taskHeadline: "Task A" }));
+      await store.append("b.example.com", entry({ taskHeadline: "Task B" }));
+
+      await store.clear("a.example.com");
+
+      expect(existsSync(join(cacheDir, "a.example.com.md"))).toBe(false);
+      expect(existsSync(join(cacheDir, "b.example.com.md"))).toBe(true);
+    });
+
+    it("removes all *.md files when no host arg is given", async () => {
+      const store = makeStore();
+      await store.append("a.example.com", entry({ taskHeadline: "Task A" }));
+      await store.append("b.example.com", entry({ taskHeadline: "Task B" }));
+
+      await store.clear();
+
+      expect(existsSync(join(cacheDir, "a.example.com.md"))).toBe(false);
+      expect(existsSync(join(cacheDir, "b.example.com.md"))).toBe(false);
+    });
+
+    it("leaves non-md files alone when clearing without a host arg", async () => {
+      const store = makeStore();
+      await store.append("a.example.com", entry());
+      // Drop a non-md file in the cache dir.
+      const nonMd = join(cacheDir, "keep-me.txt");
+      writeFileSync(nonMd, "not a skill file");
+
+      await store.clear();
+
+      expect(existsSync(join(cacheDir, "a.example.com.md"))).toBe(false);
+      expect(existsSync(nonMd)).toBe(true);
+    });
+
+    it("is a no-op when the cache dir does not exist", async () => {
+      const store = makeStore();
+      expect(existsSync(cacheDir)).toBe(false);
+      // Should not throw.
+      await expect(store.clear()).resolves.toBeUndefined();
+      await expect(store.clear("anything.example.com")).resolves.toBeUndefined();
+    });
+
+    it("is a no-op when clearing a host whose file does not exist", async () => {
+      const store = makeStore();
+      await store.append("a.example.com", entry());
+      // Should not throw.
+      await expect(store.clear("nonexistent.example.com")).resolves.toBeUndefined();
+      // The existing file should still be present.
+      expect(existsSync(join(cacheDir, "a.example.com.md"))).toBe(true);
+    });
+  });
+
+  describe("filename escaping", () => {
+    it("URL-encodes ':' (port separator) in host filenames", async () => {
+      const store = makeStore();
+      await store.append("localhost:3000", entry({ taskHeadline: "Local task" }));
+      // encodeURIComponent turns ":" into "%3A".
+      expect(existsSync(join(cacheDir, "localhost%3A3000.md"))).toBe(true);
+      expect(existsSync(join(cacheDir, "localhost:3000.md"))).toBe(false);
+    });
+
+    it("reads back content written under an escaped host name", async () => {
+      const store = makeStore();
+      await store.append("localhost:3000", entry({ taskHeadline: "Local task" }));
+      const content = await store.read("localhost:3000");
+      expect(content).toContain("Local task");
+    });
+
+    it("clear(host) uses the same escaping rule", async () => {
+      const store = makeStore();
+      await store.append("localhost:3000", entry());
+      await store.clear("localhost:3000");
+      expect(existsSync(join(cacheDir, "localhost%3A3000.md"))).toBe(false);
+    });
+
+    it("accepts hostnames containing underscores", async () => {
+      // Some dev/staging hosts and CDNs return underscored hostnames; these
+      // are valid WHATWG host shapes and must round-trip cleanly.
+      const store = makeStore();
+      await expect(
+        store.append("my_dev.example.com", entry({ taskHeadline: "Underscored host" })),
+      ).resolves.toBeUndefined();
+      const content = await store.read("my_dev.example.com");
+      expect(content).toContain("Underscored host");
+    });
+
+    it("accepts IPv6 literals with port and round-trips them", async () => {
+      const store = makeStore();
+      await expect(
+        store.append("[::1]:3000", entry({ taskHeadline: "IPv6 host" })),
+      ).resolves.toBeUndefined();
+      // Filename must be deterministic for the same input host.
+      const files = readdirSync(cacheDir).filter((f) => f.endsWith(".md"));
+      expect(files.length).toBe(1);
+      // A second append to the same host must land in the same file.
+      await store.append("[::1]:3000", entry({ taskHeadline: "Second IPv6 task" }));
+      const filesAfter = readdirSync(cacheDir).filter((f) => f.endsWith(".md"));
+      expect(filesAfter.length).toBe(1);
+      const content = await store.read("[::1]:3000");
+      expect(content).toContain("IPv6 host");
+      expect(content).toContain("Second IPv6 task");
+    });
+  });
+
+  describe("atomic write", () => {
+    it("survives concurrent appends with well-formed output (last-writer-wins, intermediate entries may be lost)", async () => {
+      const store = makeStore();
+      // Fire several appends in parallel. append() is not concurrency-safe:
+      // each call does a read-modify-write, so two appends in flight will both
+      // read the pre-append content and one will overwrite the other (TOCTOU).
+      // The atomic-rename strategy guarantees the on-disk file is always
+      // well-formed markdown — never half-written — but we cannot assert that
+      // all entries survive. See the JSDoc warning on SkillStore.append().
+      const appends = Array.from({ length: 5 }, (_, i) =>
+        store.append(
+          "example.com",
+          entry({
+            date: `2026-05-${String(i + 10).padStart(2, "0")}`,
+            taskHeadline: `Task ${i}`,
+            hint: `Hint ${i}`,
+          }),
+        ),
+      );
+      await Promise.all(appends);
+
+      const content = readFileSync(join(cacheDir, "example.com.md"), "utf-8");
+      // Each section must start with "## " and be well-formed.
+      const sections = content.split(/\n(?=## )/);
+      expect(sections.length).toBeGreaterThan(0);
+      for (const section of sections) {
+        expect(section.startsWith("## ")).toBe(true);
+      }
+      // At least one of the writers must have landed (the last successful one).
+      // We don't assert which — concurrent reordering is allowed.
+      const taskMatches = content.match(/Task \d/g) ?? [];
+      expect(taskMatches.length).toBeGreaterThanOrEqual(1);
+      // No leftover tmp files in the cache dir.
+      const files = readdirSync(cacheDir);
+      const tmpFiles = files.filter((f) => f.includes(".tmp."));
+      expect(tmpFiles).toEqual([]);
+    });
+  });
+
+  describe("path traversal hardening", () => {
+    // Hosts that must be rejected at the validator. Note: embedded whitespace
+    // is accepted by the validator (it's not a traversal vector) and gets
+    // URL-encoded into the filename; only chars that could escape the cache
+    // directory or smuggle a filename across newlines are rejected.
+    const invalidHosts: Array<[string, string]> = [
+      ["../etc/passwd", "parent directory traversal"],
+      ["foo/bar", "embedded slash"],
+      ["foo\\bar", "embedded backslash"],
+      ["", "empty string"],
+      ["example.com\0evil", "embedded null byte"],
+      ["example.com\nevil", "embedded newline"],
+      ["example.com\revil", "embedded carriage return"],
+      ["..", "lone parent directory"],
+      ["a..b", "double-dot anywhere in the host"],
+    ];
+
+    for (const [host, description] of invalidHosts) {
+      it(`read() rejects ${description}: ${JSON.stringify(host)}`, async () => {
+        const store = makeStore();
+        await expect(store.read(host)).rejects.toThrow(/Invalid host/);
+      });
+
+      it(`append() rejects ${description}: ${JSON.stringify(host)}`, async () => {
+        const store = makeStore();
+        await expect(store.append(host, entry())).rejects.toThrow(/Invalid host/);
+      });
+
+      it(`clear(host) rejects ${description}: ${JSON.stringify(host)}`, async () => {
+        const store = makeStore();
+        await expect(store.clear(host)).rejects.toThrow(/Invalid host/);
+      });
+    }
+
+    it("accepts a plain hostname", async () => {
+      const store = makeStore();
+      await expect(store.read("example.com")).resolves.toBe(null);
+    });
+
+    it("accepts a hostname with port", async () => {
+      const store = makeStore();
+      await expect(store.read("localhost:3000")).resolves.toBe(null);
+    });
+
+    it("accepts a hostname with underscores", async () => {
+      const store = makeStore();
+      await expect(store.read("my_dev.example.com")).resolves.toBe(null);
+    });
+
+    it("accepts IPv6 literals with port", async () => {
+      const store = makeStore();
+      await expect(store.read("[::1]:3000")).resolves.toBe(null);
+    });
+  });
+});

--- a/packages/core/test/webAgent.test.ts
+++ b/packages/core/test/webAgent.test.ts
@@ -6,6 +6,11 @@ import { LanguageModel, streamText } from "ai";
 import { Logger } from "../src/loggers/types.js";
 import { generateTextWithRetry } from "../src/utils/retry.js";
 import { PlanningError } from "../src/errors.js";
+// Imported below the vi.mock("../src/skills/store.js") factory — at runtime
+// this resolves to the mocked SkillStore class (the one with read/append/clear
+// bound to the mock fns), not the real one. We instantiate it to hand a
+// `skillStore` option to WebAgent.
+import { SkillStore } from "../src/skills/store.js";
 
 // Mock the AI module
 vi.mock("ai", () => ({
@@ -28,6 +33,34 @@ vi.mock("../src/search/searchService.js", () => ({
       search: vi.fn().mockResolvedValue("# Mock Results"),
     }),
   },
+}));
+
+// Mock SkillStore so tests can inject host content without touching disk
+const mockSkillStoreRead = vi.fn<(host: string) => Promise<string | null>>();
+const mockSkillStoreAppend = vi.fn<(...args: any[]) => Promise<void>>();
+const mockSkillStoreClear = vi.fn<(...args: any[]) => Promise<void>>();
+vi.mock("../src/skills/store.js", () => ({
+  SkillStore: class {
+    read = mockSkillStoreRead;
+    append = mockSkillStoreAppend;
+    clear = mockSkillStoreClear;
+  },
+}));
+
+// Mock the extractor so tests don't hit the LLM. Defaults to a successful
+// extraction so the happy path is "extraction returned something". Tests that
+// need null / throw can override per-call.
+//
+// Use vi.hoisted because the factory references the mock fn directly (as a
+// value), which requires the var to exist when vi.mock is hoisted to the top
+// of the file. The SkillStore mock above gets away without this because its
+// factory only references the mock fns inside a class body that's evaluated
+// lazily on instantiation.
+const { mockExtractSkill } = vi.hoisted(() => ({
+  mockExtractSkill: vi.fn<(...args: any[]) => Promise<any>>(),
+}));
+vi.mock("../src/skills/extractor.js", () => ({
+  extractSkill: mockExtractSkill,
 }));
 
 const mockStreamText = vi.mocked(streamText);
@@ -3866,6 +3899,620 @@ describe("WebAgent", () => {
       expect(result.success).toBe(true);
       expect(result.finalAnswer).toBe("Completed");
       expect(result.stats.actions).toBe(4); // 2 clicks + 1 fill + 1 done
+    });
+  });
+
+  describe("skills injection", () => {
+    const SKILLS_MARKER = "<!-- NOTES FROM PRIOR RUNS ON THIS SITE -->";
+
+    // Run a simple done() task with the supplied agent and return the system
+    // prompt that streamText saw on its first call.
+    async function runTaskAndCaptureSystemPrompt(
+      agent: WebAgent,
+      startingUrl: string,
+    ): Promise<string> {
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Done", plan: "1. Done" },
+            output: { successCriteria: "Done", plan: "1. Done" },
+          },
+        ],
+      } as any);
+
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "ok" },
+              output: { action: "done", result: "ok", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [
+              { role: "assistant", content: "Done" },
+              {
+                role: "tool",
+                content: [
+                  {
+                    type: "tool-result",
+                    toolCallId: "done_1",
+                    toolName: "done",
+                    output: { action: "done", result: "ok" },
+                  },
+                ],
+              },
+            ],
+          },
+        }) as any,
+      );
+
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await agent.execute("test task", { startingUrl });
+      expect(result.success).toBe(true);
+
+      const call = mockStreamText.mock.calls[0]?.[0];
+      expect(call?.system).toBeDefined();
+      return String(call!.system);
+    }
+
+    beforeEach(() => {
+      mockSkillStoreRead.mockReset();
+    });
+
+    it("injects the skills section when the store returns content for the host", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce("## 2026-01-01 — prior run\n\nPrior hint.");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const systemPrompt = await runTaskAndCaptureSystemPrompt(agent, "https://example.com");
+        expect(systemPrompt).toContain(SKILLS_MARKER);
+        expect(systemPrompt).toContain("Prior hint.");
+        expect(mockSkillStoreRead).toHaveBeenCalledWith("example.com");
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT inject when no skillStore is passed (feature inert)", async () => {
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+      });
+
+      try {
+        const systemPrompt = await runTaskAndCaptureSystemPrompt(agent, "https://example.com");
+        expect(systemPrompt).not.toContain(SKILLS_MARKER);
+        expect(mockSkillStoreRead).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT inject when the store returns null", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const systemPrompt = await runTaskAndCaptureSystemPrompt(agent, "https://example.com");
+        expect(systemPrompt).not.toContain(SKILLS_MARKER);
+        expect(mockSkillStoreRead).toHaveBeenCalledWith("example.com");
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT inject when the URL has no resolvable host (about:blank)", async () => {
+      // Use search-first flow: planner returns no URL, the agent stays on about:blank.
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Done", plan: "1. Done" },
+            output: { successCriteria: "Done", plan: "1. Done" },
+          },
+        ],
+      } as any);
+
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "ok" },
+              output: { action: "done", result: "ok", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [{ role: "assistant", content: "Done" }],
+          },
+        }) as any,
+      );
+
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+        searchProvider: "parallel-api",
+        searchApiKey: "fake-test-key",
+      });
+
+      try {
+        // No startingUrl, search provider enabled -> url stays at about:blank.
+        const result = await agent.execute("test task");
+        expect(result.success).toBe(true);
+
+        const call = mockStreamText.mock.calls[0]?.[0];
+        const systemPrompt = String(call!.system);
+        expect(systemPrompt).not.toContain(SKILLS_MARKER);
+        // resolveHost("about:blank") returns null, so read should never be called.
+        expect(mockSkillStoreRead).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("survives SkillStore.read() throwing without failing the task", async () => {
+      mockSkillStoreRead.mockRejectedValueOnce(new Error("disk on fire"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const systemPrompt = await runTaskAndCaptureSystemPrompt(agent, "https://example.com");
+        expect(systemPrompt).not.toContain(SKILLS_MARKER);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("[skills] failed to read host file for example.com"),
+          expect.any(Error),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        await agent.close();
+      }
+    });
+  });
+
+  describe("skill extraction", () => {
+    // Wire up the standard task mocks: plan -> done -> validation. The
+    // validation quality is configurable so tests can drive the extraction
+    // gate (excellent / complete / partial / failed).
+    function wireSuccessfulTask(
+      quality: "failed" | "partial" | "complete" | "excellent" = "excellent",
+    ): void {
+      // Planning
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Done", plan: "1. Done" },
+            output: { successCriteria: "Done", plan: "1. Done" },
+          },
+        ],
+      } as any);
+
+      // done() action
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "ok" },
+              output: { action: "done", result: "ok", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [
+              { role: "assistant", content: "Done" },
+              {
+                role: "tool",
+                content: [
+                  {
+                    type: "tool-result",
+                    toolCallId: "done_1",
+                    toolName: "done",
+                    output: { action: "done", result: "ok" },
+                  },
+                ],
+              },
+            ],
+          },
+        }) as any,
+      );
+
+      // Validation
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse(quality));
+    }
+
+    beforeEach(() => {
+      mockSkillStoreRead.mockReset();
+      mockSkillStoreAppend.mockReset();
+      mockExtractSkill.mockReset();
+      // Default: extractor returns a successful extraction. Individual tests
+      // override per-call when they need null or a throw.
+      mockExtractSkill.mockResolvedValue({
+        hint: "Use the search bar at the top.",
+        taskHeadline: "test task",
+      });
+    });
+
+    it("calls extractSkill and appends on excellent completion", async () => {
+      // No prior skill content for this host.
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+      wireSuccessfulTask("excellent");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+
+        expect(mockExtractSkill).toHaveBeenCalledTimes(1);
+        const extractArgs = mockExtractSkill.mock.calls[0][0];
+        expect(extractArgs.task).toBe("test task");
+        expect(extractArgs.host).toBe("example.com");
+        expect(extractArgs.providerConfig).toEqual({ model: mockProvider });
+        expect(Array.isArray(extractArgs.messages)).toBe(true);
+
+        expect(mockSkillStoreAppend).toHaveBeenCalledWith(
+          "example.com",
+          expect.objectContaining({
+            date: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+            taskHeadline: expect.any(String),
+            hint: expect.any(String),
+          }),
+        );
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT extract when completionQuality is 'complete' (not excellent)", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+      wireSuccessfulTask("complete");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).not.toHaveBeenCalled();
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT extract when force-accepted at the max-attempts cap", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+
+      // Planning
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Done", plan: "1. Done" },
+            output: { successCriteria: "Done", plan: "1. Done" },
+          },
+        ],
+      } as any);
+
+      // done() action
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "ok" },
+              output: { action: "done", result: "ok", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [
+              { role: "assistant", content: "Done" },
+              {
+                role: "tool",
+                content: [
+                  {
+                    type: "tool-result",
+                    toolCallId: "done_1",
+                    toolName: "done",
+                    output: { action: "done", result: "ok" },
+                  },
+                ],
+              },
+            ],
+          },
+        }) as any,
+      );
+
+      // Validation returns "failed" — with maxValidationAttempts = 1, this
+      // hits the cap on the first attempt and the agent force-accepts.
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("failed"));
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+        maxValidationAttempts: 1,
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).not.toHaveBeenCalled();
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT extract when no skillStore is passed (feature inert)", async () => {
+      wireSuccessfulTask("excellent");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).not.toHaveBeenCalled();
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT extract when the task failed", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+
+      // Planning succeeds.
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Done", plan: "1. Done" },
+            output: { successCriteria: "Done", plan: "1. Done" },
+          },
+        ],
+      } as any);
+
+      // Action fails: agent calls abort() and the task terminates with success=false.
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Aborting",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "abort_1",
+              toolName: "abort",
+              input: { reason: "Cannot proceed" },
+              output: { action: "abort", reason: "Cannot proceed", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [{ role: "assistant", content: "Aborting" }],
+          },
+        }) as any,
+      );
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(false);
+        expect(mockExtractSkill).not.toHaveBeenCalled();
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT extract when the ending URL has no resolvable host", async () => {
+      // Plan with a non-http URL so the loaded page has no host. The host
+      // resolver returns null for file://, so extraction must be skipped.
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Plan",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: {
+              successCriteria: "Done",
+              plan: "1. Done",
+              url: "file:///tmp/local.html",
+            },
+            output: {
+              successCriteria: "Done",
+              plan: "1. Done",
+              url: "file:///tmp/local.html",
+            },
+          },
+        ],
+      } as any);
+
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Done",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "ok" },
+              output: { action: "done", result: "ok", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [{ role: "assistant", content: "Done" }],
+          },
+        }) as any,
+      );
+
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("excellent"));
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task");
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).not.toHaveBeenCalled();
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("does NOT append when extractSkill returns null", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+      mockExtractSkill.mockResolvedValueOnce(null);
+      wireSuccessfulTask("excellent");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).toHaveBeenCalledTimes(1);
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+      } finally {
+        await agent.close();
+      }
+    });
+
+    it("swallows extractSkill throws and still completes the task", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+      mockExtractSkill.mockRejectedValueOnce(new Error("LLM down"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      wireSuccessfulTask("excellent");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockSkillStoreAppend).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("[skills] extraction failed for example.com"),
+          expect.any(Error),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        await agent.close();
+      }
+    });
+
+    it("swallows SkillStore.append throws and still completes the task", async () => {
+      mockSkillStoreRead.mockResolvedValueOnce(null);
+      mockSkillStoreAppend.mockRejectedValueOnce(new Error("disk full"));
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      wireSuccessfulTask("excellent");
+
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        eventEmitter,
+        logger: mockLogger,
+        skillStore: new SkillStore({ cacheDir: "/tmp/test-skill-cache" }),
+      });
+
+      try {
+        const result = await agent.execute("test task", { startingUrl: "https://example.com" });
+        expect(result.success).toBe(true);
+        expect(mockExtractSkill).toHaveBeenCalledTimes(1);
+        expect(mockSkillStoreAppend).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining("[skills] extraction failed for example.com"),
+          expect.any(Error),
+        );
+      } finally {
+        warnSpy.mockRestore();
+        await agent.close();
+      }
     });
   });
 });

--- a/packages/extension/src/background/AgentManager.ts
+++ b/packages/extension/src/background/AgentManager.ts
@@ -61,7 +61,12 @@ export class AgentManager {
       modelName,
     );
 
-    // Create WebAgent - same as CLI and server
+    // Create WebAgent - same as CLI and server.
+    //
+    // Skills cache is intentionally not wired here — `SkillStore` requires
+    // Node fs/path/os, which the extension's browser bundle cannot provide.
+    // With no `skillStore` passed, the WebAgent's skills feature stays inert
+    // (no reads, no writes, no extraction LLM calls).
     const agent = new WebAgent(browser, {
       providerConfig: {
         model,

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -47,6 +47,10 @@ vi.mock("pilo-core", () => {
       timeoutMultiplier: overrides?.timeoutMultiplier ?? 2,
     })),
     SEARCH_PROVIDERS: ["none", "duckduckgo", "google", "bing", "parallel-api"],
+    // Skill cache wiring is exercised in core tests; the server only forwards
+    // the resolved store into WebAgent. Returning null here mirrors the
+    // "skills_enabled: false" production default.
+    createSkillStoreFromConfig: vi.fn(() => null),
   };
 });
 

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -10,6 +10,7 @@ import {
   createNavigationRetryConfig,
   RecoverableError,
   SEARCH_PROVIDERS,
+  createSkillStoreFromConfig,
 } from "pilo-core";
 import type { TaskExecutionResult, UserDataCallback } from "pilo-core";
 import { StreamLogger } from "./StreamLogger.js";
@@ -360,12 +361,18 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     openai_compatible_name: body.openaiCompatibleName,
   });
 
+  // Build a skill store from server config (null when skills_enabled is false).
+  // The WebAgent reads / writes through this store; passing null keeps the
+  // skills feature inert.
+  const skillStore = createSkillStoreFromConfig(serverConfig);
+
   const agent = new WebAgent(browser, {
     ...webAgentConfig,
     providerConfig,
     logger,
     onUserDataRequired,
     taskId,
+    skillStore,
   });
 
   try {

--- a/packages/server/test/sensitive-data-leak.test.ts
+++ b/packages/server/test/sensitive-data-leak.test.ts
@@ -56,6 +56,10 @@ vi.mock("pilo-core", () => {
     })),
     SEARCH_PROVIDERS: ["none", "duckduckgo", "google", "bing", "parallel-api"],
     withRemoteContext: vi.fn((_headers: unknown, fn: () => unknown) => fn()),
+    // Skill cache wiring is exercised in core tests; the server only forwards
+    // the resolved store into WebAgent. Returning null here mirrors the
+    // "skills_enabled: false" production default.
+    createSkillStoreFromConfig: vi.fn(() => null),
   };
 });
 


### PR DESCRIPTION
## Summary

Adds an opt-in local skill cache. After a task completes with `excellent` validation quality, an LLM helper summarizes the trajectory into a short natural-language note about the site, appended to a host-keyed markdown file in the user's cache dir. On future tasks against the same host, the file is injected into the system prompt as advisory notes.

Inspired by browser-use's "[skills](https://browser-use.com/posts/web-agents-that-actually-learn)" post, scoped down to a single-user local feature. v1 is opt-in (`skills_enabled = false` by default) and deliberately small — no embeddings, no ranking, no cross-host sharing, no multi-user submissions.

## Design Decisions

- **Natural-language hints only.** Wrong selectors injected with apparent authority are worse than no hint; NL filters through the model's reasoning and the live snapshot, so the model can adapt or ignore.
- **Host-only key.** Simple, robust, no normalization rules. Files at `~/.cache/pilo/skills/<host>.md` (XDG-compliant; `%LOCALAPPDATA%/pilo/skills/` on Windows).
- **Excellent-only extraction.** The validator already grades quality. Force-accepted runs do not produce skills.
- **Append-only markdown.** Human-readable, grep-able, no schema lock-in. Token-budget trim drops oldest sections.
- **No retrieval ranking.** Inject the whole file. The model judges relevance implicitly.
- **Synchronous extraction.** Blocks `execute()` returning. Predictable error semantics, deterministic tests.
- **Silent failures.** Disk / LLM errors warn and skip — never fail a task.
- **Injection pattern.** `WebAgent` receives a `skillStore?` option rather than constructing one. CLI and server build the store from config and inject it; the extension intentionally does not (browser context, no `fs`).

## Changes

**`packages/core` (the bulk of the change):**
- New `src/skills/` subsystem: `host.ts`, `paths.ts`, `store.ts`, `injector.ts`, `extractor.ts`, `extractionPrompt.ts`, `factory.ts`.
- Three new config fields: `skills_enabled`, `skills_cache_dir`, `skills_max_host_tokens` — opt-in via `pilo config set`.
- New `createSkillStoreFromConfig(config)` helper exported from the Node-only public API.
- `WebAgent` gains a `skillStore?: SkillStore | null` option. Retrieval lives in `initializeSystemPromptAndTask` (host file → system prompt slot via a new `hasSkills` / `skillsBlock` LiquidJS conditional). Extraction lives in a new private `extractAndStoreSkill` called after `runMainLoop` returns on success.
- `validateTaskCompletion` return shape extended to surface `completionQuality` (now typed as a literal union) and `forceAccept`.

**`packages/cli`, `packages/server`:** wire `createSkillStoreFromConfig(cfg)` into their `new WebAgent(...)` calls.

**`packages/extension`:** intentionally not wired — added an inline comment explaining why the browser bundle can't host the cache.

## Security

- Path traversal hardening at `SkillStore.pathFor` (rejects `/`, `\`, `..`, `\0`, `\n`; filename via `encodeURIComponent` so underscored hosts and IPv6 literals work).
- Atomic write via `randomUUID()` tmp file + rename.
- Trajectory wrapped via `wrapExternalContentWithWarning` before being sent to the extraction LLM (web-derived content treated as untrusted).
- No PII scrubbing pass in v1 — single-user local scope. Would need to be added before any multi-user variant.

## Test Plan

- [x] `pnpm run check` — full root validation
- [x] core 810, cli 221, server 96, extension 266 — all green
- [x] Extension chrome build emits no `externalized for browser compatibility` warnings for the new skills modules
- [x] `gitleaks detect --log-opts="origin/main..HEAD"` — no leaks
- [ ] Manual smoke: `pnpm pilo config set skills_enabled true && pnpm pilo run "..."` against a real site, verify a `~/.cache/pilo/skills/<host>.md` file appears, then a follow-up run on the same host shows the prior notes in the system prompt

## Usage

```bash
pnpm pilo config set skills_enabled true
pnpm pilo run "..."   # writes ~/.cache/pilo/skills/<host>.md on excellent runs
pnpm pilo run "..."   # subsequent runs on same host get the prior notes injected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)