### PR TITLE
feat(core): multi-action per turn (maxActionsPerStep) — core batching

### DIFF
--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
@@ -6,7 +6,8 @@ Ran the partial WebVoyager suite via `evals/partial/...` branches (config defaul
 
 - **Run #1 (toolChoice "auto"): 50% (15/30)** — 8/15 failures were a zero-tool cascade: `"auto"` let the model return no tools on hard tasks → repeated "at least one tool" errors → `maxConsecutiveErrors` abort.
 - **Fix:** `toolChoice: "required"` always (forces ≥1 tool, still allows several). Committed `536284f` on the PR branch.
-- **Run #2 (toolChoice "required"): 80% (24/30)** — 0 cascades. Remaining 6 failures all environmental/known-hard. Batching real: ~15% of 221 turns emitted >1 tool → ~24% fewer round-trips on this suite (form-density-dependent; not the 2–3× headline). `maxActionsPerStep=5` correctness-neutral.
+- **Run #2 (toolChoice "required", max=5): 80% (24/30)** — 0 cascades. Remaining 6 failures all environmental/known-hard. Batching real: ~15% of 221 turns emitted >1 tool → ~24% fewer round-trips on this suite (form-density-dependent; not the 2–3× headline).
+- **Baseline (toolChoice "required", max=1, batch off): 63% (19/30)** — batching-5 (80%) ≥ baseline, but the gap is environmental noise (bot-detection 6 vs 3; failing tasks shuffle run-to-run). n=1 per config → defensible claim is "batching correctness-neutral," not "improves." Eval branches deleted; GCS reports persist (`9qmv6`/`lzq6d`/`9xr8w`).
 - **Lesson:** the issue's suggested `"auto"` flip was wrong; evals caught it. The `superpowers:receiving-code-review` instinct (verify, don't blindly implement) applied to the _issue spec_ itself.
 
 ## Session state (execution complete)

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
@@ -1,10 +1,22 @@
 # Notes — multi-action per turn (#438)
 
-## Session state (as of plan completion)
+## Session state (execution complete)
 
 - Worktree: `.claude/worktrees/438-multi-action-per-turn/`, branch `worktree-438-multi-action-per-turn`, off origin/main @ a26880e.
-- Baseline: 1324 tests green (core 741).
-- Phase: spec ✓, research ✓, plan ✓. **Awaiting approval to execute.** PR 1 of 2 (per-action repetition rework is PR 2).
+- Baseline: 1324 tests green (core 741). After: **1338 green** (core 755, cli 221, server 96, extension 266), typecheck + format + check:schemas clean.
+- Phase: spec ✓, research ✓, plan ✓, **execute ✓ (3 phases committed)**. Next: `pr`. PR 1 of 2 (per-action repetition rework is PR 2).
+
+### Commits
+
+- `e419814` Phase 1: maxActionsPerStep option, config, safe-batch classifier (+14 classifier/config tests context)
+- `6353005` Phase 2: prompt batching guidance parameterized on maxActionsPerStep (+6 prompt tests)
+- `f156df2` Phase 3: unified processing loop + SYSTEM_DEBUG_BATCH telemetry (+6 batch scenarios)
+
+### Execution adaptations (vs plan)
+
+- **`noUnusedLocals`** forced the `toolChoice` flip into Phase 1 (planned for Phase 2) so the field had a real use.
+- Updated three **structural-guard tests** that enumerate config keys / event types: `config.test.ts` (+`max_actions_per_step`), `events.test.ts` (+`system:debug_batch`). Legit sync updates, not weakening.
+- **Schema**: `packages/core/schemas/` is `.prettierignore`d (prettier diverges from ts-json-schema-generator). Regenerate with `pnpm --filter pilo-core generate:schemas` ONLY — never prettier it. Committed the regenerated `webagent-event.json`.
 
 ## Load-bearing discoveries (read before resuming)
 

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
@@ -1,0 +1,21 @@
+# Notes — multi-action per turn (#438)
+
+## Session state (as of plan completion)
+
+- Worktree: `.claude/worktrees/438-multi-action-per-turn/`, branch `worktree-438-multi-action-per-turn`, off origin/main @ a26880e.
+- Baseline: 1324 tests green (core 741).
+- Phase: spec ✓, research ✓, plan ✓. **Awaiting approval to execute.** PR 1 of 2 (per-action repetition rework is PR 2).
+
+## Load-bearing discoveries (read before resuming)
+
+1. **Eager execution.** AI SDK v6 `streamText` runs every returned tool's `execute` fn before `toolResults` resolves (`webActionTools.ts:166-241`). So we CANNOT prevent a mis-ordered batch action from hitting the browser — the loop only controls _processing/reporting_. Safety is prompt-driven (Les's explicit choice over manual execution control). The recoverable-error path is the net for mis-ordering.
+2. **`pageChanged` is the inverse concept.** `webAgent.ts:1124` treats everything as page-changing except `extract`/`webSearch`. The batch safe-set (`fill, select, check, uncheck, focus`) is a _new_ classifier (`isBatchTerminating`), NOT a reuse of `pageChanged`.
+3. **Telemetry can't go on `AI_GENERATION`** — that event fires before tool processing (`webAgent.ts:1050`). Using a new `SYSTEM_DEBUG_BATCH` event emitted after processing.
+4. **Config, not a one-off CLI flag.** `max_actions_per_step` goes in `config/defaults.ts` schema → auto-generates `--max-actions-per-step` + `PILO_MAX_ACTIONS_PER_STEP`.
+5. The multi-tool **drop** path already exists (`1081-1094`); we unify around `slice(0, maxActionsPerStep)` so cap=1 reproduces today's behavior exactly.
+
+## Key decisions (Les)
+
+- Safe-to-batch set: form-fill only (`fill, select, check, uncheck, focus`); `select` kept safe.
+- Phased delivery: core batching now (this PR); per-action repetition detector later.
+- Safety mechanism: prompt-ordered + eager execution (not manual execution control).

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/notes.md
@@ -1,5 +1,14 @@
 # Notes — multi-action per turn (#438)
 
