### PR TITLE
fix(core): route snapshot-time browser disconnects through reconnect handler

### DIFF
--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -540,22 +540,26 @@ export class WebAgent {
             currentIteration: executionState.currentIteration,
           });
 
-          // Add page snapshot if needed
-          if (needsPageSnapshot) {
-            // Clear approved refs when page changes: ARIA refs reset on each snapshot,
-            // so old ref strings may now point to different DOM elements.
-            // Recoverable blocked action errors deliberately keep needsPageSnapshot=false
-            // so a blocked submit retry remains tied to the same agent-filled refs.
-            if (approvedRefs) {
-              approvedRefs.clear();
-            }
-            agentFilledRefs.clear();
-            operationalRefs.clear();
-            await this.addPageSnapshot();
-          }
-
-          // Single try-catch for ALL iteration logic
+          // Single try-catch for ALL iteration logic, including the page snapshot.
+          // The snapshot lives inside the try so a mid-snapshot browser disconnect
+          // (e.g. getTreeWithRefs/getCurrentPageInfo throwing BrowserDisconnectedError
+          // after a navigation destroys the page) is routed through
+          // handleBrowserDisconnect rather than escaping runMainLoop as a hard failure.
           try {
+            // Add page snapshot if needed
+            if (needsPageSnapshot) {
+              // Clear approved refs when page changes: ARIA refs reset on each snapshot,
+              // so old ref strings may now point to different DOM elements.
+              // Recoverable blocked action errors deliberately keep needsPageSnapshot=false
+              // so a blocked submit retry remains tied to the same agent-filled refs.
+              if (approvedRefs) {
+                approvedRefs.clear();
+              }
+              agentFilledRefs.clear();
+              operationalRefs.clear();
+              await this.addPageSnapshot();
+            }
+
             const result = await this.generateAndProcessAction(task, allTools, executionState);
 
             // Reset error counter on success
@@ -1828,10 +1832,15 @@ export class WebAgent {
         url,
       });
     } catch (error) {
-      // Browser might be disconnected or page might be in transition
-      // Use cached values if available
+      // Browser might be disconnected or page might be in transition.
+      // Use cached values if available; otherwise the browser is unavailable
+      // with no recoverable state — surface a BrowserDisconnectedError so the
+      // action loop routes it through handleBrowserDisconnect (restart on the
+      // next CDP endpoint) instead of treating it as an ordinary agent error.
       if (!this.currentPage.url) {
-        throw new Error("Browser disconnected or page unavailable");
+        throw new BrowserDisconnectedError(
+          error instanceof Error ? error.message : "page state unavailable",
+        );
       }
     }
   }
@@ -1843,12 +1852,17 @@ export class WebAgent {
       this.currentPage = { title, url };
       return { title, url };
     } catch (error) {
-      // Browser might be disconnected or page might be in transition
-      // Return cached values if available
+      // Browser might be disconnected or page might be in transition.
+      // Return cached values if available; otherwise the browser is unavailable
+      // with no recoverable state — surface a BrowserDisconnectedError so the
+      // action loop routes it through handleBrowserDisconnect (restart on the
+      // next CDP endpoint) instead of treating it as an ordinary agent error.
       if (this.currentPage.url) {
         return this.currentPage;
       }
-      throw new Error("Browser disconnected or page unavailable");
+      throw new BrowserDisconnectedError(
+        error instanceof Error ? error.message : "page state unavailable",
+      );
     }
   }
 

--- a/packages/core/test/webAgent.test.ts
+++ b/packages/core/test/webAgent.test.ts
@@ -12,7 +12,7 @@ import { WebAgentEventEmitter, WebAgentEventType } from "../src/events.js";
 import { LanguageModel, streamText } from "ai";
 import { Logger } from "../src/loggers/types.js";
 import { generateTextWithRetry } from "../src/utils/retry.js";
