### PR TITLE
ci: add smoke-eval job to exercise Pilo agent end-to-end on every PR

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -356,3 +356,108 @@ jobs:
           path: packages/extension/test-results/
           retention-days: 30
           if-no-files-found: ignore
+
+  smoke-eval:
+    name: Smoke eval (Pilo agent on example.com)
+    runs-on: ubuntu-latest
+    needs: [detect-changes, setup]
+    if: needs.detect-changes.outputs.cli == 'true' || needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.workflows == 'true'
+    # id-token: write is required if/when this job is switched to Workload
+    # Identity Federation (see the auth step below).
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache core build
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/core/dist
+            packages/core/src/browser/ariaTree/bundle.ts
+          key: ${{ runner.os }}-core-dist-${{ github.sha }}
+
+      - name: Build CLI
+        run: pnpm --filter pilo-cli run build
+
+      - name: Get Playwright version
+        id: playwright-version
+        run: |
+          set -euo pipefail
+          version=$(jq -re '.dependencies["playwright"] // empty' package.json)
+          if [ -z "$version" ]; then
+            echo "Error: playwright dependency not found in root package.json" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ steps.playwright-version.outputs.version }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      # GCP auth for Vertex AI (Gemini). Default path uses a service-account
+      # JSON secret; once Workload Identity Federation is provisioned for
+      # nonprod Vertex access, swap `credentials_json` for the WIF inputs
+      # shown in the commented block below.
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SMOKE_EVAL_SA_KEY }}
+          # workload_identity_provider: ${{ vars.GCP_SMOKE_EVAL_WIF_PROVIDER }}
+          # service_account: ${{ vars.GCP_SMOKE_EVAL_SERVICE_ACCOUNT }}
+
+      - name: Run smoke eval
+        env:
+          GOOGLE_CLOUD_PROJECT: moz-fx-tabs-nonprod
+          GOOGLE_CLOUD_REGION: us-central1
+          SMOKE_EVAL_PROVIDER: vertex
+          SMOKE_EVAL_MODEL: gemini-2.5-flash
+          SMOKE_EVAL_TIMEOUT_MS: "180000"
+        run: pnpm smoke-eval
+
+      - name: Upload smoke-eval log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-eval-log
+          path: .smoke-eval-output/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ dist
 scripts/docker-build.sh
 debug
 coverage
+.smoke-eval-output
 
 # Auto-generated files
 packages/core/src/browser/ariaTree/bundle.ts

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "test": "pnpm -r run test",
     "check": "pnpm run typecheck && pnpm run test",
     "pilo": "pnpm --filter pilo-cli run pilo",
+    "smoke-eval": "node scripts/smoke-eval/run.mjs",
     "dev:extension": "pnpm --filter pilo-extension run dev --",
     "dev:server": "pnpm --filter pilo-server run dev"
   },

