### PR TITLE
refactor: replace dotenv with built-in process.loadEnvFile (#150)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "cross-fetch": "^4.1.0",
-    "dotenv": "^17.4.2",
     "eventemitter3": "^5.0.4",
     "liquidjs": "^10.26.0",
     "nanoid": "^5.1.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,6 @@
     "chalk": "^5.6.2",
     "commander": "^14.0.3",
     "cross-fetch": "^4.1.0",
-    "dotenv": "^17.4.2",
     "eventemitter3": "^5.0.4",
     "liquidjs": "^10.26.0",
     "nanoid": "^5.1.7",

--- a/packages/core/src/config/manager.ts
+++ b/packages/core/src/config/manager.ts
@@ -1,5 +1,5 @@
 /**
- * Config Manager (Node.js only - uses fs, path, os, dotenv)
+ * Config Manager (Node.js only - uses fs, path, os)
  */
 
 // Build-time flag: replaced with `true` by the production build step.
@@ -14,7 +14,6 @@ export function isProduction(): boolean {
 import { readFileSync, writeFileSync, existsSync, mkdirSync, unlinkSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
-import { config as loadDotenv } from "dotenv";
 
 import { DEFAULTS, type PiloConfig, type PiloConfigResolved } from "./defaults.js";
 import { parseEnvConfig } from "./env.js";
@@ -63,7 +62,7 @@ export class ConfigManager {
 
     // Dev mode: load local .env file and include env vars.
     try {
-      loadDotenv({ path: ".env", quiet: true });
+      process.loadEnvFile(".env");
     } catch {
       // Ignore if .env doesn't exist
     }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -39,7 +39,6 @@
     "@opentelemetry/sdk-metrics": "^2.5.0",
     "@opentelemetry/sdk-node": "^0.217.0",
     "@opentelemetry/semantic-conventions": "^1.34.0",
-    "dotenv": "^17.4.2",
     "hono": "^4.12.18",
     "pilo-core": "workspace:*"
   },

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import "dotenv/config";
+import "./loadEnv.js";
 import { initTelemetry } from "./telemetry.js";
 
 // Initialize OTel SDK before app creation

--- a/packages/server/src/loadEnv.ts
+++ b/packages/server/src/loadEnv.ts
@@ -1,0 +1,8 @@
+// Load .env from CWD as a side effect, before any other module is evaluated.
+// Imported first in index.ts so env vars are present before telemetry/OTel
+// initialization reads them. Uses Node's built-in env-file loader (Node 21+).
+try {
+  process.loadEnvFile();
+} catch {
+  // No .env file present; ignore.
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       cross-fetch:
         specifier: ^4.1.0
         version: 4.1.0
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       eventemitter3:
         specifier: ^5.0.4
         version: 5.0.4
@@ -169,9 +166,6 @@ importers:
       cross-fetch:
         specifier: ^4.1.0
         version: 4.1.0
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       eventemitter3:
         specifier: ^5.0.4
         version: 5.0.4
@@ -390,9 +384,6 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.34.0
         version: 1.40.0
-      dotenv:
-        specifier: ^17.4.2
-        version: 17.4.2
       hono:
         specifier: ^4.12.18
         version: 4.12.18


### PR DESCRIPTION
Closes #150.

dotenv v17 ships up-sell/promo output (the motivation for #150), and Node 21+ provides a built-in `process.loadEnvFile()`. Pilo requires Node `^22`, so the dependency is no longer needed.

## Changes

- **`packages/core/src/config/manager.ts`**: `loadDotenv({ path: ".env", quiet: true })` → `process.loadEnvFile(".env")`. The existing try/catch already handles a missing file (the built-in throws `ENOENT` where dotenv was silent).
- **`packages/server/src/index.ts`**: `import "dotenv/config"` → `import "./loadEnv.js"`, a new dedicated side-effect module. ES imports are hoisted, so inlining the load as executable code would run it *after* the OTel imports evaluate; a side-effect import imported first preserves the original load ordering.
- Dropped `dotenv` from root, core, and server `package.json` + lockfile.

## Semantics

Verified on Node that the built-in matches dotenv's defaults:
- Existing env vars take precedence over the file (no override).
- A missing `.env` is ignored (handled by try/catch at both call sites — the only behavioral difference from dotenv).

## Verification

- core typecheck + tests: 741 passed
- server typecheck + tests: 96 passed
- root `format:check` clean, gitleaks clean
- Functional smoke test: a `.env` in CWD is picked up via the new loader in dev mode, and an absent `.env` does not crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)