-import { PlanningError } from "../src/errors.js";
+import { PlanningError, BrowserDisconnectedError } from "../src/errors.js";
 import {
   wrapExternalContentWithWarning,
   ExternalContentLabel,
@@ -1407,6 +1407,115 @@ describe("WebAgent", () => {
       );
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe("browser disconnect classification", () => {
+    it("getCurrentPageInfo throws BrowserDisconnectedError when browser unavailable and no page cached", async () => {
+      mockBrowser.getTitle = vi
+        .fn()
+        .mockRejectedValue(new Error("Target page, context or browser has been closed"));
+      mockBrowser.getUrl = vi
+        .fn()
+        .mockRejectedValue(new Error("Target page, context or browser has been closed"));
+      (webAgent as any).currentPage = { url: "", title: "" };
+
+      await expect((webAgent as any).getCurrentPageInfo()).rejects.toBeInstanceOf(
+        BrowserDisconnectedError,
+      );
+    });
+
+    it("updatePageState throws BrowserDisconnectedError when browser unavailable and no page cached", async () => {
+      mockBrowser.getTitle = vi
+        .fn()
+        .mockRejectedValue(new Error("Target page, context or browser has been closed"));
+      mockBrowser.getUrl = vi
+        .fn()
+        .mockRejectedValue(new Error("Target page, context or browser has been closed"));
+      (webAgent as any).currentPage = { url: "", title: "" };
+
+      await expect((webAgent as any).updatePageState()).rejects.toBeInstanceOf(
+        BrowserDisconnectedError,
+      );
+    });
+
+    it("getCurrentPageInfo returns cached page info without throwing when browser unavailable but page cached", async () => {
+      mockBrowser.getTitle = vi.fn().mockRejectedValue(new Error("transient"));
+      mockBrowser.getUrl = vi.fn().mockRejectedValue(new Error("transient"));
+      (webAgent as any).currentPage = { url: "https://example.com", title: "Cached" };
+
+      await expect((webAgent as any).getCurrentPageInfo()).resolves.toEqual({
+        url: "https://example.com",
+        title: "Cached",
+      });
+    });
+
+    it("recovers via handleBrowserDisconnect when the first page snapshot hits a disconnect", async () => {
+      // Planning phase
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Planning",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: { successCriteria: "Test", plan: "1. Test" },
+            output: { successCriteria: "Test", plan: "1. Test" },
+          },
+        ],
+      } as any);
+
+      // First snapshot disconnects; subsequent snapshots succeed (post-reconnect).
+      vi.spyOn(mockBrowser, "getTreeWithRefs")
+        .mockRejectedValueOnce(
+          new BrowserDisconnectedError(
+            "page.evaluate: Execution context was destroyed, most likely because of a navigation",
+          ),
+        )
+        .mockResolvedValue(`<div><button [ref=btn1]>Click me</button></div>`);
+
+      const reconnectSpy = vi.spyOn(webAgent as any, "handleBrowserDisconnect");
+
+      // After reconnect, finish the task.
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "Task complete",
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "Recovered and completed" },
+              output: { action: "done", result: "Recovered and completed", isTerminal: true },
+            },
+          ],
+          response: {
+            messages: [
+              { role: "assistant", content: "Task complete" },
+              {
+                role: "tool",
+                content: [
+                  {
+                    type: "tool-result",
+                    toolCallId: "done_1",
+                    toolName: "done",
+                    output: { action: "done", result: "Recovered and completed", isTerminal: true },
+                  },
+                ],
+              },
+            ],
+          },
+        }) as any,
+      );
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      const result = await webAgent.execute("Find something", {
+        startingUrl: "https://example.com",
+      });
+
+      expect(reconnectSpy).toHaveBeenCalledTimes(1);
+      expect(result.success).toBe(true);
+      expect(result.finalAnswer).toBe("Recovered and completed");
     });
   });
 


### PR DESCRIPTION
## Problem

In eval runs, pilo failed several tasks with `browser_crash` / `browser_render_failure` at **0 steps** — the browser disconnected during the initial page snapshot and the task hard-failed with "Task failed: Browser disconnected or page unavailable".

Root cause: the first `addPageSnapshot()` ran **outside** the action loop's reconnect-aware try block, so a disconnect during the snapshot (`getTreeWithRefs` / `getCurrentPageInfo` / `getUrl`) escaped `runMainLoop` and was converted to a hard failure by `execute()`, **never reaching `handleBrowserDisconnect`**. The reconnect-on-next-CDP-endpoint machinery already existed — it was simply unreachable for snapshot-time disconnects.

## Fix

- Move the page-snapshot block **inside** the per-iteration try (`runMainLoop`) so snapshot-time `BrowserDisconnectedError`s are routed to `handleBrowserDisconnect` (shutdown + restart on next CDP endpoint + retry).
- Classify the no-cache failure in `updatePageState` / `getCurrentPageInfo` as `BrowserDisconnectedError` instead of a plain `Error`, so it is recognized as recoverable.

## Tests (TDD, RED→GREEN)

- `getCurrentPageInfo` / `updatePageState` throw `BrowserDisconnectedError` on disconnect with no cached page
- cached-page path still returns without throwing (no regression)
- end-to-end: a first-snapshot disconnect now invokes `handleBrowserDisconnect` once and the task completes instead of hard-failing

Full core suite passes (844 tests).

## Eval validation

Partial eval (30 tasks) on this build: **26/30 (87%)** vs **24/30 (80%)** baseline.

The targeted failure classes are eliminated:
- baseline: `browser_crash ×3, browser_render_failure ×1, ai_generation_failure ×1`
- this run: **0** of all three

4 of 6 baseline failures now pass (Allrecipes-0, Booking-0, Cambridge Dictionary-25, GitHub-23). Remaining failures are bot detection (Cloudflare/Bing — out of scope) and one reasoning bug on Booking-9 (wrong price threshold) that the crash had been masking.

Note: eval run used vertex/gemini-2.5-flash; live-site bot detection is flaky run-to-run, so the robust claim is the elimination of the crash/render/generation failure modes, not the exact percentage.