--- a/scripts/smoke-eval/run.mjs
+++ b/scripts/smoke-eval/run.mjs
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+// Smoke-eval runner: executes pilo-cli against a single trivial task and
+// asserts the agent's final answer contains an expected substring.
+//
+// Intended to exercise the Pilo stack end-to-end (CLI -> agent -> Playwright
+// -> LLM) on every PR / merge to main. Not a quality benchmark.
+
+import { spawn } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(SCRIPT_DIR, "..", "..");
+
+const TASKS_FILE = process.env.SMOKE_EVAL_TASKS_FILE
+  ? resolve(process.env.SMOKE_EVAL_TASKS_FILE)
+  : resolve(SCRIPT_DIR, "test.jsonl");
+const CLI_ENTRY = resolve(REPO_ROOT, "packages/cli/dist/cli/src/cli.js");
+const PROVIDER = process.env.SMOKE_EVAL_PROVIDER ?? "vertex";
+const MODEL = process.env.SMOKE_EVAL_MODEL ?? "gemini-2.5-flash";
+const TIMEOUT_MS = Number.parseInt(process.env.SMOKE_EVAL_TIMEOUT_MS ?? "180000", 10);
+const LOG_DIR = resolve(REPO_ROOT, ".smoke-eval-output");
+
+function fail(message, exitCode = 1) {
+  process.stderr.write(`❌ ${message}\n`);
+  process.exit(exitCode);
+}
+
+function readFirstTask(path) {
+  let raw;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch (err) {
+    fail(`Tasks file not found: ${path} (${err.message})`, 2);
+  }
+  const line = raw.split(/\r?\n/).find((l) => l.trim().length > 0);
+  if (!line) fail(`Tasks file is empty: ${path}`, 2);
+  try {
+    return JSON.parse(line);
+  } catch (err) {
+    fail(`Tasks file first line is not valid JSON: ${err.message}`, 2);
+  }
+}
+
+function ensureCliBuilt() {
+  try {
+    readFileSync(CLI_ENTRY);
+  } catch {
+    fail(
+      `pilo-cli is not built. Run: pnpm --filter pilo-cli build\n   (expected at ${CLI_ENTRY})`,
+      2,
+    );
+  }
+}
+
+function runAgent({ question, url }) {
+  return new Promise((resolvePromise) => {
+    const args = [
+      CLI_ENTRY,
+      "run",
+      question,
+      "--url",
+      url,
+      "--browser",
+      "chromium",
+      "--headless",
+      "--logger",
+      "json",
+      "--provider",
+      PROVIDER,
+      "--model",
+      MODEL,
+    ];
+    const child = spawn(process.execPath, args, {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+
+    let stdoutBuf = "";
+    let stderrBuf = "";
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdoutBuf += text;
+      process.stdout.write(text);
+    });
+    child.stderr.on("data", (chunk) => {
+      const text = chunk.toString();
+      stderrBuf += text;
+      process.stderr.write(text);
+    });
+
+    const timer = setTimeout(() => {
+      process.stderr.write(`⏱️  Killing agent after ${TIMEOUT_MS}ms timeout\n`);
+      child.kill("SIGKILL");
+    }, TIMEOUT_MS);
+
+    child.on("exit", (code, signal) => {
+      clearTimeout(timer);
+      resolvePromise({ code, signal, stdout: stdoutBuf, stderr: stderrBuf });
+    });
+  });
+}
+
+function extractFinalAnswer(ndjson) {
+  let finalAnswer = null;
+  let abortReason = null;
+  for (const line of ndjson.split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    let evt;
+    try {
+      evt = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (evt.event === "task:completed" && evt.data && typeof evt.data.finalAnswer === "string") {
+      finalAnswer = evt.data.finalAnswer;
+    }
+    if (evt.event === "task:aborted" && evt.data && typeof evt.data.reason === "string") {
+      abortReason = evt.data.reason;
+    }
+  }
+  return { finalAnswer, abortReason };
+}
+
+async function main() {
+  ensureCliBuilt();
+  const task = readFirstTask(TASKS_FILE);
+  for (const field of ["id", "url", "question", "answer"]) {
+    if (typeof task[field] !== "string" || !task[field]) {
+      fail(`Task is missing required field "${field}"`, 2);
+    }
+  }
+
+  mkdirSync(LOG_DIR, { recursive: true });
+  const logFile = resolve(LOG_DIR, `${task.id}.ndjson.log`);
+
+  process.stdout.write(
+    [
+      `🚀 Smoke eval: ${task.id}`,
+      `   URL:      ${task.url}`,
+      `   Question: ${task.question}`,
+      `   Expected: ${task.answer}`,
+      `   Provider: ${PROVIDER} (${MODEL})`,
+      `   Timeout:  ${TIMEOUT_MS}ms`,
+      `   Log:      ${logFile}`,
+      "",
+    ].join("\n"),
+  );
+
+  const { code, signal, stdout } = await runAgent(task);
+  writeFileSync(logFile, stdout);
+
+  if (signal === "SIGKILL") {
+    fail(`Agent killed by smoke-eval timeout (${TIMEOUT_MS}ms)`);
+  }
+  if (code !== 0) {
+    fail(`Agent exited with status ${code}`);
+  }
+
+  const { finalAnswer, abortReason } = extractFinalAnswer(stdout);
+  if (abortReason && finalAnswer === null) {
+    fail(`Agent aborted: ${abortReason}`);
+  }
+  if (finalAnswer === null) {
+    fail("No task:completed event with finalAnswer found in agent output");
+  }
+
+  process.stdout.write(`\nAgent answer: ${finalAnswer}\n`);
+
+  const ok = finalAnswer.toLowerCase().includes(task.answer.toLowerCase());
+  if (!ok) {
+    fail(`Smoke eval failed: expected answer to contain "${task.answer}"`);
+  }
+
+  process.stdout.write(`✅ Smoke eval passed (answer contains "${task.answer}")\n`);
+}
+
+main().catch((err) => {
+  fail(`Unexpected error: ${err.stack ?? err.message ?? String(err)}`);
+});

--- a/scripts/smoke-eval/test.jsonl
+++ b/scripts/smoke-eval/test.jsonl
@@ -1,0 +1,1 @@
+{"website_name":"Example Domain","id":"test-example-0","url":"https://example.com/","question":"What is the title of this page?","answer":"Example Domain"}


### PR DESCRIPTION
## Summary

- Adds a lightweight single-task eval (`scripts/smoke-eval/`) that runs the full Pilo stack — CLI → agent → Playwright → Vertex/Gemini — against `example.com` and asserts the agent's final answer contains "Example Domain".
- New `smoke-eval` job in `build-test.yml` runs on every PR + push to main alongside the existing `cli`/`core`/`extension`/`server` jobs and is required on failure. Gated by the same `detect-changes` outputs as the `cli` job, so it skips when only docs/extension/server changed.
- Authenticates to GCP via `secrets.GCP_SMOKE_EVAL_SA_KEY` (already added to repo secrets). The Workload Identity Federation alternative is documented inline in the workflow file for a future swap once WIF is provisioned for nonprod Vertex.

## Background

Existing CI runs typecheck/test/build per package but never exercises the agent end-to-end on a real page. This adds that missing safety net. The task is intentionally trivial (one step, fully deterministic page) so failures point at the stack, not at the LLM or the website. Verified locally end-to-end in ~3s using ~2700 Gemini Flash tokens.

## Files

- `scripts/smoke-eval/test.jsonl` — single task: title of example.com → "Example Domain"
- `scripts/smoke-eval/run.mjs` — Node ESM runner. Spawns `pilo run` with `--browser chromium --headless --logger json --provider vertex --model gemini-2.5-flash`, parses NDJSON for the `task:completed` event, substring-matches the `finalAnswer` field. Captures the full event log to `.smoke-eval-output/` for artifact upload.
- `package.json` — `pnpm smoke-eval` script
- `.gitignore` — excludes `.smoke-eval-output/`
- `.github/workflows/build-test.yml` — new job; uploads the NDJSON log on every run for debugging

## Test plan

- [x] PR triggers `smoke-eval` job under Build & Test
- [x] Job authenticates to `moz-fx-tabs-nonprod` via the new SA key secret
- [x] Agent run completes and exits 0
- [ ] `smoke-eval-log` artifact is uploaded and inspectable
- [ ] Merge gating: the job becomes a required check (configured via branch protection separately)

## Follow-ups (not in this PR)

- Migrate to Workload Identity Federation once a nonprod Vertex WIF binding is provisioned (commented inline in the auth step).
- Consider adding a second smoke task (e.g., a search interaction) if/when the single task isn't catching enough regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)