+## Eval-driven course correction (post-PR)
+
+Ran the partial WebVoyager suite via `evals/partial/...` branches (config default temporarily = 5).
+
+- **Run #1 (toolChoice "auto"): 50% (15/30)** — 8/15 failures were a zero-tool cascade: `"auto"` let the model return no tools on hard tasks → repeated "at least one tool" errors → `maxConsecutiveErrors` abort.
+- **Fix:** `toolChoice: "required"` always (forces ≥1 tool, still allows several). Committed `536284f` on the PR branch.
+- **Run #2 (toolChoice "required"): 80% (24/30)** — 0 cascades. Remaining 6 failures all environmental/known-hard. Batching real: ~15% of 221 turns emitted >1 tool → ~24% fewer round-trips on this suite (form-density-dependent; not the 2–3× headline). `maxActionsPerStep=5` correctness-neutral.
+- **Lesson:** the issue's suggested `"auto"` flip was wrong; evals caught it. The `superpowers:receiving-code-review` instinct (verify, don't blindly implement) applied to the _issue spec_ itself.
+
 ## Session state (execution complete)
 
 - Worktree: `.claude/worktrees/438-multi-action-per-turn/`, branch `worktree-438-multi-action-per-turn`, off origin/main @ a26880e.

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
@@ -381,14 +381,15 @@ if (result.actionExecuted) {
 
 **Verification — automated:**
 
-- [ ] `pnpm --filter pilo-core test` passes (6 new scenarios green; all 741 existing green, none modified)
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm format:check` passes
-- [ ] `pnpm check` passes (full)
+- [x] `pnpm --filter pilo-core test` passes (755; 6 new batch scenarios green, events-enum + config-schema sync tests updated)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm format:check` passes
+- [x] `pnpm check` passes (full: core 755, cli 221, server 96, extension 266)
+- [x] `pnpm --filter pilo-core check:schemas` passes (regenerated `webagent-event.json` with `system:debug_batch`; schemas are `.prettierignore`d — no prettier)
 
 **Verification — manual:**
 
-- [ ] Re-read the diff of `generateAndProcessAction`: at `maxActionsPerStep:1`, `slice(0,1)` + drop-emit + single-result processing is behaviorally identical to the original
+- [x] At `maxActionsPerStep:1`, `slice(0,1)` + drop-emit + single-result processing is behaviorally identical to the original — proven by regression scenario 6 (default agent, `[click, fill]` → processes click only, emits `SYSTEM_DEBUG_TOOL_DROP` for fill) plus all 741 pre-existing core tests still green, none modified
 
 ---
 

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
@@ -219,14 +219,16 @@ it("renders single-tool instruction when maxActionsPerStep === 1", () => {
 
 **Verification — automated:**
 
-- [ ] `pnpm --filter pilo-core test` passes (new prompt tests green; existing prompt text tests still green)
-- [ ] `pnpm typecheck` passes
-- [ ] `pnpm format:check` passes
+- [x] `pnpm --filter pilo-core test` passes (749 pass; 6 new prompt tests green, existing prompt tests unchanged)
+- [x] `pnpm typecheck` passes
+- [x] `pnpm format:check` passes
 
 **Verification — manual:**
 
-- [ ] Eyeball a rendered action-loop prompt at `maxActionsPerStep:3` — batching guidance reads coherently, page-changer-last rule is clear
-- [ ] Rendered prompt at default (1) still says "exactly ONE" and contains no batching text
+- [x] Eyeball a rendered action-loop prompt at `maxActionsPerStep:3` — Core Rule #2, CRITICAL line, and batching block all render coherently with the page-changer-last rule (verified via render)
+- [x] Rendered prompt at default (1) still says "exactly ONE" and contains no batching text (existing `actionLoopSystemPrompt` describe block asserts this)
+
+> **Note:** the `toolChoice` flip listed in this phase's Files already landed in Phase 1 (see Phase 1 adaptation). Phase 2 is the prompt-guidance work only.
 
 ---
 

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md
@@ -1,0 +1,397 @@
+# Multi-action per turn — core batching Implementation Plan
+
+**Goal:** Let the web agent batch several safe, non-navigating actions in one LLM turn (gated on `maxActionsPerStep`, default 1 = no change), cutting round-trips.
+
+**Approach:** Add a `maxActionsPerStep` option (config-driven). When `>1`, flip `toolChoice` to `"auto"` and prompt the model to batch safe actions with any page-changer last. Because the AI SDK executes all returned tool calls eagerly, the loop's job is to _process_ the executed results in order (stop at first terminal/error) and produce one aggregated turn-result + telemetry. Safety is prompt-driven, not code-gated.
+
+**Tech stack:** TypeScript, pnpm monorepo (`@tabstack/pilo`), AI SDK v6, Vitest, nunjucks-style prompt templates.
+
+**Verification commands** (no Makefile; run from repo root):
+
+- lint/format: `pnpm format:check`
+- types: `pnpm typecheck`
+- tests: `pnpm --filter pilo-core test` (full suite: `pnpm test`)
+- combined: `pnpm check`
+
+---
+
+## Phase 1: Option plumbing + config + safe-set classifier
+
+Foundation slice: the option exists end-to-end (config → CLI flag/env → `WebAgent` field) and a tested classifier defines the safe-to-batch set. **No loop behavior changes** (default 1; loop still processes `[0]`).
+
+**Files:**
+
+- Modify: `packages/core/src/config/defaults.ts` — add `max_actions_per_step` to the optional interface (~line 104), the resolved interface (~line 176), and the schema map (after `max_repeated_actions`, ~line 491).
+- Modify: `packages/core/src/core.ts` — export `DEFAULT_MAX_ACTIONS_PER_STEP` (mirror `DEFAULT_MAX_REPEATED_ACTIONS`, line 95).
+- Modify: `packages/core/src/webAgent.ts` — add `maxActionsPerStep?: number` to `WebAgentOptions` (~line 88, near `maxRepeatedActions`); add `private readonly maxActionsPerStep: number` field (~line 219) and init in constructor (~line 255).
+- Modify: `packages/core/src/tools/webActionTools.ts` — add `SAFE_TO_BATCH_ACTIONS` constant + `isBatchTerminating()`, exported.
+- Modify: `packages/cli/src/commands/run.ts` — pass `maxActionsPerStep: options.maxActionsPerStep ?? cfg.max_actions_per_step` into `new WebAgent(...)` (~line 314).
+- Test: `packages/core/test/webActionTools.test.ts` (or new `test/batching.test.ts`) — classifier unit test.
+
+**Key changes:**
+
+In `config/defaults.ts` schema map (mirror `max_repeated_actions` at 483-491):
+
+```ts
+max_actions_per_step: {
+  default: 1,
+  type: "number",
+  cli: "--max-actions-per-step",
+  placeholder: "n",
+  env: ["PILO_MAX_ACTIONS_PER_STEP"],
+  description: "Maximum tool calls the agent may batch in one turn (1 = one action per turn)",
+  category: "agent",
+},
+```
+
+Add `max_actions_per_step?: number;` to the optional interface (~104) and `max_actions_per_step: number;` to the resolved interface (~176).
+
+In `core.ts` (after line 95):
+
+```ts
+export const DEFAULT_MAX_ACTIONS_PER_STEP = _defaults.max_actions_per_step;
+```
+
+In `webAgent.ts` `WebAgentOptions` (after `maxRepeatedActions`):
+
+```ts
+/** Maximum tool calls the agent may batch in one turn (default 1 = one action per turn). */
+maxActionsPerStep?: number;
+```
+
+Field + constructor init (mirror line 255):
+
+```ts
+private readonly maxActionsPerStep: number;
+// ...in constructor:
+this.maxActionsPerStep = options.maxActionsPerStep ?? defaults.max_actions_per_step;
+```
+
+In `tools/webActionTools.ts` (near the top-level exports):
+
+```ts
+/**
+ * Actions that mutate form state without navigating or invalidating other refs.
+ * The model may batch these before a single trailing page-changing action.
+ * Single source of truth shared by prompt guidance and any batch logic.
+ */
+export const SAFE_TO_BATCH_ACTIONS: ReadonlySet<string> = new Set([
+  "fill",
+  "select",
+  "check",
+  "uncheck",
+  "focus",
+]);
+
+/** True when an action ends a batch (page-changing, terminal, or unknown — fail safe). */
+export function isBatchTerminating(action: string): boolean {
+  return !SAFE_TO_BATCH_ACTIONS.has(action);
+}
+```
+
+In `cli/src/commands/run.ts` `new WebAgent(browser, { ... })` (~314):
+
+```ts
+maxActionsPerStep: options.maxActionsPerStep ?? cfg.max_actions_per_step,
+```
+
+**Test (write first, watch fail):**
+
+```ts
+import { SAFE_TO_BATCH_ACTIONS, isBatchTerminating } from "../src/tools/webActionTools.js";
+
+describe("batch action classification", () => {
+  it("treats form-fill actions as safe to batch", () => {
+    for (const a of ["fill", "select", "check", "uncheck", "focus"]) {
+      expect(isBatchTerminating(a)).toBe(false);
+      expect(SAFE_TO_BATCH_ACTIONS.has(a)).toBe(true);
+    }
+  });
+  it("treats navigating/terminal/unknown actions as batch-terminating", () => {
+    for (const a of [
+      "click",
+      "enter",
+      "goto",
+      "back",
+      "forward",
+      "scroll",
+      "wait",
+      "webSearch",
+      "extract",
+      "done",
+      "abort",
+      "hover",
+      "totally-unknown",
+    ]) {
+      expect(isBatchTerminating(a)).toBe(true);
+    }
+  });
+});
+```
+
+**Verification — automated:**
+
+- [x] `pnpm --filter pilo-core test` passes (743 pass; new classifier test green, config schema-sync test updated)
+- [x] `pnpm typecheck` passes (core + cli)
+- [x] `pnpm format:check` passes
+- [x] `pnpm check:schemas` passes (config doesn't touch the events schema — no diff)
+
+**Verification — manual:**
+
+- [x] `pnpm pilo run --help` shows `--max-actions-per-step <n>` under agent options (verified)
+- [x] Existing default behavior unchanged: `maxActionsPerStep` resolves to 1 when unset (config default + schema-sync test)
+
+> **Adaptation:** the repo has `noUnusedLocals`, so declaring the field without using it failed typecheck. Pulled the one-line `toolChoice` flip (planned for Phase 2) into Phase 1 as the field's first real use — behaviorally safe (stays `"required"` at the default of 1). Also updated `test/config.test.ts`'s hardcoded key list (the schema-sync structural guard) to include `max_actions_per_step`.
+
+---
+
+## Phase 2: Prompt batching guidance + toolChoice flip
+
+Slice: when `maxActionsPerStep > 1`, the action-loop prompts invite batching and `streamText` uses `toolChoice:"auto"`; when `=== 1`, everything renders/behaves exactly as today. The processing loop is still single-action (Phase 3 changes that), so this phase is safe at any value — at most the model batches and extras get dropped as they are today.
+
+**Files:**
+
+- Modify: `packages/core/src/prompts.ts` — replace the `${toolCallInstruction}` interpolation in the three _action-loop_ templates (action system prompt ~424, page snapshot ~518, step error feedback ~560) with a templated `{{ toolCallInstruction }}` var computed per `maxActionsPerStep`; make the static "exactly ONE" lines (rule #2 ~331 and the CRITICAL block ~339-343) conditional. Leave planning (~287) and validation (~611) templates untouched — those legitimately want one tool call.
+- Modify: `packages/core/src/webAgent.ts` — thread `this.maxActionsPerStep` into `buildActionLoopSystemPrompt(...)` (~1757), `buildPageSnapshotPrompt(...)` (call site), and `buildStepErrorFeedbackPrompt(...)` (call site); set `toolChoice` conditionally in the `streamText` call (~963).
+- Test: `packages/core/test/prompts.test.ts` (or existing prompt test file) — assert guidance text presence by `maxActionsPerStep`.
+
+**Key changes:**
+
+In `prompts.ts`, add a builder for the instruction (keeps the `toolCallInstruction` constant for planning/validation):
+
+```ts
+const BATCHING_INSTRUCTION = (n: number) =>
+  `
+You may call up to ${n} tools in one turn, but ONLY for related actions that do
+not change the page (filling several fields of the same form, focusing inputs,
+checking boxes). Any page-changing action — click, enter, goto, back, forward,
+scroll, webSearch, extract, done, abort — MUST be the LAST call in the turn, or
+the only call. Actions placed after a page-changing call run against a stale page
+and will fail.
+
+Safe to batch together (before any page-changing action): fill, select, check, uncheck, focus.
+Must be last or alone: everything else.
+
+Use valid JSON for all arguments. Do not call the same tool with identical arguments more than once.
+`.trim();
+
+/** Instruction text for the action loop, parameterized on the per-turn action cap. */
+const toolCallInstructionFor = (maxActionsPerStep: number): string =>
+  maxActionsPerStep > 1 ? BATCHING_INSTRUCTION(maxActionsPerStep) : toolCallInstruction;
+```
+
+Thread a `maxActionsPerStep` arg (default 1, added as the LAST param to avoid breaking other callers) through the three builders and pass `toolCallInstruction: toolCallInstructionFor(maxActionsPerStep)` plus `maxActionsPerStep` into each template context. Change `${toolCallInstruction}` → `{{ toolCallInstruction }}` in those three templates.
+
+For the static lines in the action system prompt template, make them conditional:
+
+```nunjucks
+{# rule #2 #}
+{% if maxActionsPerStep > 1 %}2. You may batch up to {{ maxActionsPerStep }} safe actions per turn; any page-changing action must be last{% else %}2. Execute EXACTLY ONE tool per turn{% endif %}
+{# CRITICAL block #}
+{% if maxActionsPerStep > 1 %}**CRITICAL:** Use 1–{{ maxActionsPerStep }} tools per turn (page-changing action last). Choose:{% else %}**CRITICAL:** You MUST use exactly ONE tool with valid arguments EVERY turn. Choose:{% endif %}
+```
+
+In `webAgent.ts` `streamText` call (~963):
+
+```ts
+toolChoice: this.maxActionsPerStep > 1 ? "auto" : "required",
+```
+
+And pass `this.maxActionsPerStep` to the three prompt builders at their call sites.
+
+**Test (write first, watch fail):**
+
+```ts
+it("renders batching guidance when maxActionsPerStep > 1", () => {
+  const p = buildActionLoopSystemPrompt(false, false, false, false, false, 3);
+  expect(p).toMatch(/up to 3 tools/i);
+  expect(p).toMatch(/Safe to batch together/i);
+  expect(p).not.toMatch(/EXACTLY ONE tool per turn/);
+});
+it("renders single-tool instruction when maxActionsPerStep === 1", () => {
+  const p = buildActionLoopSystemPrompt(false, false, false, false, false, 1);
+  expect(p).toMatch(/EXACTLY ONE tool per turn/);
+  expect(p).not.toMatch(/Safe to batch together/i);
+});
+```
+
+(Match the final `buildActionLoopSystemPrompt` signature — `maxActionsPerStep` is the appended last param with default 1.)
+
+**Verification — automated:**
+
+- [ ] `pnpm --filter pilo-core test` passes (new prompt tests green; existing prompt text tests still green)
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm format:check` passes
+
+**Verification — manual:**
+
+- [ ] Eyeball a rendered action-loop prompt at `maxActionsPerStep:3` — batching guidance reads coherently, page-changer-last rule is clear
+- [ ] Rendered prompt at default (1) still says "exactly ONE" and contains no batching text
+
+---
+
+## Phase 3: Unified processing loop + batch telemetry
+
+Slice: replace the single-result processing (`webAgent.ts:1077-1189`) with a capped, ordered processing loop that produces one aggregated turn-result and emits a `SYSTEM_DEBUG_BATCH` telemetry event. At `maxActionsPerStep === 1` this reproduces today's exact behavior (process `[0]`, drop+emit the rest).
+
+**Files:**
+
+- Modify: `packages/core/src/events.ts` — add `SYSTEM_DEBUG_BATCH` to `WebAgentEventType` (mirror `SYSTEM_DEBUG_TOOL_DROP`), a payload interface, and the discriminated-union entry (~line 378).
+- Modify: `packages/core/src/webAgent.ts` — soften the zero-tool error message (1067-1075) when `maxActionsPerStep > 1`; refactor the terminal `done`/`abort` block (1127-1173) into `handleTerminalAction(actionOutput, task, executionState)`; replace lines 1077-1189 with the processing loop; add `actionsProcessed` to the return shape; update the caller's `actionCount` increment (~541-543).
+- Test: `packages/core/test/webAgent.test.ts` — batch scenarios.
+
+**Zero-tool message (webAgent.ts:1067-1075):**
+
+```ts
+if (!aiResponse?.toolResults?.length) {
+  console.error("[WebAgent] No tools called in action generation");
+  const msg =
+    this.maxActionsPerStep > 1
+      ? "You must use at least one tool. Please use one of the available tools."
+      : "You must use exactly one tool. Please use one of the available tools.";
+  throw new ToolExecutionError(msg, { action: "none" });
+}
+```
+
+**Key changes:**
+
+In `events.ts` (mirror the tool-drop event):
+
+```ts
+SYSTEM_DEBUG_BATCH = "system:debug:batch",
+// ...
+export interface SystemDebugBatchEventData extends WebAgentEventData {
+  actionsRequested: number;
+  actionsProcessed: number;
+  batchStoppedBy: "terminal" | "error" | "completed";
+}
+// ...union:
+| { type: WebAgentEventType.SYSTEM_DEBUG_BATCH; data: SystemDebugBatchEventData }
+```
+
+In `webAgent.ts`, extend the return type of `generateAndProcessAction` (935-942) with `actionsProcessed: number;`.
+
+Replace lines 1077-1189 with (keeping the existing terminal/error code by extracting `handleTerminalAction`):
+
+```ts
+// Cap processing at maxActionsPerStep. Results beyond the cap already executed
+// (the AI SDK runs every returned tool's execute fn) — note them as dropped,
+// matching the historical single-action behavior when the cap is 1.
+const toProcess = aiResponse.toolResults.slice(0, this.maxActionsPerStep);
+if (aiResponse.toolResults.length > toProcess.length) {
+  const droppedTools = aiResponse.toolResults.slice(toProcess.length).map((r: any) => r.toolName);
+  console.warn(
+    `[WebAgent] Provider returned ${aiResponse.toolResults.length} tool calls; ` +
+      `processing ${toProcess.length}, dropping: ${droppedTools.join(", ")}`,
+  );
+  this.emit(WebAgentEventType.SYSTEM_DEBUG_TOOL_DROP, {
+    iterationId: this.currentIterationId,
+    droppedCount: droppedTools.length,
+    droppedTools,
+    keptTool: toProcess[0].toolName,
+  });
+}
+
+let actionsProcessed = 0;
+let anyPageChanged = false;
+let lastNonTerminalOutput: any = null;
+let batchStoppedBy: "terminal" | "error" | "completed" = "completed";
+
+try {
+  for (const tr of toProcess) {
+    const actionOutput = tr.output as any;
+    if (!actionOutput) throw new Error("Tool execution failed: missing output property.");
+
+    // Error result → throw (matches the single-action path). Earlier successful
+    // actions are already in this.messages (appended from response.messages above),
+    // so the model sees them next turn.
+    if (!actionOutput.success && actionOutput.error) {
+      batchStoppedBy = "error";
+      if (actionOutput.isRecoverable) {
+        throw new ToolExecutionError(actionOutput.error, {
+          action: actionOutput.action,
+          ref: actionOutput.ref,
+          output: actionOutput,
+        });
+      }
+      throw new Error(actionOutput.error);
+    }
+
+    // Terminal action (done/abort) — handle and return; ignore any later results.
+    if (actionOutput.isTerminal) {
+      batchStoppedBy = "terminal";
+      actionsProcessed++;
+      const terminal = await this.handleTerminalAction(actionOutput, task, executionState);
+      return { ...terminal, actionsProcessed };
+    }
+
+    // Regular action: count it, track page change.
+    actionsProcessed++;
+    lastNonTerminalOutput = actionOutput;
+    if (actionOutput.action !== "extract" && actionOutput.action !== "webSearch") {
+      anyPageChanged = true;
+    }
+  }
+} finally {
+  this.emit(WebAgentEventType.SYSTEM_DEBUG_BATCH, {
+    iterationId: this.currentIterationId,
+    actionsRequested: aiResponse.toolResults.length,
+    actionsProcessed,
+    batchStoppedBy,
+  });
+}
+
+// Repetition check on the last non-terminal action (unchanged shape; per-action
+// tracking deferred to PR 2).
+if (lastNonTerminalOutput) {
+  const repetitionResult = this.checkAndHandleRepeatedAction(lastNonTerminalOutput, executionState);
+  if (repetitionResult) return { ...repetitionResult, actionsProcessed };
+}
+
+return {
+  isTerminal: false,
+  success: false,
+  finalAnswer: null,
+  pageChanged: anyPageChanged,
+  actionExecuted: actionsProcessed > 0,
+  actionsProcessed,
+};
+```
+
+`handleTerminalAction` is the existing `done`/`abort` body (1128-1172) lifted verbatim into a private method returning the same `{isTerminal, success, finalAnswer, pageChanged, actionExecuted, error?}` shape. The two `checkAndHandleRepeatedAction` early-return paths must also carry `actionsProcessed` — spread it as shown.
+
+Caller change (`webAgent.ts:541-543`):
+
+```ts
+if (result.actionExecuted) {
+  executionState.actionCount += result.actionsProcessed ?? 1;
+}
+```
+
+**Tests (write first, watch fail):** add to `webAgent.test.ts` using `createMockStreamResponse({ toolResults: [...] })`. Construct the agent with `maxActionsPerStep: 3` where noted.
+
+1. **3-fill batch (completed):** toolResults = 3 successful `fill` outputs. Assert: turn returns `actionExecuted:true`, `pageChanged:true`, `actionsProcessed:3`; a `SYSTEM_DEBUG_BATCH` event with `{actionsRequested:3, actionsProcessed:3, batchStoppedBy:"completed"}`; `actionCount` incremented by 3.
+2. **fill + enter (page-changer last, completed):** toolResults = [fill ok, enter ok]. Assert both processed, `batchStoppedBy:"completed"`, `pageChanged:true`, `actionsProcessed:2`.
+3. **fill + done (terminal):** toolResults = [fill ok, done(isTerminal)]; mock validation `complete`. Assert terminal success returned, `batchStoppedBy:"terminal"`, validation ran once.
+4. **fill + recoverable error (stops at error):** toolResults = [fill ok, fill {success:false,error:"Invalid element reference",isRecoverable:true}]. Assert `ToolExecutionError` thrown; `SYSTEM_DEBUG_BATCH` with `batchStoppedBy:"error"`, `actionsProcessed:1`; the successful fill's message is present in `this.messages`.
+5. **done not last in batch:** toolResults = [done(isTerminal), fill]. Assert terminal handling runs on `done`, the trailing fill is ignored (`actionsProcessed:1`, `batchStoppedBy:"terminal"`).
+6. **default (maxActionsPerStep:1) regression:** toolResults = [click ok, fill ok] with default agent. Assert only `[0]` processed (`actionsProcessed:1`), `SYSTEM_DEBUG_TOOL_DROP` emitted for the extra; behavior identical to pre-change (existing tests should also cover this — confirm none changed).
+
+**Verification — automated:**
+
+- [ ] `pnpm --filter pilo-core test` passes (6 new scenarios green; all 741 existing green, none modified)
+- [ ] `pnpm typecheck` passes
+- [ ] `pnpm format:check` passes
+- [ ] `pnpm check` passes (full)
+
+**Verification — manual:**
+
+- [ ] Re-read the diff of `generateAndProcessAction`: at `maxActionsPerStep:1`, `slice(0,1)` + drop-emit + single-result processing is behaviorally identical to the original
+
+---
+
+## Out of scope (deferred / NOT this plan)
+
+- Per-action repetition-detector rework → PR 2 / follow-up issue.
+- Server-side wiring of `maxActionsPerStep`.
+- The manual latency eval (real-provider run) — Les runs it via `--max-actions-per-step 3` after merge; acceptance is a 2–3× wall-clock reduction on a form-heavy task vs. `1`. Not a CI gate.

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/research.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/research.md
@@ -1,0 +1,65 @@
+# Research — multi-action per turn (#438)
+
+All refs are `packages/core/src/...` unless noted. Verified against worktree branched off origin/main @ a26880e.
+
+## 1. Per-turn action loop: `generateAndProcessAction()`
+
+- Method spans `webAgent.ts:931-1190`. Return type declared at `webAgent.ts:935-940` (`{ isTerminal, success, finalAnswer, pageChanged, actionExecuted }`).
+- `streamText` call at `webAgent.ts:958-966`: `toolChoice: "required"`, `tools: webActionTools`, `maxOutputTokens: DEFAULT_GENERATION_MAX_TOKENS`, `abortSignal`.
+- Reasoning streamed via `fullStream` loop `webAgent.ts:972-1000`; `AGENT_REASONED` emitted once at reasoning-end / first tool-call (`webAgent.ts:992-995`), payload `{ reasoning, iterationId }`.
+- Await tuple of promises (`toolResults`, `response`, `finishReason`, `usage`, `warnings`, `providerMetadata`) at `webAgent.ts:1003-1011`.
+- **`AI_GENERATION` event emitted `webAgent.ts:1050-1059`** (always, success or error). Payload: `{ messages, temperature:0, object:null, finishReason, usage:{inputTokens,outputTokens}, warnings, providerMetadata, error? }`. No batch fields today.
+- **Multi-tool DROP path `webAgent.ts:1081-1094`**: when `toolResults.length > 1`, keeps `[0]`, warns, emits `SYSTEM_DEBUG_TOOL_DROP { iterationId, droppedCount, droppedTools, keptTool }`. _This is the path the batching feature converts from "drop" to "execute"._
+- Single result consumed at `webAgent.ts:1096`: `const toolResult = aiResponse.toolResults[0]`.
+- Zero-tool handling: if no tools executed, `ToolExecutionError("You must use exactly one tool")` thrown `webAgent.ts:1067-1075`; caught as recoverable, fed back as a message.
+- Recoverable tool error: `actionOutput.success === false && error` + `isRecoverable` → `throw new ToolExecutionError(...)` `webAgent.ts:1108-1118`.
+
+## 2. ActionResult shape + action classification
+
+- Base type `tools/webActionTools.ts:40-52`: `{ success, action, ref?, value?, error?, isRecoverable?, targetIdentity? }`. **No `isTerminal` in the base type.**
+- `done`/`abort` tools return an _extended_ shape with `isTerminal: true`:
+  - `done` → `{ success:true, action:"done", result, isTerminal:true }` (`tools/webActionTools.ts:438`)
+  - `abort` → `{ success:true, action:"abort", reason, isTerminal:true }` (`tools/webActionTools.ts:453`)
+- Loop reads `actionOutput.isTerminal` at `webAgent.ts:1127`.
+- **`pageChanged` already exists `webAgent.ts:1124`:** `action !== "extract" && action !== "webSearch"`. ⇒ _Every_ action is considered page-changing today EXCEPT `extract` and `webSearch`. This drives whether a fresh snapshot is taken next iteration.
+  - ⚠️ **This is the inverse of the issue's `isPageChangingAction`.** The issue wants to know which actions are SAFE TO BATCH (fill/focus/check don't invalidate refs). The existing `pageChanged` flag treats fill/focus/check as page-changing. We need a NEW, separate classifier for "batch terminator" — do not overload `pageChanged`.
+- Web action tools defined in `tools/webActionTools.ts:159-457`. Names: `click, fill, select, hover, check, uncheck, focus, enter, wait, scroll, goto, back, forward, extract, done, abort`.
+- **`webSearch` is a separate, CONDITIONAL tool** in `tools/searchTools.ts:22`, added only when `searchProvider !== "none"` (gated at `webAgent.ts:1473`). Not in the base webActionTools list.
+
+## 3. Repetition detector: `checkAndHandleRepeatedAction()`
+
+- Defined `webAgent.ts:1196-1286`. Called once per turn at `webAgent.ts:1177` (after successful tool exec, before returning non-terminal).
+- State in `executionState` (`webAgent.ts:151-161`): `actionRepeatCount`, `lastAction` (single signature string).
+- Signature via `createActionSignature()` `webAgent.ts:1577-1590`: `action:role:name:normalizedValue` or `action:normalizedValue`. **Ref deliberately excluded** (handles snapshot ref churn).
+- Exempt: `scroll`, `wait` reset count + clear `lastAction` (`webAgent.ts:1211-1212`, exempt set `webAgent.ts:237-240`).
+- Thresholds: warning at `maxRepeatedActions+1`, abort at `maxRepeatedActions+2` (`webAgent.ts:1217-1276`). Warning returns intervention result with `pageChanged:true` to force snapshot; abort emits `TASK_ABORTED`.
+- ⚠️ Tracks ONE action per turn. With batching, multiple actions execute per turn — detector must consider each (issue's noted dependency).
+
+## 4. WebAgentOptions + events
+
+- `WebAgentOptions` interface `webAgent.ts:66-103`. Has `maxIterations, maxConsecutiveErrors, maxTotalErrors, maxValidationAttempts, maxRepeatedActions, initialNavigationRetries, guardrails, searchProvider, ...`. **No `maxActionsPerStep` yet** — this is the new field.
+- `AGENT_ACTION` emitted per-tool in `tools/webActionTools.ts:79-83` (start of `performActionWithValidation`), payload `{ action, ref?, value? }`. Already per-action, so a batch naturally emits multiple — matches issue section B.
+- Events defined in `events.ts` (WebAgentEventType enum + payload types).
+
+## 5. Validator-on-done
+
+- Triggered only when `isTerminal && action === "done"` (`webAgent.ts:1127-1130`).
+- `validateTaskCompletion()` `webAgent.ts:1291-1426`: builds validation prompt, calls `generateTextWithRetry` with `createValidationTools()`, reads `completionQuality` ∈ {failed, partial, complete, excellent}; accepts on complete/excellent (`webAgent.ts:1364`), force-accepts at max attempts (`webAgent.ts:1387`).
+- On accept → terminal success return `webAgent.ts:1137-1144`. On reject → non-terminal, feedback already in messages, `pageChanged:false` to avoid snapshot `webAgent.ts:1148-1154`.
+- ⚠️ For batching: if `done` appears mid-batch, only actions before it should run, then validate `done`; nothing after `done`.
+
+## 6. Test conventions — `packages/core/test/webAgent.test.ts`
+
+- `vi.mock("ai", ...)` stubs `streamText` + `tool` (`webAgent.test.ts:14-26`); `generateTextWithRetry` mocked separately.
+- `createMockStreamResponse(response)` factory `webAgent.test.ts:41-116` builds a `fullStream` async-iterator that yields `reasoning-*` then **iterates over `response.toolResults` yielding `tool-call`/`tool-result` per entry** — so multi-tool batches are already expressible in the mock. Returns promise-wrapped `toolResults`, `response`, `finishReason`, etc.
+- Usage pattern `webAgent.test.ts:327-406`: planning via `mockGenerateTextWithRetry.mockResolvedValueOnce`, action via `mockStreamText.mockReturnValueOnce(createMockStreamResponse({ toolResults:[...], response:{messages:[...]} }))`, validation via `mockValidationResponse("complete")`. Tool result entries include `toolCallId, toolName, input, output` (output = ActionResult).
+- Browser mock implements `AriaBrowser` (`webAgent.test.ts:147-226`); logger mock captures all events into `events[]` (`webAgent.test.ts:229-248`); fake timers in `beforeEach`/`afterEach`.
+
+## Deltas from the issue's assumptions
+
+1. **Line numbers** all shifted (issue cited ~905/1011/1019; real: streamText 958, drop 1081, `[0]` 1096, zero-tool 1067). Issue said to verify — done.
+2. **`pageChanged` already exists and is the inverse concept.** Don't reuse it as the batch terminator; introduce a distinct `isBatchTerminating(action)` (or "safe-to-batch" allowlist). Safe-to-batch candidates: `fill, select, check, uncheck, focus, hover`. Terminating: `click, enter, goto, back, forward, webSearch, extract?, done, abort, scroll, wait?`.
+3. **`isTerminal` is not on the base ActionResult type** — it's added by `done`/`abort` returns. The batch loop's `output.isTerminal` check works because of that.
+4. **`webSearch` is conditional** (only when search provider configured); the batch terminator classifier must handle its possible absence gracefully.
+5. **The multi-tool drop path already exists** (1081-1094) and is the natural hook to convert into batch execution.
+6. **Test harness already supports multi-tool mocks** — `createMockStreamResponse` iterates `toolResults`.

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
@@ -75,16 +75,18 @@ Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, s
 
 ## Eval findings (partial WebVoyager suite, pilo-evals-judge)
 
-Run via `evals/partial/...` branches with the config default raised to 5 (throwaway commit). Two runs:
+Run via throwaway `evals/partial/...` branches (eval branches since deleted; GCS reports persist). Three runs:
 
-| Run          | toolChoice (batch path) | Pass rate       | Zero-tool cascades   |
-| ------------ | ----------------------- | --------------- | -------------------- |
-| #1 (`9qmv6`) | `"auto"`                | 50% (15/30)     | **8 of 15 failures** |
-| #2 (`lzq6d`) | `"required"`            | **80% (24/30)** | **0**                |
+| Run                | toolChoice   | maxActionsPerStep | Pass rate       | Zero-tool cascades   |
+| ------------------ | ------------ | ----------------- | --------------- | -------------------- |
+| #1 (`9qmv6`)       | `"auto"`     | 5                 | 50% (15/30)     | **8 of 15 failures** |
+| #2 (`lzq6d`)       | `"required"` | 5                 | **80% (24/30)** | **0**                |
+| baseline (`9xr8w`) | `"required"` | 1 (batch off)     | 63% (19/30)     | 0                    |
 
 - **The `"auto"` flip was a regression.** With `"auto"`, the model returned zero tool calls on hard tasks (Google Flights, Maps, Apple, GitHub, Huggingface), repeatedly tripping the zero-tool error until `maxConsecutiveErrors` aborted the task. `"required"` (forces ≥1 tool, still allows several) eliminated all 8 cascades. → drove the `toolChoice: "required"` decision above.
 - **Batching genuinely occurs under `"required"`:** across 221 turns, ~15% emitted >1 tool (18×2, 3×3, 3×4, 8×5, 1×9-capped-to-5) → ~24% fewer LLM round-trips on this suite; tokens down 28% (partly from removing the cascade-retry loops). The 2–3× headline is form-density-specific; WebVoyager is search/navigate-heavy, so the win here is modest but real.
-- **`maxActionsPerStep=5` is correctness-neutral here.** Remaining 6 failures at 80% are environmental/known-hard (3 bot-detection, 1 render, 1 Booking date-picker, 1 stale-ref) — none batching-caused. The cap was exercised (8 turns at 5; one 9-tool turn capped to 5, exercising the drop→force-snapshot path).
+- **Batching at 5 is correctness-neutral vs the default-1 baseline.** Batching-5 (80%) ≥ baseline (63%), but the gap is dominated by environmental noise, not batching: bot-detection failures alone were 6 (baseline) vs 3 (batching-5) — purely random CAPTCHA luck — and the specific failing tasks shuffle between runs (the signature of run-to-run flakiness). With n=1 per config we can't claim batching _improves_ accuracy; the defensible conclusion is it doesn't hurt it. The dominant failure mode in every run is environmental (bot detection / render), unrelated to this PR.
+- **`maxActionsPerStep=5` cap exercised:** 8 turns at 5; one 9-tool turn capped to 5 (exercising the drop→force-snapshot path). No correctness fallout from the aggressive cap.
 
 ## Open questions
 

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
@@ -22,7 +22,7 @@ Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, s
 ## Desired end state
 
 - New option `WebAgentOptions.maxActionsPerStep?: number`, default **1** (exact current behavior preserved). Recommended production value 3.
-- When `maxActionsPerStep > 1`: `toolChoice: "auto"` (so the model may emit several tool calls) and the prompt invites batching up to N. When `=== 1`: `toolChoice: "required"` and the "exactly one tool" prompt, unchanged.
+- `toolChoice` stays `"required"` in all modes. The prompt invites batching ("up to N") when `maxActionsPerStep > 1`; at `=== 1` it renders the "exactly one tool" instruction. **(Revised post-eval — see "Eval findings". The original design flipped to `"auto"` when batching, but that let the model return zero tools and cascade into consecutive-error aborts. `"required"` forces ≥1 tool while still permitting several per turn.)**
 - **Unified processing loop.** Because execution is eager (all returned tools already ran), the loop's job is to _process_ the executed results in order and produce one aggregated turn-result. Take `toProcess = toolResults.slice(0, maxActionsPerStep)`; for any results beyond the cap, keep the existing `SYSTEM_DEBUG_TOOL_DROP` emit. When `maxActionsPerStep === 1` this reduces to today's exact behavior (process `[0]`, drop+emit the rest). Process `toProcess` in order, **stopping at the first terminal action or the first error**:
   - Regular (non-terminal, success) action → count it; track `pageChanged ||= (action !== "extract" && action !== "webSearch")`.
   - Terminal (`done`/`abort`) → run existing terminal handling (validation / abort) and return; ignore any later results (they executed but are irrelevant).
@@ -30,7 +30,7 @@ Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, s
 - **Safety comes from the prompt, not the loop.** The classifier `isBatchTerminating()` is only used in the _prompt guidance_ framing (which actions to put last) and is not a code gate on execution. Safe-to-batch (model is told these may precede others): `fill, select, check, uncheck, focus`. Page-changing / must-be-last: everything else. If the model mis-orders and a later action runs against a changed page, it typically returns a recoverable error (stale ref) → fed back → model retries.
 - Refs are stable across actions the model batches _only if_ no page-changer precedes them — which the prompt enforces by ordering, not the code.
 - Repetition check unchanged in shape: called once on the **last processed non-terminal action** (current call site `webAgent.ts:1177`). Per-action tracking deferred to PR 2.
-- Zero-tool case: keep throwing, but soften the message wording when `maxActionsPerStep > 1` (e.g. "You must use at least one tool"). With `toolChoice:"auto"` some providers may return zero tools more often; the existing recoverable feedback path handles it.
+- Zero-tool case: keep throwing, but soften the message wording when `maxActionsPerStep > 1` (e.g. "You must use at least one tool"). With `toolChoice:"required"` zero-tool is rare (provider edge case), same as today's default path.
 - System prompt updated to describe batching (see Patterns), parameterized on `maxActionsPerStep`.
 - Telemetry via a **new** `SYSTEM_DEBUG_BATCH` event (mirroring `SYSTEM_DEBUG_TOOL_DROP`) emitted after the processing loop: `{ iterationId, actionsRequested: number (= toolResults.length), actionsProcessed: number, batchStoppedBy: "terminal" | "error" | "completed" }`. (The issue proposed putting these on `AI_GENERATION`, but that event fires _before_ tool processing — `webAgent.ts:1050` — so `actionsProcessed`/`batchStoppedBy` aren't known there. A dedicated post-processing event is the correct home.)
 - Expose via the existing config schema (`config/defaults.ts`): add `max_actions_per_step` (default 1) which auto-generates the `--max-actions-per-step` CLI flag + `PILO_MAX_ACTIONS_PER_STEP` env var, matching the `max_iterations`/`max_repeated_actions` pattern. Wire `cfg.max_actions_per_step` into the CLI's `new WebAgent(...)` call (`cli/src/commands/run.ts:310-318`). This makes the latency eval runnable. (Server wiring deferred — see NOT doing.)
@@ -49,7 +49,7 @@ Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, s
 - **Decision:** Unify the processing loop around `toolResults.slice(0, maxActionsPerStep)` rather than branching on `maxActionsPerStep > 1`. Keep the `SYSTEM_DEBUG_TOOL_DROP` emit for results beyond the cap.
   - **Why:** When `maxActionsPerStep === 1`, `slice(0,1)` + drop-emit reproduces today's exact behavior — no separate default code path to keep in sync.
   - **Rejected:** A parallel `if (maxActionsPerStep>1)` block duplicating terminal/error/repetition handling.
-- **Decision:** Default `maxActionsPerStep = 1`; new behavior gated entirely on `> 1` (only changes `toolChoice` and prompt wording).
+- **Decision:** Default `maxActionsPerStep = 1`; new behavior gated entirely on `> 1` (only changes the prompt wording — `toolChoice` is `"required"` either way).
   - **Why:** Backwards-compat and easy rollback, per the issue's feature-flag guidance.
 - **Decision:** Repetition detector left as-is; called once on the **last processed non-terminal action** (current call site `webAgent.ts:1177` preserved).
   - **Why:** Per-action repetition tracking is a separable refactor (deferred to PR 2). Default path unchanged; batched path degrades gracefully (slightly weaker coverage, not incorrect).
@@ -72,6 +72,19 @@ Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, s
 - **Provider-specific tuning** or per-provider default `maxActionsPerStep` values.
 - **Changing default behavior** — default stays 1; no existing test should change its expectations.
 - **The manual latency eval itself** — that's a real-provider run for Les to execute (the CLI flag enables it); not something this session validates in CI.
+
+## Eval findings (partial WebVoyager suite, pilo-evals-judge)
+
+Run via `evals/partial/...` branches with the config default raised to 5 (throwaway commit). Two runs:
+
+| Run          | toolChoice (batch path) | Pass rate       | Zero-tool cascades   |
+| ------------ | ----------------------- | --------------- | -------------------- |
+| #1 (`9qmv6`) | `"auto"`                | 50% (15/30)     | **8 of 15 failures** |
+| #2 (`lzq6d`) | `"required"`            | **80% (24/30)** | **0**                |
+
+- **The `"auto"` flip was a regression.** With `"auto"`, the model returned zero tool calls on hard tasks (Google Flights, Maps, Apple, GitHub, Huggingface), repeatedly tripping the zero-tool error until `maxConsecutiveErrors` aborted the task. `"required"` (forces ≥1 tool, still allows several) eliminated all 8 cascades. → drove the `toolChoice: "required"` decision above.
+- **Batching genuinely occurs under `"required"`:** across 221 turns, ~15% emitted >1 tool (18×2, 3×3, 3×4, 8×5, 1×9-capped-to-5) → ~24% fewer LLM round-trips on this suite; tokens down 28% (partly from removing the cascade-retry loops). The 2–3× headline is form-density-specific; WebVoyager is search/navigate-heavy, so the win here is modest but real.
+- **`maxActionsPerStep=5` is correctness-neutral here.** Remaining 6 failures at 80% are environmental/known-hard (3 bot-detection, 1 render, 1 Booking date-picker, 1 stale-ref) — none batching-caused. The cap was exercised (8 turns at 5; one 9-tool turn capped to 5, exercising the drop→force-snapshot path).
 
 ## Open questions
 

--- a/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
+++ b/docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md
@@ -1,0 +1,79 @@
+# Multi-action per turn — core batching Spec
+
+**Goal:** Let the web agent execute several safe, non-navigating actions (e.g. filling multiple form fields) in a single LLM turn, cutting round-trips — the dominant latency — without changing default behavior.
+
+**Source:** https://github.com/mozilla/pilo/issues/438 (this spec is PR 1 of a phased delivery)
+
+## Current state
+
+The per-turn loop `generateAndProcessAction()` (`webAgent.ts:931-1190`) enforces one action per turn:
+
+- `streamText` uses `toolChoice: "required"` (`webAgent.ts:958-966`).
+- When a provider returns >1 tool call, the extras are **dropped**: keep `toolResults[0]`, warn, emit `SYSTEM_DEBUG_TOOL_DROP` (`webAgent.ts:1081-1094`). Single result consumed at `webAgent.ts:1096`.
+- Zero tool calls → `ToolExecutionError("You must use exactly one tool")` (`webAgent.ts:1067-1075`), caught as recoverable.
+- The system prompt repeats "EXACTLY ONE tool" in `prompts.ts` (tool-call instruction + per-step + error-feedback templates).
+
+A `pageChanged` flag already exists (`webAgent.ts:1124`): `action !== "extract" && action !== "webSearch"` — it decides whether to snapshot next turn, and treats nearly every action (including `fill`) as page-changing. It is **not** the same concept as "safe to batch" and must not be overloaded. See `research.md` §2.
+
+Action tools: `click, fill, select, hover, check, uncheck, focus, enter, wait, scroll, goto, back, forward, extract, done, abort` (`tools/webActionTools.ts:159-457`), plus conditional `webSearch` (`tools/searchTools.ts:22`, only when `searchProvider !== "none"`). `done`/`abort` return an extended result carrying `isTerminal:true` (`webActionTools.ts:438,453`); base `ActionResult` (`webActionTools.ts:40-52`) has no `isTerminal`.
+
+**Eager execution (load-bearing).** Every tool has an `execute` fn that performs the browser action immediately (`webActionTools.ts:166-241`). With AI SDK v6 `streamText` (single step, no `stopWhen`/`maxSteps`), when the model returns N tool calls in one assistant message, the SDK runs **all N** `execute` fns before `streamResult.toolResults` resolves. So by the time the loop inspects results, every returned action has already hit the browser — the current drop path (`webAgent.ts:1081-1094`) drops them from _processing_, not from _execution_. The caller (`webAgent.ts:527-545`) consumes one aggregated turn-result: `actionCount++` once, `needsPageSnapshot = result.pageChanged`, terminal breaks the loop. Recoverable errors are surfaced by `throw`ing `ToolExecutionError`, caught at `webAgent.ts:546` (trackError + retry).
+
+## Desired end state
+
+- New option `WebAgentOptions.maxActionsPerStep?: number`, default **1** (exact current behavior preserved). Recommended production value 3.
+- When `maxActionsPerStep > 1`: `toolChoice: "auto"` (so the model may emit several tool calls) and the prompt invites batching up to N. When `=== 1`: `toolChoice: "required"` and the "exactly one tool" prompt, unchanged.
+- **Unified processing loop.** Because execution is eager (all returned tools already ran), the loop's job is to _process_ the executed results in order and produce one aggregated turn-result. Take `toProcess = toolResults.slice(0, maxActionsPerStep)`; for any results beyond the cap, keep the existing `SYSTEM_DEBUG_TOOL_DROP` emit. When `maxActionsPerStep === 1` this reduces to today's exact behavior (process `[0]`, drop+emit the rest). Process `toProcess` in order, **stopping at the first terminal action or the first error**:
+  - Regular (non-terminal, success) action → count it; track `pageChanged ||= (action !== "extract" && action !== "webSearch")`.
+  - Terminal (`done`/`abort`) → run existing terminal handling (validation / abort) and return; ignore any later results (they executed but are irrelevant).
+  - Error result (`!success && error`) → `throw` exactly as the single-action path does today (`ToolExecutionError` if `isRecoverable`, else `Error`). Earlier successful actions are already in `this.messages` (appended from `response.messages` at `webAgent.ts:1043-1047`), so the model sees them next turn.
+- **Safety comes from the prompt, not the loop.** The classifier `isBatchTerminating()` is only used in the _prompt guidance_ framing (which actions to put last) and is not a code gate on execution. Safe-to-batch (model is told these may precede others): `fill, select, check, uncheck, focus`. Page-changing / must-be-last: everything else. If the model mis-orders and a later action runs against a changed page, it typically returns a recoverable error (stale ref) → fed back → model retries.
+- Refs are stable across actions the model batches _only if_ no page-changer precedes them — which the prompt enforces by ordering, not the code.
+- Repetition check unchanged in shape: called once on the **last processed non-terminal action** (current call site `webAgent.ts:1177`). Per-action tracking deferred to PR 2.
+- Zero-tool case: keep throwing, but soften the message wording when `maxActionsPerStep > 1` (e.g. "You must use at least one tool"). With `toolChoice:"auto"` some providers may return zero tools more often; the existing recoverable feedback path handles it.
+- System prompt updated to describe batching (see Patterns), parameterized on `maxActionsPerStep`.
+- Telemetry via a **new** `SYSTEM_DEBUG_BATCH` event (mirroring `SYSTEM_DEBUG_TOOL_DROP`) emitted after the processing loop: `{ iterationId, actionsRequested: number (= toolResults.length), actionsProcessed: number, batchStoppedBy: "terminal" | "error" | "completed" }`. (The issue proposed putting these on `AI_GENERATION`, but that event fires _before_ tool processing — `webAgent.ts:1050` — so `actionsProcessed`/`batchStoppedBy` aren't known there. A dedicated post-processing event is the correct home.)
+- Expose via the existing config schema (`config/defaults.ts`): add `max_actions_per_step` (default 1) which auto-generates the `--max-actions-per-step` CLI flag + `PILO_MAX_ACTIONS_PER_STEP` env var, matching the `max_iterations`/`max_repeated_actions` pattern. Wire `cfg.max_actions_per_step` into the CLI's `new WebAgent(...)` call (`cli/src/commands/run.ts:310-318`). This makes the latency eval runnable. (Server wiring deferred — see NOT doing.)
+
+## Design decisions
+
+- **Decision:** Safety is prompt-driven, not code-gated (Les's choice — see #438 brainstorm). The AI SDK executes all returned tool calls eagerly, so the code cannot prevent a mis-ordered action from running. We instead (a) cap how many tools the model is invited to call via `maxActionsPerStep`, and (b) instruct it to batch only safe actions and put any page-changer last. The recoverable-error path is the safety net for mis-ordering.
+  - **Why:** True execution control would require stripping `execute` from the tools and running them manually (synthesizing tool-result messages by hand) — a much larger change, rejected as out of scope for PR 1.
+  - **Rejected:** Manual execution control (Option B in brainstorm); slicing-to-prevent-execution (impossible — execution already happened by await time).
+- **Decision:** `isBatchTerminating(action: string): boolean` exists to drive the _prompt guidance wording_ (safe set = `fill, select, check, uncheck, focus`; everything else, incl. unknown names, is "page-changing / last"). It is **not** a runtime gate on the processing loop.
+  - **Why:** A single source of truth for the safe/unsafe split keeps the prompt and any future logic consistent; unknown actions default to "terminating/unsafe" (fail safe).
+  - **Rejected:** Reusing the existing `pageChanged` flag (`webAgent.ts:1124`) — it is the inverse concept (snapshot-driver that treats fills as page-changing).
+- **Decision:** `select` is in the safe set.
+  - **Why:** Les's call; a dropdown `onchange` that navigates is rare, and if it happens the trailing batched actions return recoverable stale-ref errors that self-heal next turn. Revisit if evals show breakage.
+  - **Rejected:** Treating `select` as page-changing (smaller wins for the common multi-select form).
+- **Decision:** Unify the processing loop around `toolResults.slice(0, maxActionsPerStep)` rather than branching on `maxActionsPerStep > 1`. Keep the `SYSTEM_DEBUG_TOOL_DROP` emit for results beyond the cap.
+  - **Why:** When `maxActionsPerStep === 1`, `slice(0,1)` + drop-emit reproduces today's exact behavior — no separate default code path to keep in sync.
+  - **Rejected:** A parallel `if (maxActionsPerStep>1)` block duplicating terminal/error/repetition handling.
+- **Decision:** Default `maxActionsPerStep = 1`; new behavior gated entirely on `> 1` (only changes `toolChoice` and prompt wording).
+  - **Why:** Backwards-compat and easy rollback, per the issue's feature-flag guidance.
+- **Decision:** Repetition detector left as-is; called once on the **last processed non-terminal action** (current call site `webAgent.ts:1177` preserved).
+  - **Why:** Per-action repetition tracking is a separable refactor (deferred to PR 2). Default path unchanged; batched path degrades gracefully (slightly weaker coverage, not incorrect).
+  - **Rejected:** Full per-action rework here (scope creep; it's its own issue).
+
+## Patterns to follow
+
+- **Processing loop** replaces `webAgent.ts:1081-1096`: `toProcess = toolResults.slice(0, maxActionsPerStep)`; keep `SYSTEM_DEBUG_TOOL_DROP` for results beyond `toProcess`. Iterate `toProcess` in order; stop at first terminal action or first error. Accumulate `pageChanged` and processed-count for the aggregated turn-result.
+- **Terminal handling** reuse the existing `isTerminal` + `action==="done"/"abort"` blocks (`webAgent.ts:1127-1170`) — feed the terminal action through them unchanged.
+- **Error handling** reuse the existing throw at `webAgent.ts:1108-1120` (`ToolExecutionError` if recoverable, else `Error`) for the first error result encountered.
+- **Prompt updates** mirror existing template structure in `prompts.ts`: the tool-call instruction (~`prompts.ts:213-217` per issue) plus the per-step snapshot and error-feedback templates. Add the issue's "Action batching" guidance block, parameterized on `maxActionsPerStep`; when it's 1, keep the "exactly one tool" wording.
+- **Event payload** extend the object built at `webAgent.ts:1050-1059`; update the corresponding payload type in `events.ts`.
+- **Tests** follow `webAgent.test.ts` conventions: `createMockStreamResponse({ toolResults:[...] })` (`webAgent.test.ts:41-116`) already yields multiple `tool-call`/`tool-result` pairs; assert on the `events[]` logger capture (`webAgent.test.ts:229-248`).
+
+## What we're NOT doing
+
+- **Per-action repetition-detector rework** (`checkAndHandleRepeatedAction`, `createActionSignature`) — deferred to PR 2 / a follow-up issue. This PR keeps the single-signature tracking.
+- **Server-side wiring** of `maxActionsPerStep` (HTTP API / config). CLI flag only, just enough to run the eval. Server can adopt the core option later.
+- **Adjusting the `pageChanged`/snapshot logic** beyond what batching requires.
+- **Provider-specific tuning** or per-provider default `maxActionsPerStep` values.
+- **Changing default behavior** — default stays 1; no existing test should change its expectations.
+- **The manual latency eval itself** — that's a real-provider run for Les to execute (the CLI flag enables it); not something this session validates in CI.
+
+## Open questions
+
+- **Should `hover` ever be safe-to-batch?** Default answer: **no** (page-changing), per Les's "form-fill only" choice. Revisit only if a concrete combobox/menu case needs `focus`+`hover` batched.
+- **`batchStoppedBy` mapping.** Default answer: `"terminal"` when processing stopped at a `done`/`abort`; `"error"` when stopped at an error result; `"completed"` when all of `toProcess` was processed without hitting either. (Eager execution means there is no "page-change truncation" — the SDK already ran everything; this field reports why _processing_ stopped.)

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -324,6 +324,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       maxIterations: options.maxIterations ?? cfg.max_iterations,
       maxValidationAttempts: options.maxValidationAttempts ?? cfg.max_validation_attempts,
       maxRepeatedActions: options.maxRepeatedActions ?? cfg.max_repeated_actions,
+      maxActionsPerStep: options.maxActionsPerStep ?? cfg.max_actions_per_step,
       initialNavigationRetries: options.initialNavigationRetries ?? cfg.initial_navigation_retries,
       maxConsecutiveErrors: options.maxConsecutiveErrors ?? cfg.max_consecutive_errors,
       maxTotalErrors: options.maxTotalErrors ?? cfg.max_total_errors,

--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -3227,6 +3227,43 @@
       ],
       "description": "Top-level discriminated union of every event a `/v1/automate` SSE client can receive on the wire. Composes  {@link  WebAgentEvent }  (agent-loop events emitted via  {@link  WebAgentEventEmitter } ) with the stream-wrapper events (`complete`, `done`, `error`) emitted by the HTTP route handler after the agent returns.\n\nThis is the authoritative source-of-truth for downstream SDK generation. Its JSON Schema export (`schemas/automate-stream-event.json`) is consumed by tabs-api to type `/v1/automate`'s SSE response in `@tabstack/sdk`."
     },
+    "BatchDebugEventData": {
+      "additionalProperties": false,
+      "description": "Emitted after a multi-action turn is processed (when maxActionsPerStep > 1).",
+      "properties": {
+        "actionsProcessed": {
+          "description": "Number of those the loop processed before stopping.",
+          "type": "number"
+        },
+        "actionsRequested": {
+          "description": "Number of tool calls the model returned this turn.",
+          "type": "number"
+        },
+        "batchStoppedBy": {
+          "description": "Why processing stopped: hit a terminal action, an error, or ran the whole batch.",
+          "enum": [
+            "terminal",
+            "error",
+            "completed"
+          ],
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "actionsProcessed",
+        "actionsRequested",
+        "batchStoppedBy",
+        "iterationId",
+        "timestamp"
+      ],
+      "type": "object"
+    },
     "BrowserReconnectedEventData": {
       "additionalProperties": false,
       "description": "Event data when the browser reconnects after a mid-task disconnect",
@@ -4674,6 +4711,23 @@
             },
             "type": {
               "const": "system:debug_tool_drop",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/BatchDebugEventData"
+            },
+            "type": {
+              "const": "system:debug_batch",
               "type": "string"
             }
           },

--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -3229,7 +3229,7 @@
     },
     "BatchDebugEventData": {
       "additionalProperties": false,
-      "description": "Emitted after a multi-action turn is processed (when maxActionsPerStep > 1).",
+      "description": "Emitted after each action turn is processed, reporting how many of the returned tool calls were processed and why processing stopped. Fires on every turn (including the single-action default), so consumers can rely on it.",
       "properties": {
         "actionsProcessed": {
           "description": "Number of those the loop processed before stopping.",

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -104,6 +104,7 @@ export interface PiloConfig {
   max_iterations?: number;
   max_validation_attempts?: number;
   max_repeated_actions?: number;
+  max_actions_per_step?: number;
   max_consecutive_errors?: number;
   max_total_errors?: number;
   initial_navigation_retries?: number;
@@ -178,6 +179,7 @@ export interface PiloConfigResolved {
   max_iterations: number;
   max_validation_attempts: number;
   max_repeated_actions: number;
+  max_actions_per_step: number;
   max_consecutive_errors: number;
   max_total_errors: number;
   initial_navigation_retries: number;
@@ -491,6 +493,15 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     placeholder: "n",
     env: ["PILO_MAX_REPEATED_ACTIONS"],
     description: "Maximum times an action can be repeated before warning",
+    category: "agent",
+  },
+  max_actions_per_step: {
+    default: 1,
+    type: "number",
+    cli: "--max-actions-per-step",
+    placeholder: "n",
+    env: ["PILO_MAX_ACTIONS_PER_STEP"],
+    description: "Maximum tool calls the agent may batch in one turn (1 = one action per turn)",
     category: "agent",
   },
   max_consecutive_errors: {

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -105,6 +105,7 @@ export const DEFAULT_BYPASS_CSP = _defaults.bypass_csp;
 export const DEFAULT_MAX_ITERATIONS = _defaults.max_iterations;
 export const DEFAULT_MAX_VALIDATION_ATTEMPTS = _defaults.max_validation_attempts;
 export const DEFAULT_MAX_REPEATED_ACTIONS = _defaults.max_repeated_actions;
+export const DEFAULT_MAX_ACTIONS_PER_STEP = _defaults.max_actions_per_step;
 export const DEFAULT_MAX_CONSECUTIVE_ERRORS = _defaults.max_consecutive_errors;
 export const DEFAULT_MAX_TOTAL_ERRORS = _defaults.max_total_errors;
 export const DEFAULT_INITIAL_NAVIGATION_RETRIES = _defaults.initial_navigation_retries;

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -41,6 +41,7 @@ export enum WebAgentEventType {
   SYSTEM_DEBUG_COMPRESSION = "system:debug_compression",
   SYSTEM_DEBUG_MESSAGE = "system:debug_message",
   SYSTEM_DEBUG_TOOL_DROP = "system:debug_tool_drop",
+  SYSTEM_DEBUG_BATCH = "system:debug_batch",
 
   // CDP endpoint failover
   CDP_ENDPOINT_CONNECTED = "cdp:endpoint_connected",
@@ -290,6 +291,16 @@ export interface ToolDropDebugEventData extends WebAgentEventData {
   keptTool: string;
 }
 
+/** Emitted after a multi-action turn is processed (when maxActionsPerStep > 1). */
+export interface BatchDebugEventData extends WebAgentEventData {
+  /** Number of tool calls the model returned this turn. */
+  actionsRequested: number;
+  /** Number of those the loop processed before stopping. */
+  actionsProcessed: number;
+  /** Why processing stopped: hit a terminal action, an error, or ran the whole batch. */
+  batchStoppedBy: "terminal" | "error" | "completed";
+}
+
 /**
  * Event data for waiting notifications
  */
@@ -411,6 +422,7 @@ export type WebAgentEvent =
   | { type: WebAgentEventType.SYSTEM_DEBUG_COMPRESSION; data: CompressionDebugEventData }
   | { type: WebAgentEventType.SYSTEM_DEBUG_MESSAGE; data: MessagesDebugEventData }
   | { type: WebAgentEventType.SYSTEM_DEBUG_TOOL_DROP; data: ToolDropDebugEventData }
+  | { type: WebAgentEventType.SYSTEM_DEBUG_BATCH; data: BatchDebugEventData }
   | { type: WebAgentEventType.CDP_ENDPOINT_CONNECTED; data: CdpEndpointConnectedEventData }
   | { type: WebAgentEventType.CDP_ENDPOINT_CYCLE; data: CdpEndpointCycleEventData }
   | { type: WebAgentEventType.BROWSER_RECONNECTED; data: BrowserReconnectedEventData }

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -291,7 +291,11 @@ export interface ToolDropDebugEventData extends WebAgentEventData {
   keptTool: string;
 }
 
-/** Emitted after a multi-action turn is processed (when maxActionsPerStep > 1). */
+/**
+ * Emitted after each action turn is processed, reporting how many of the
+ * returned tool calls were processed and why processing stopped. Fires on every
+ * turn (including the single-action default), so consumers can rely on it.
+ */
 export interface BatchDebugEventData extends WebAgentEventData {
   /** Number of tool calls the model returned this turn. */
   actionsRequested: number;

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -215,12 +215,31 @@ function buildToolExamples(
   return lines.join("\n");
 }
 
-/** Standard tool calling instruction. */
+/** Standard tool calling instruction (one tool per turn). */
 const toolCallInstruction = `
 You MUST use exactly one tool with the required parameters.
 Use valid JSON format for all arguments.
 CRITICAL: Use each tool exactly ONCE. Do not repeat or duplicate the same tool call multiple times.
 `.trim();
+
+/** Tool calling instruction when batching is enabled (up to N tools per turn). */
+const batchingToolCallInstruction = (maxActionsPerStep: number): string =>
+  `
+You may call up to ${maxActionsPerStep} tools in one turn, but ONLY for related actions that
+do not change the page (filling several fields of the same form, focusing inputs, checking
+boxes). Any page-changing action — click, enter, goto, back, forward, scroll, webSearch,
+extract, done, abort — MUST be the LAST call in the turn, or the only call. Actions placed
+after a page-changing call run against a stale page and will fail.
+
+Safe to batch together (before any page-changing action): fill, select, check, uncheck, focus.
+Must be last or alone: everything else.
+
+Use valid JSON format for all arguments. Do not call the same tool with identical arguments more than once.
+`.trim();
+
+/** Instruction text for the action loop, parameterized on the per-turn action cap. */
+const toolCallInstructionFor = (maxActionsPerStep: number): string =>
+  maxActionsPerStep > 1 ? batchingToolCallInstruction(maxActionsPerStep) : toolCallInstruction;
 
 /**
  * Base planning prompt content - shared across all planning prompt variants.
@@ -328,7 +347,7 @@ Analyze the current page state and determine your next action based on previous 
 
 **Core Rules:**
 1. Use element refs from page snapshot. They are found in square brackets: [ref=${TOOL_STRINGS.webActions.common.elementRefExample}].
-2. Execute EXACTLY ONE tool per turn
+{% if maxActionsPerStep > 1 %}2. You may batch up to {{ maxActionsPerStep }} safe actions per turn; any page-changing action must be the last call{% else %}2. Execute EXACTLY ONE tool per turn{% endif %}
 3. Complete planned steps before using done()
 4. done() provides your final answer to the user
 5. goto() only accepts URLs from earlier in conversation
@@ -336,7 +355,7 @@ Analyze the current page state and determine your next action based on previous 
 7. DATA GROUNDING: Every value in your done() result and your reasoning must come from the page snapshot, a tool result, or the task input. Do not use training knowledge to fill gaps. If you cannot verify a value from the current session, say so explicitly.
 {% if hasGuardrails %}8. ALL actions MUST comply with provided guardrails{% endif %}
 
-**CRITICAL:** You MUST use exactly ONE tool with valid arguments EVERY turn. Choose:
+{% if maxActionsPerStep > 1 %}**CRITICAL:** Use 1–{{ maxActionsPerStep }} tools per turn, with any page-changing action last. Choose:{% else %}**CRITICAL:** You MUST use exactly ONE tool with valid arguments EVERY turn. Choose:{% endif %}
 - done(result) if task is complete
 - abort(reason) if task cannot be completed due to site issues, blocking, or missing data
 - Appropriate action tool if work remains
@@ -421,7 +440,7 @@ You MUST use request_user_data() for any form field that requires the user's per
 After clicking submit, check the next page snapshot for validation errors. Fields with errors will show [invalid] and [errormessage="..."] properties directly on the element. Error messages may also appear as text near the affected fields. If you see invalid fields, call request_user_data again immediately with reason "validation_error" for the affected fields only. Include any error message in each field's description so the user knows what went wrong.
 {% endif %}
 
-${toolCallInstruction}
+{{ toolCallInstruction }}
 `.trim(),
 );
 
@@ -432,6 +451,7 @@ const buildActionLoopSystemPrompt = (
   hasTabstack: boolean = false,
   hasStartingUrl: boolean = false,
   hasInteractive: boolean = false,
+  maxActionsPerStep: number = 1,
 ) =>
   actionLoopSystemPromptTemplate({
     hasGuardrails,
@@ -439,6 +459,8 @@ const buildActionLoopSystemPrompt = (
     hasTabstack,
     hasStartingUrl,
     hasInteractive,
+    maxActionsPerStep,
+    toolCallInstruction: toolCallInstructionFor(maxActionsPerStep),
     toolExamples: buildToolExamples(hasWebSearch, hasTabstack, hasInteractive),
     currentDate: getCurrentFormattedDate(),
   });
@@ -515,7 +537,7 @@ This shows the complete current page content.{% if hasScreenshot %} A labeled sc
 {% if hasScreenshot %}- Use the labeled screenshot to visually locate interactive elements and match them to [ref=E###] IDs in the tree{% endif %}
 - Follow all guardrails
 
-${toolCallInstruction}
+{{ toolCallInstruction }}
 `.trim(),
 );
 
@@ -524,6 +546,7 @@ export const buildPageSnapshotPrompt = (
   url: string,
   snapshot: string,
   hasScreenshot: boolean = false,
+  maxActionsPerStep: number = 1,
 ) => {
   const pageContent = `Title: ${title}\nURL: ${url}\n\n${snapshot}`;
   return pageSnapshotTemplate({
@@ -532,6 +555,7 @@ export const buildPageSnapshotPrompt = (
       ExternalContentLabel.PageSnapshot,
     ),
     hasScreenshot,
+    toolCallInstruction: toolCallInstructionFor(maxActionsPerStep),
     currentDate: getCurrentFormattedDate(),
   });
 };
@@ -557,7 +581,7 @@ CRITICAL: ALL TOOL CALLS MUST COMPLY WITH THE PROVIDED GUARDRAILS
 **Available Tools:**
 {{ toolExamples }}
 
-${toolCallInstruction}
+{{ toolCallInstruction }}
 `.trim(),
 );
 
@@ -566,10 +590,12 @@ export const buildStepErrorFeedbackPrompt = (
   hasGuardrails: boolean = false,
   hasWebSearch: boolean = false,
   hasTabstack: boolean = false,
+  maxActionsPerStep: number = 1,
 ) =>
   stepErrorFeedbackTemplate({
     error,
     hasGuardrails,
+    toolCallInstruction: toolCallInstructionFor(maxActionsPerStep),
     toolExamples: buildToolExamples(hasWebSearch, hasTabstack),
   });
 

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -222,6 +222,30 @@ Use valid JSON format for all arguments.
 CRITICAL: Use each tool exactly ONCE. Do not repeat or duplicate the same tool call multiple times.
 `.trim();
 
+/**
+ * Actions the model may batch (before a single trailing page-changing action)
+ * when `maxActionsPerStep > 1` — they mutate form state without navigating or
+ * invalidating other refs. Single source of truth for both the prompt guidance
+ * below and the `isBatchTerminating` classifier (re-exported from
+ * `tools/webActionTools.ts`). Defined here because the prompt is the consumer
+ * and `prompts.ts` already owns tool-facing metadata (TOOL_STRINGS).
+ */
+export const SAFE_TO_BATCH_ACTIONS: ReadonlySet<string> = new Set([
+  "fill",
+  "select",
+  "check",
+  "uncheck",
+  "focus",
+]);
+
+/**
+ * True when an action ends a batch — i.e. it is page-changing, terminal, or
+ * unrecognized. Unknown action names default to terminating (fail safe).
+ */
+export function isBatchTerminating(action: string): boolean {
+  return !SAFE_TO_BATCH_ACTIONS.has(action);
+}
+
 /** Tool calling instruction when batching is enabled (up to N tools per turn). */
 const batchingToolCallInstruction = (maxActionsPerStep: number): string =>
   `
@@ -231,7 +255,7 @@ boxes). Any page-changing action — click, enter, goto, back, forward, scroll, 
 extract, done, abort — MUST be the LAST call in the turn, or the only call. Actions placed
 after a page-changing call run against a stale page and will fail.
 
-Safe to batch together (before any page-changing action): fill, select, check, uncheck, focus.
+Safe to batch together (before any page-changing action): ${[...SAFE_TO_BATCH_ACTIONS].join(", ")}.
 Must be last or alone: everything else.
 
 Use valid JSON format for all arguments. Do not call the same tool with identical arguments more than once.

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -184,27 +184,10 @@ async function assessFormSubmissionForAction(
   return null;
 }
 
-/**
- * Actions that mutate form state without navigating or invalidating other refs.
- * When `maxActionsPerStep > 1`, the model may batch these before a single
- * trailing page-changing action. Single source of truth shared by the prompt
- * guidance (which actions are "safe to batch") and any batch logic.
- */
-export const SAFE_TO_BATCH_ACTIONS: ReadonlySet<string> = new Set([
-  "fill",
-  "select",
-  "check",
-  "uncheck",
-  "focus",
-]);
-
-/**
- * True when an action ends a batch — i.e. it is page-changing, terminal, or
- * unrecognized. Unknown action names default to terminating (fail safe).
- */
-export function isBatchTerminating(action: string): boolean {
-  return !SAFE_TO_BATCH_ACTIONS.has(action);
-}
+// Batch-action classification lives in prompts.ts (the prompt guidance is its
+// primary consumer, and prompts.ts owns tool-facing metadata). Re-exported here
+// so action-related consumers can import it from the tools module.
+export { SAFE_TO_BATCH_ACTIONS, isBatchTerminating } from "../prompts.js";
 
 /**
  * Helper function to perform an action with full error handling and logging

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -185,6 +185,28 @@ async function assessFormSubmissionForAction(
 }
 
 /**
+ * Actions that mutate form state without navigating or invalidating other refs.
+ * When `maxActionsPerStep > 1`, the model may batch these before a single
+ * trailing page-changing action. Single source of truth shared by the prompt
+ * guidance (which actions are "safe to batch") and any batch logic.
+ */
+export const SAFE_TO_BATCH_ACTIONS: ReadonlySet<string> = new Set([
+  "fill",
+  "select",
+  "check",
+  "uncheck",
+  "focus",
+]);
+
+/**
+ * True when an action ends a batch — i.e. it is page-changing, terminal, or
+ * unrecognized. Unknown action names default to terminating (fail safe).
+ */
+export function isBatchTerminating(action: string): boolean {
+  return !SAFE_TO_BATCH_ACTIONS.has(action);
+}
+
+/**
  * Helper function to perform an action with full error handling and logging
  * Handles browser exceptions and converts them to recoverable errors for the agent
  *

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -91,6 +91,8 @@ export interface WebAgentOptions {
   maxValidationAttempts?: number;
   /** Maximum times an action can be repeated before warning/aborting */
   maxRepeatedActions?: number;
+  /** Maximum tool calls the agent may batch in one turn (default 1 = one action per turn) */
+  maxActionsPerStep?: number;
   /** Number of times to retry initial navigation with browser restart (0 = no retries, default: 1) */
   initialNavigationRetries?: number;
   /** Search provider to use for web search (default: from config, typically "none") */
@@ -246,6 +248,7 @@ export class WebAgent {
   private readonly maxTotalErrors: number;
   private readonly maxValidationAttempts: number;
   private readonly maxRepeatedActions: number;
+  private readonly maxActionsPerStep: number;
   private readonly initialNavigationRetries: number;
   private readonly guardrails: string | null;
   private readonly searchProvider: SearchProviderName;
@@ -284,6 +287,7 @@ export class WebAgent {
     this.maxTotalErrors = options.maxTotalErrors ?? defaults.max_total_errors;
     this.maxValidationAttempts = options.maxValidationAttempts ?? defaults.max_validation_attempts;
     this.maxRepeatedActions = options.maxRepeatedActions ?? defaults.max_repeated_actions;
+    this.maxActionsPerStep = options.maxActionsPerStep ?? defaults.max_actions_per_step;
     this.initialNavigationRetries =
       options.initialNavigationRetries ?? defaults.initial_navigation_retries;
     this.guardrails = options.guardrails ?? null;
@@ -978,7 +982,9 @@ export class WebAgent {
             system: this.systemPrompt,
             messages: this.messages,
             tools: webActionTools,
-            toolChoice: "required",
+            // When batching is enabled, let the model emit several tool calls;
+            // otherwise require exactly one (historical behavior).
+            toolChoice: this.maxActionsPerStep > 1 ? "auto" : "required",
             maxOutputTokens: DEFAULT_GENERATION_MAX_TOKENS,
             abortSignal: this.abortSignal,
           });

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -751,6 +751,7 @@ export class WebAgent {
       Boolean(this.guardrails),
       this.searchProvider !== "none",
       Boolean(this.tabstackApiKey),
+      this.maxActionsPerStep,
     );
     this.messages.push({ role: "user", content: errorFeedback });
   }
@@ -888,6 +889,7 @@ export class WebAgent {
       currentPageInfo.url,
       compressedSnapshot,
       this.vision,
+      this.maxActionsPerStep,
     );
 
     // Handle vision mode with screenshots
@@ -1792,6 +1794,7 @@ export class WebAgent {
       hasTabstack,
       hasStartingUrl,
       hasInteractive,
+      this.maxActionsPerStep,
     );
 
     this.messages = [

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -991,9 +991,11 @@ export class WebAgent {
             system: this.systemPrompt,
             messages: this.messages,
             tools: webActionTools,
-            // When batching is enabled, let the model emit several tool calls;
-            // otherwise require exactly one (historical behavior).
-            toolChoice: this.maxActionsPerStep > 1 ? "auto" : "required",
+            // Always require a tool call. "required" forces the model to call at
+            // least one tool while still allowing several in one turn (batching),
+            // whereas "auto" lets the model return zero tools — which, on hard
+            // tasks, cascades into consecutive-error aborts (observed at eval).
+            toolChoice: "required",
             maxOutputTokens: DEFAULT_GENERATION_MAX_TOKENS,
             abortSignal: this.abortSignal,
           });

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -287,7 +287,12 @@ export class WebAgent {
     this.maxTotalErrors = options.maxTotalErrors ?? defaults.max_total_errors;
     this.maxValidationAttempts = options.maxValidationAttempts ?? defaults.max_validation_attempts;
     this.maxRepeatedActions = options.maxRepeatedActions ?? defaults.max_repeated_actions;
-    this.maxActionsPerStep = options.maxActionsPerStep ?? defaults.max_actions_per_step;
+    // Clamp to a sane integer ≥ 1: a value of 0/negative/NaN would make the
+    // processing loop's slice empty and crash the drop path (toProcess[0]).
+    const requestedMaxActions = options.maxActionsPerStep ?? defaults.max_actions_per_step;
+    this.maxActionsPerStep = Number.isFinite(requestedMaxActions)
+      ? Math.max(1, Math.floor(requestedMaxActions))
+      : 1;
     this.initialNavigationRetries =
       options.initialNavigationRetries ?? defaults.initial_navigation_retries;
     this.guardrails = options.guardrails ?? null;
@@ -1106,6 +1111,11 @@ export class WebAgent {
     // browser. Process up to maxActionsPerStep of them in order; results beyond
     // the cap already executed but are dropped from processing (this reproduces
     // the historical single-action behavior when the cap is 1).
+    let actionsProcessed = 0;
+    let anyPageChanged = false;
+    let lastNonTerminalOutput: any = null;
+    let batchStoppedBy: "terminal" | "error" | "completed" = "completed";
+
     const toProcess = aiResponse.toolResults.slice(0, this.maxActionsPerStep);
     if (aiResponse.toolResults.length > toProcess.length) {
       const droppedTools = aiResponse.toolResults
@@ -1121,12 +1131,11 @@ export class WebAgent {
         droppedTools,
         keptTool: toProcess[0].toolName,
       });
+      // Dropped actions already executed (eager AI SDK) and any of them may have
+      // navigated/changed the page. Force a snapshot refresh next turn so we
+      // don't run against stale refs even if the processed actions were no-refresh.
+      anyPageChanged = true;
     }
-
-    let actionsProcessed = 0;
-    let anyPageChanged = false;
-    let lastNonTerminalOutput: any = null;
-    let batchStoppedBy: "terminal" | "error" | "completed" = "completed";
 
     try {
       for (const tr of toProcess) {

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -559,9 +559,10 @@ export class WebAgent {
               return { flow: "break" as const };
             }
 
-            // Update state for successful action
+            // Update state for successful action(s). A batched turn may have
+            // executed several actions; count them all.
             if (result.actionExecuted) {
-              executionState.actionCount++;
+              executionState.actionCount += result.actionsProcessed ?? 1;
             }
 
             return { flow: "next" as const, needsPageSnapshot: result.pageChanged };
@@ -962,6 +963,7 @@ export class WebAgent {
     finalAnswer: string | null;
     pageChanged: boolean;
     actionExecuted: boolean;
+    actionsProcessed: number;
     error?: TaskError;
   }> {
     // Start processing - hasScreenshot is true if we're in vision mode and just captured a screenshot
@@ -1092,125 +1094,173 @@ export class WebAgent {
     // Process tool results
     if (!aiResponse?.toolResults?.length) {
       console.error("[WebAgent] No tools called in action generation");
-      throw new ToolExecutionError(
-        "You must use exactly one tool. Please use one of the available tools.",
-        {
-          action: "none",
-        },
-      );
+      const message =
+        this.maxActionsPerStep > 1
+          ? "You must use at least one tool. Please use one of the available tools."
+          : "You must use exactly one tool. Please use one of the available tools.";
+      throw new ToolExecutionError(message, { action: "none" });
     }
 
-    // The system prompt instructs the model to call exactly one tool per turn,
-    // but providers occasionally return more (especially on retries or with
-    // certain models). Warn + emit a debug event so the drop is observable
-    // instead of silently lost.
-    if (aiResponse.toolResults.length > 1) {
-      const keptTool = aiResponse.toolResults[0].toolName;
-      const droppedTools = aiResponse.toolResults.slice(1).map((r: any) => r.toolName);
+    // The AI SDK executes every returned tool's `execute` fn before toolResults
+    // resolves, so by now all returned actions have already run against the
+    // browser. Process up to maxActionsPerStep of them in order; results beyond
+    // the cap already executed but are dropped from processing (this reproduces
+    // the historical single-action behavior when the cap is 1).
+    const toProcess = aiResponse.toolResults.slice(0, this.maxActionsPerStep);
+    if (aiResponse.toolResults.length > toProcess.length) {
+      const droppedTools = aiResponse.toolResults
+        .slice(toProcess.length)
+        .map((r: any) => r.toolName);
       console.warn(
         `[WebAgent] Provider returned ${aiResponse.toolResults.length} tool calls in one turn; ` +
-          `keeping '${keptTool}', dropping: ${droppedTools.join(", ")}`,
+          `processing ${toProcess.length}, dropping: ${droppedTools.join(", ")}`,
       );
       this.emit(WebAgentEventType.SYSTEM_DEBUG_TOOL_DROP, {
         iterationId: this.currentIterationId,
         droppedCount: droppedTools.length,
         droppedTools,
-        keptTool,
+        keptTool: toProcess[0].toolName,
       });
     }
 
-    const toolResult = aiResponse.toolResults[0];
-    const actionOutput = toolResult.output as any;
+    let actionsProcessed = 0;
+    let anyPageChanged = false;
+    let lastNonTerminalOutput: any = null;
+    let batchStoppedBy: "terminal" | "error" | "completed" = "completed";
 
-    if (!actionOutput) {
-      throw new Error("Tool execution failed: missing output property.");
-    }
-
-    // Check if the tool returned an error
-    // The tool output structure is guaranteed to have:
-    // - success: boolean
-    // - error?: string (present when success is false)
-    // - isRecoverable?: boolean (present for browser errors)
-    if (!actionOutput.success && actionOutput.error) {
-      // For recoverable tool errors, throw ToolExecutionError
-      // This special error type indicates the error is already in the tool result,
-      // so we don't need to add it as a separate user message
-      if (actionOutput.isRecoverable) {
-        throw new ToolExecutionError(actionOutput.error, {
-          action: actionOutput.action,
-          ref: actionOutput.ref,
-          output: actionOutput, // Store the full output for debugging
-        });
-      }
-      // For non-recoverable errors, throw regular error
-      throw new Error(actionOutput.error);
-    }
-
-    const pageChanged = WebAgent.shouldRefreshPageSnapshotAfterAction(actionOutput.action);
-
-    // Check for terminal actions
-    if (actionOutput.isTerminal) {
-      if (actionOutput.action === "done") {
-        // Validate the task completion before accepting it
-        const validationResult = await this.validateTaskCompletion(
-          task,
-          actionOutput.result,
-          executionState,
-        );
-
-        // Check if validation passed
-        if (validationResult.isAccepted) {
-          return {
-            isTerminal: true,
-            success: true,
-            finalAnswer: actionOutput.result,
-            pageChanged: false,
-            actionExecuted: true,
-          };
-        } else {
-          // Validation failed - the feedback has been added to messages
-          // Don't add a new page snapshot, let the agent respond to feedback
-          return {
-            isTerminal: false,
-            success: false,
-            finalAnswer: null,
-            pageChanged: false, // Keep false to avoid new snapshot
-            actionExecuted: false, // Don't count as action since we're retrying
-          };
+    try {
+      for (const tr of toProcess) {
+        const actionOutput = tr.output as any;
+        if (!actionOutput) {
+          throw new Error("Tool execution failed: missing output property.");
         }
-      } else if (actionOutput.action === "abort") {
-        // Emit TASK_ABORTED event
-        this.emit(WebAgentEventType.TASK_ABORTED, {
-          reason: actionOutput.reason,
-          finalAnswer: `Aborted: ${actionOutput.reason}`,
-          iterationId: this.currentIterationId,
-        });
 
-        const message = `Aborted: ${actionOutput.reason}`;
-        return {
-          isTerminal: true,
-          success: false,
-          finalAnswer: message,
-          pageChanged: false,
-          actionExecuted: true,
-          error: { code: TaskErrorCode.TASK_ABORTED, message },
-        };
+        // Error result → throw, matching the single-action path. Earlier
+        // successful actions are already in this.messages (appended from
+        // response.messages above), so the model sees them next turn.
+        // The error string is already in the tool result the LLM sees, so for
+        // recoverable errors we throw ToolExecutionError (no duplicate message).
+        if (!actionOutput.success && actionOutput.error) {
+          batchStoppedBy = "error";
+          if (actionOutput.isRecoverable) {
+            throw new ToolExecutionError(actionOutput.error, {
+              action: actionOutput.action,
+              ref: actionOutput.ref,
+              output: actionOutput,
+            });
+          }
+          throw new Error(actionOutput.error);
+        }
+
+        // Terminal action (done/abort) — handle and return. Any later results
+        // in the batch already executed but are irrelevant to the outcome.
+        if (actionOutput.isTerminal) {
+          batchStoppedBy = "terminal";
+          actionsProcessed++;
+          const terminal = await this.handleTerminalAction(actionOutput, task, executionState);
+          return { ...terminal, actionsProcessed };
+        }
+
+        // Regular action: count it and track whether a snapshot refresh is
+        // needed afterward (ACTIONS_WITHOUT_PAGE_REFRESH are exempt).
+        actionsProcessed++;
+        lastNonTerminalOutput = actionOutput;
+        if (WebAgent.shouldRefreshPageSnapshotAfterAction(actionOutput.action)) {
+          anyPageChanged = true;
+        }
+      }
+    } finally {
+      this.emit(WebAgentEventType.SYSTEM_DEBUG_BATCH, {
+        iterationId: this.currentIterationId,
+        actionsRequested: aiResponse.toolResults.length,
+        actionsProcessed,
+        batchStoppedBy,
+      });
+    }
+
+    // Check for repeated actions on the last non-terminal action of the batch.
+    // (Per-action repetition tracking is deferred — see issue #438 PR 2.)
+    if (lastNonTerminalOutput) {
+      const repetitionResult = this.checkAndHandleRepeatedAction(
+        lastNonTerminalOutput,
+        executionState,
+      );
+      if (repetitionResult) {
+        return { ...repetitionResult, actionsProcessed };
       }
     }
 
-    // Check for repeated actions on non-terminal actions
-    const repetitionResult = this.checkAndHandleRepeatedAction(actionOutput, executionState);
-    if (repetitionResult) {
-      return repetitionResult; // Early return if intervention needed
-    }
-
-    // Regular action executed successfully
+    // Regular action(s) executed successfully
     return {
       isTerminal: false,
       success: false,
       finalAnswer: null,
-      pageChanged,
+      pageChanged: anyPageChanged,
+      actionExecuted: actionsProcessed > 0,
+      actionsProcessed,
+    };
+  }
+
+  /**
+   * Handle a terminal action (done/abort) from a turn: validates a `done`
+   * result and returns the appropriate turn outcome, or emits TASK_ABORTED for
+   * an `abort`. Extracted so the processing loop can invoke it on whichever
+   * action in a batch is terminal. Only `done` and `abort` set isTerminal.
+   */
+  private async handleTerminalAction(
+    actionOutput: any,
+    task: string,
+    executionState: ExecutionState,
+  ): Promise<{
+    isTerminal: boolean;
+    success: boolean;
+    finalAnswer: string | null;
+    pageChanged: boolean;
+    actionExecuted: boolean;
+    error?: TaskError;
+  }> {
+    if (actionOutput.action === "done") {
+      // Validate the task completion before accepting it
+      const validationResult = await this.validateTaskCompletion(
+        task,
+        actionOutput.result,
+        executionState,
+      );
+
+      if (validationResult.isAccepted) {
+        return {
+          isTerminal: true,
+          success: true,
+          finalAnswer: actionOutput.result,
+          pageChanged: false,
+          actionExecuted: true,
+        };
+      }
+      // Validation failed - the feedback has been added to messages.
+      // Don't add a new page snapshot, let the agent respond to feedback.
+      return {
+        isTerminal: false,
+        success: false,
+        finalAnswer: null,
+        pageChanged: false,
+        actionExecuted: false,
+      };
+    }
+
+    // abort
+    this.emit(WebAgentEventType.TASK_ABORTED, {
+      reason: actionOutput.reason,
+      finalAnswer: `Aborted: ${actionOutput.reason}`,
+      iterationId: this.currentIterationId,
+    });
+    const message = `Aborted: ${actionOutput.reason}`;
+    return {
+      isTerminal: true,
+      success: false,
+      finalAnswer: message,
+      pageChanged: false,
       actionExecuted: true,
+      error: { code: TaskErrorCode.TASK_ABORTED, message },
     };
   }
 

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -174,6 +174,7 @@ describe("ConfigManager", () => {
         "max_iterations",
         "max_validation_attempts",
         "max_repeated_actions",
+        "max_actions_per_step",
         "max_consecutive_errors",
         "max_total_errors",
         "initial_navigation_retries",

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -136,6 +136,7 @@ describe("WebAgentEventEmitter", () => {
         "system:debug_compression",
         "system:debug_message",
         "system:debug_tool_drop",
+        "system:debug_batch",
         "cdp:endpoint_connected",
         "cdp:endpoint_cycle",
         "browser:reconnected",

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -307,6 +307,51 @@ describe("prompts", () => {
       expect(prompt).toContain("DATA GROUNDING");
       expect(prompt).toContain("**Before calling done():**");
     });
+
+    it("renders batching guidance when maxActionsPerStep > 1", () => {
+      const prompt = buildActionLoopSystemPrompt(false, false, false, false, false, 3);
+
+      expect(prompt).toMatch(/up to 3 tools/i);
+      expect(prompt).toMatch(/Safe to batch together/i);
+      expect(prompt).not.toContain("Execute EXACTLY ONE tool per turn");
+      expect(prompt).not.toContain("You MUST use exactly one tool with the required parameters");
+    });
+
+    it("renders single-tool instruction when maxActionsPerStep === 1", () => {
+      const prompt = buildActionLoopSystemPrompt(false, false, false, false, false, 1);
+
+      expect(prompt).toContain("Execute EXACTLY ONE tool per turn");
+      expect(prompt).toContain("You MUST use exactly one tool with the required parameters");
+      expect(prompt).not.toMatch(/Safe to batch together/i);
+    });
+  });
+
+  describe("buildStepErrorFeedbackPrompt batching", () => {
+    it("renders batching guidance when maxActionsPerStep > 1", () => {
+      const prompt = buildStepErrorFeedbackPrompt("oops", false, false, false, 3);
+      expect(prompt).toMatch(/up to 3 tools/i);
+      expect(prompt).not.toContain("You MUST use exactly one tool with the required parameters");
+    });
+
+    it("keeps single-tool instruction at default", () => {
+      const prompt = buildStepErrorFeedbackPrompt("oops");
+      expect(prompt).toContain("You MUST use exactly one tool with the required parameters");
+      expect(prompt).not.toMatch(/Safe to batch together/i);
+    });
+  });
+
+  describe("buildPageSnapshotPrompt batching", () => {
+    it("renders batching guidance when maxActionsPerStep > 1", () => {
+      const prompt = buildPageSnapshotPrompt("Title", "https://e.com", "tree", false, 3);
+      expect(prompt).toMatch(/up to 3 tools/i);
+      expect(prompt).not.toContain("You MUST use exactly one tool with the required parameters");
+    });
+
+    it("keeps single-tool instruction at default", () => {
+      const prompt = buildPageSnapshotPrompt("Title", "https://e.com", "tree");
+      expect(prompt).toContain("You MUST use exactly one tool with the required parameters");
+      expect(prompt).not.toMatch(/Safe to batch together/i);
+    });
   });
 
   describe("buildTaskAndPlanPrompt", () => {

--- a/packages/core/test/webActionTools.test.ts
+++ b/packages/core/test/webActionTools.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { SAFE_TO_BATCH_ACTIONS, isBatchTerminating } from "../src/tools/webActionTools.js";
+
+describe("batch action classification", () => {
+  it("treats form-fill actions as safe to batch", () => {
+    for (const a of ["fill", "select", "check", "uncheck", "focus"]) {
+      expect(isBatchTerminating(a)).toBe(false);
+      expect(SAFE_TO_BATCH_ACTIONS.has(a)).toBe(true);
+    }
+  });
+
+  it("treats navigating/terminal/unknown actions as batch-terminating", () => {
+    for (const a of [
+      "click",
+      "enter",
+      "goto",
+      "back",
+      "forward",
+      "scroll",
+      "wait",
+      "webSearch",
+      "extract",
+      "done",
+      "abort",
+      "hover",
+      "totally-unknown",
+    ]) {
+      expect(isBatchTerminating(a)).toBe(true);
+    }
+  });
+});

--- a/packages/core/test/webAgent.test.ts
+++ b/packages/core/test/webAgent.test.ts
@@ -4654,6 +4654,30 @@ describe("WebAgent", () => {
       await agent.close();
     });
 
+    it("clamps maxActionsPerStep below 1 to 1 without crashing on an empty slice", async () => {
+      const { agent, logger } = makeBatchAgent(0);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          toolResult("click", { action: "click", ref: "btn1", isTerminal: false }),
+          fill(1),
+        ]),
+      );
+      mockStreamText.mockReturnValueOnce(doneTurn());
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await agent.execute("clamp test", { startingUrl: "https://example.com" });
+
+      // Clamped to 1: processes the first tool, drops the rest — no crash.
+      expect(result.success).toBe(true);
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 1,
+        batchStoppedBy: "completed",
+      });
+      await agent.close();
+    });
+
     it("at the default of 1, processes only the first result and drops the rest", async () => {
       // Default agent (maxActionsPerStep = 1) but provider returns two tools.
       const emitter = new WebAgentEventEmitter();

--- a/packages/core/test/webAgent.test.ts
+++ b/packages/core/test/webAgent.test.ts
@@ -4467,6 +4467,229 @@ describe("WebAgent", () => {
       expect(result.finalAnswer).toContain("click");
     });
   });
+
+  describe("action batching (maxActionsPerStep > 1)", () => {
+    // Build an agent with batching enabled and its own logger so we can read
+    // the SYSTEM_DEBUG_BATCH telemetry it emits.
+    function makeBatchAgent(maxActionsPerStep: number) {
+      const emitter = new WebAgentEventEmitter();
+      const logger = new MockLogger();
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        maxIterations: 10,
+        maxConsecutiveErrors: 5,
+        maxTotalErrors: 15,
+        guardrails: null,
+        eventEmitter: emitter,
+        logger,
+        maxActionsPerStep,
+      });
+      return { agent, logger };
+    }
+
+    function toolResult(toolName: string, output: any, n = 1) {
+      return { type: "tool-result", toolCallId: `${toolName}_${n}`, toolName, input: {}, output };
+    }
+
+    function actionTurn(toolResults: any[]) {
+      return createMockStreamResponse({
+        text: "acting",
+        toolResults,
+        response: { messages: [{ role: "assistant", content: "acting" }] },
+      }) as any;
+    }
+
+    function mockPlan() {
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Planning",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "done", plan: "1. fill form" },
+            output: { successCriteria: "done", plan: "1. fill form" },
+          },
+        ],
+      } as any);
+    }
+
+    function doneTurn(result = "All done") {
+      return actionTurn([toolResult("done", { action: "done", result, isTerminal: true })]);
+    }
+
+    const fill = (n: number) =>
+      toolResult(
+        "fill",
+        { action: "fill", ref: `input${n}`, value: `v${n}`, isTerminal: false },
+        n,
+      );
+
+    function batchEvents(logger: MockLogger) {
+      return logger.events.filter((e) => e.type === WebAgentEventType.SYSTEM_DEBUG_BATCH);
+    }
+
+    it("processes a 3-fill batch in one turn (completed)", async () => {
+      const { agent, logger } = makeBatchAgent(3);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(actionTurn([fill(1), fill(2), fill(3)]));
+      mockStreamText.mockReturnValueOnce(doneTurn());
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await agent.execute("fill the form", {
+        startingUrl: "https://example.com",
+      });
+
+      const batch = batchEvents(logger);
+      expect(batch[0].data).toMatchObject({
+        actionsRequested: 3,
+        actionsProcessed: 3,
+        batchStoppedBy: "completed",
+      });
+      // The fill turn counts 3 actions; the terminal done turn doesn't increment.
+      expect(result.stats.actions).toBe(3);
+      await agent.close();
+    });
+
+    it("processes fill + enter (page-changer last) without stopping early", async () => {
+      const { agent, logger } = makeBatchAgent(3);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          fill(1),
+          toolResult("enter", { action: "enter", ref: "input1", isTerminal: false }),
+        ]),
+      );
+      mockStreamText.mockReturnValueOnce(doneTurn());
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      await agent.execute("fill and submit", { startingUrl: "https://example.com" });
+
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 2,
+        batchStoppedBy: "completed",
+      });
+      await agent.close();
+    });
+
+    it("stops the batch at a terminal done and validates it", async () => {
+      const { agent, logger } = makeBatchAgent(3);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          fill(1),
+          toolResult("done", { action: "done", result: "ok", isTerminal: true }),
+        ]),
+      );
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await agent.execute("fill then done", {
+        startingUrl: "https://example.com",
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.finalAnswer).toBe("ok");
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 2,
+        batchStoppedBy: "terminal",
+      });
+      await agent.close();
+    });
+
+    it("stops the batch at a recoverable error", async () => {
+      const { agent, logger } = makeBatchAgent(3);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          fill(1),
+          toolResult(
+            "fill",
+            {
+              action: "fill",
+              ref: "input2",
+              success: false,
+              error: "Invalid element reference",
+              isRecoverable: true,
+            },
+            2,
+          ),
+        ]),
+      );
+      // After the recoverable error the loop retries; let it finish with done.
+      mockStreamText.mockReturnValueOnce(doneTurn());
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      await agent.execute("fill with stale ref", { startingUrl: "https://example.com" });
+
+      // Only the first fill was counted as processed; the error stopped the batch.
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 1,
+        batchStoppedBy: "error",
+      });
+      await agent.close();
+    });
+
+    it("ignores actions after a done that is not last in the batch", async () => {
+      const { agent, logger } = makeBatchAgent(3);
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          toolResult("done", { action: "done", result: "early", isTerminal: true }),
+          fill(1),
+        ]),
+      );
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await agent.execute("done first", { startingUrl: "https://example.com" });
+
+      expect(result.finalAnswer).toBe("early");
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 1,
+        batchStoppedBy: "terminal",
+      });
+      await agent.close();
+    });
+
+    it("at the default of 1, processes only the first result and drops the rest", async () => {
+      // Default agent (maxActionsPerStep = 1) but provider returns two tools.
+      const emitter = new WebAgentEventEmitter();
+      const logger = new MockLogger();
+      const agent = new WebAgent(mockBrowser, {
+        providerConfig: { model: mockProvider },
+        maxIterations: 10,
+        maxConsecutiveErrors: 5,
+        maxTotalErrors: 15,
+        guardrails: null,
+        eventEmitter: emitter,
+        logger,
+        // maxActionsPerStep omitted -> default 1
+      });
+      mockPlan();
+      mockStreamText.mockReturnValueOnce(
+        actionTurn([
+          toolResult("click", { action: "click", ref: "btn1", isTerminal: false }),
+          fill(1),
+        ]),
+      );
+      mockStreamText.mockReturnValueOnce(doneTurn());
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      await agent.execute("click then stray fill", { startingUrl: "https://example.com" });
+
+      const drop = logger.events.filter((e) => e.type === WebAgentEventType.SYSTEM_DEBUG_TOOL_DROP);
+      expect(drop[0].data).toMatchObject({ droppedTools: ["fill"], keptTool: "click" });
+      expect(batchEvents(logger)[0].data).toMatchObject({
+        actionsRequested: 2,
+        actionsProcessed: 1,
+        batchStoppedBy: "completed",
+      });
+      await agent.close();
+    });
+  });
 });
 
 describe("WebAgent firewall options", () => {


### PR DESCRIPTION
## Summary
- Lets the web agent batch several safe, non-navigating actions (e.g. filling multiple form fields) in a single LLM turn, gated on a new `maxActionsPerStep` option (default **1** = today's exact behavior).
- The LLM round-trip is the dominant latency in most Pilo runs; batching the common "fill N fields then submit" pattern cuts round-trips. PR 1 of 2 for #438.

## Design decisions
- **Safety is prompt-driven, not code-gated.** The AI SDK (v6, single step) executes *every* returned tool's `execute` fn before `toolResults` resolves — so by the time the loop inspects results, all returned actions have already hit the browser. We can't prevent a mis-ordered action by "breaking the loop." Instead we cap how many tools the model is invited to call (`maxActionsPerStep`) and prompt it to batch only safe actions with any page-changer last; the recoverable-error path is the net for mis-ordering.
- **`toolChoice` stays `"required"` in all modes** (forces ≥1 tool, still permits several per turn). The batching mode only changes the *prompt* ("up to N tools") — see eval results below for why we did **not** flip to `"auto"`.
- **Safe-to-batch set:** `fill, select, check, uncheck, focus` (everything else, incl. unknown actions, is page-changing / must-be-last). Single source of truth in `prompts.ts`, consumed by the batching prompt and re-exported as `isBatchTerminating()`.
- **Unified loop:** processing is `toolResults.slice(0, maxActionsPerStep)`, stopping at the first terminal action or error. At `maxActionsPerStep === 1` this reduces to the historical path (process `[0]`, drop+emit the rest), so default behavior is unchanged.
- **Telemetry** via a new `SYSTEM_DEBUG_BATCH` event (`actionsRequested` / `actionsProcessed` / `batchStoppedBy`), emitted after processing.

## Eval results (partial WebVoyager suite)
Ran the partial suite at `maxActionsPerStep=5` (throwaway eval branch) — this **caught a real regression and validated the fix**:

| Run | batch `toolChoice` | Pass rate | Zero-tool cascades |
|---|---|---|---|
| #1 | `"auto"` | 50% (15/30) | **8 of 15 failures** |
| #2 | `"required"` | **80% (24/30)** | **0** |

`"auto"` let the model return *zero* tool calls on hard tasks, repeatedly tripping the zero-tool error until `maxConsecutiveErrors` aborted the task. Switching to `"required"` eliminated all 8 cascades. Batching genuinely occurs under `"required"` (~15% of 221 turns emitted >1 tool) → ~24% fewer round-trips on this suite (the 2–3× headline is form-density-specific; WebVoyager is navigate/search-heavy). Remaining 6 failures at 80% are environmental/known-hard (bot detection, render, date-picker), none batching-caused.

## Changes
- `config/defaults.ts`, `core.ts`, `webAgent.ts`, `cli/.../run.ts`: `max_actions_per_step` config (default 1; auto-generates `--max-actions-per-step` + `PILO_MAX_ACTIONS_PER_STEP`) + `WebAgentOptions.maxActionsPerStep` (clamped to int ≥ 1).
- `prompts.ts`: batching guidance when `maxActionsPerStep > 1`; `SAFE_TO_BATCH_ACTIONS` / `isBatchTerminating`.
- `webAgent.ts`: unified processing loop, `handleTerminalAction` extracted, `toolChoice: "required"`, drop-path forces a snapshot refresh next turn.
- `events.ts` (+ regenerated `webagent-event.json`): `SYSTEM_DEBUG_BATCH` event.

## Test Plan
- [x] `pnpm check` (core 848, cli 228, server 96, extension 272; typecheck + format clean)
- [x] `pnpm --filter pilo-core check:schemas`
- [x] New tests: classifier, prompt rendering (both modes), clamp, and 6 loop scenarios
- [x] **Partial eval at maxActionsPerStep=5:** 80% pass, no zero-tool cascades, batching confirmed (see above)

## Notes
- **Draft:** commits kept per-phase + review/fix commits; will squash before marking ready.
- Rebased onto #478 (TAB-976), adopting its `shouldRefreshPageSnapshotAfterAction` helper.
- **Deviation from the issue (with eval evidence):** the issue proposed `toolChoice: "auto"` for batching; we use `"required"` because `"auto"` regressed pass rate 80%→50% via zero-tool cascades.
- **Deferred to PR 2:** per-action repetition-detector rework. Server-side wiring of the option also out of scope.

## References
- Spec: `docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/spec.md` (incl. Eval findings)
- Plan: `docs/dev-sessions/2026-05-28-1716-multi-action-per-turn/plan.md`
- Part of #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)