### PR TITLE
feat(core): pre-done verification checklist and data grounding rule

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -333,7 +333,8 @@ Analyze the current page state and determine your next action based on previous 
 4. done() provides your final answer to the user
 5. goto() only accepts URLs from earlier in conversation
 6. Use wait() for page loads, animations, or dynamic content
-{% if hasGuardrails %}7. ALL actions MUST comply with provided guardrails{% endif %}
+7. DATA GROUNDING: Every value in your done() result and your reasoning must come from the page snapshot, a tool result, or the task input. Do not use training knowledge to fill gaps. If you cannot verify a value from the current session, say so explicitly.
+{% if hasGuardrails %}8. ALL actions MUST comply with provided guardrails{% endif %}
 
 **CRITICAL:** You MUST use exactly ONE tool with valid arguments EVERY turn. Choose:
 - done(result) if task is complete
@@ -363,6 +364,19 @@ Analyze the current page state and determine your next action based on previous 
   - tabstack_generate_json: Use when you need AI-transformed content (summaries, categorization, restructured data){% endif %}
 {% if hasStartingUrl and hasWebSearch %}- A starting URL was provided — **focus on that site first**. Use webSearch only if you need supplementary information beyond what the site provides{% endif %}
 {% if hasGuardrails %}- Verify guardrail compliance before each action{% endif %}
+
+**Before calling done():**
+1. Re-read the user's task. List every concrete requirement (counts, filters, format, date ranges, etc.).
+2. Check each requirement against what you observed:
+   - Did you find the correct NUMBER of items requested?
+   - Did all specified filters/criteria apply (price range, date, location, format)?
+   - Does your answer match the requested format?
+3. Verify actions actually completed by checking the most recent page state:
+   - If you submitted a form, did the next page confirm success?
+   - If you extracted data, did you actually find it in the page snapshot or extract() output?
+4. Data grounding: every value in your answer must appear in a page snapshot, a tool result, or the task input. Do NOT use general knowledge to fill gaps. If a value was not found during this session, say so explicitly rather than inventing it.
+5. Blockers vs. obstacles: if you hit an unrecoverable block (paywall, login wall, access denied, payment declined) that prevented completing a core requirement, call abort() with the reason. Temporary obstacles you handled (dismissed popups, retried errors) don't change the outcome.
+6. If anything is unverified, incomplete, or uncertain — call abort() with the reason rather than done() with an overclaiming answer.
 
 **When using done():**
 Provide your final answer:

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -243,6 +243,27 @@ describe("prompts", () => {
     it("should not include webSearch when built without it", () => {
       expect(actionLoopSystemPrompt).not.toContain("webSearch(");
     });
+
+    it("should include DATA GROUNDING rule in Core Rules", () => {
+      expect(actionLoopSystemPrompt).toContain("DATA GROUNDING");
+      expect(actionLoopSystemPrompt).toContain("Do not use training knowledge to fill gaps");
+      // Rule is always present, even without guardrails, so it should be numbered 7.
+      expect(actionLoopSystemPrompt).toContain("7. DATA GROUNDING");
+    });
+
+    it("should include pre-completion verification checklist before done()", () => {
+      expect(actionLoopSystemPrompt).toContain("**Before calling done():**");
+      expect(actionLoopSystemPrompt).toContain("Re-read the user's task");
+      expect(actionLoopSystemPrompt).toContain(
+        "every value in your answer must appear in a page snapshot",
+      );
+      expect(actionLoopSystemPrompt).toContain("call abort()");
+      // Checklist must appear before the existing "When using done():" block.
+      const beforeIdx = actionLoopSystemPrompt.indexOf("**Before calling done():**");
+      const whenIdx = actionLoopSystemPrompt.indexOf("**When using done():**");
+      expect(beforeIdx).toBeGreaterThan(-1);
+      expect(whenIdx).toBeGreaterThan(beforeIdx);
+    });
   });
 
   describe("buildActionLoopSystemPrompt", () => {
@@ -270,6 +291,20 @@ describe("prompts", () => {
 
       expect(prompt).toContain("GUARDRAIL COMPLIANCE");
       expect(prompt).toContain("webSearch(");
+    });
+
+    it("should number guardrails rule as 8 when DATA GROUNDING is present", () => {
+      const prompt = buildActionLoopSystemPrompt(true, false);
+
+      expect(prompt).toContain("7. DATA GROUNDING");
+      expect(prompt).toContain("8. ALL actions MUST comply with provided guardrails");
+    });
+
+    it("should keep DATA GROUNDING and verification checklist when guardrails are enabled", () => {
+      const prompt = buildActionLoopSystemPrompt(true, false);
+
+      expect(prompt).toContain("DATA GROUNDING");
+      expect(prompt).toContain("**Before calling done():**");
     });
   });
 


### PR DESCRIPTION
## Summary

- Add Core Rule 7 (DATA GROUNDING) to `buildActionLoopSystemPrompt`: every value in `done()` must come from a page snapshot, tool result, or task input — no training-knowledge fill-ins.
- Insert a 6-item "Before calling done():" checklist immediately above the existing "When using done():" block, covering requirement re-read, action verification, data grounding, blockers-vs-obstacles, and the abort-when-uncertain rule.
- Always-on guardrails rule shifts from rule 7 to rule 8 when DATA GROUNDING occupies slot 7. Numbering only; behaviour unchanged.

Spec deviation worth flagging: issue #428 proposed DATA GROUNDING as rule 8 (appended after the conditional guardrails rule). It's an always-on rule, so making it rule 7 keeps the always-on numbered block contiguous and avoids `{% if %}{% else %}` numbering gymnastics. Content identical, template cleaner.

Closes #428.

## Test plan

- [x] `pnpm --filter pilo-core run test` (688 tests, +4 new)
- [x] `pnpm run check` (all packages: core 688, cli 221, server 96, extension 266)
- [x] `gitleaks protect -v`
- [ ] Follow-up (separate work, per issue): eval-set measurement of validator-rejection-rate delta; manual smoke test against a "value not on page" target; flash-variant condensed checklist

🤖 Generated with [Claude Code](https://claude.com/claude-code)