### PR TITLE
feat(server): accept trustedHostnames and unsafeMode in /pilo/run request

### DIFF
--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -64,6 +64,10 @@ Execute a web automation task using natural language.
   "maxIterations": "number (optional)",
   "maxValidationAttempts": "number (optional)",
 
+  // Action firewall overrides
+  "trustedHostnames": "array of strings (optional)",
+  "unsafeMode": "boolean (optional)",
+
   // Proxy configuration overrides
   "proxy": "string (optional)",
   "proxyUsername": "string (optional)",

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -357,6 +357,25 @@ describe("taskRunner", () => {
       );
     });
 
+    it("should pass trustedHostnames and unsafeMode to WebAgent constructor", async () => {
+      await runTask({
+        body: {
+          task: "submit the form",
+          trustedHostnames: ["example.com", "app.example.com"],
+          unsafeMode: true,
+        },
+        sendEvent: vi.fn(),
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(mockConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          trustedHostnames: ["example.com", "app.example.com"],
+          unsafeMode: true,
+        }),
+      );
+    });
+
     it("should not throw when agent.close fails", async () => {
       mockClose = vi.fn().mockRejectedValue(new Error("close failed"));
 

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -58,6 +58,10 @@ export interface PiloTaskRequest {
   maxIterations?: number;
   maxValidationAttempts?: number;
 
+  // Action firewall overrides
+  trustedHostnames?: string[];
+  unsafeMode?: boolean;
+
   // Proxy configuration overrides
   proxy?: string;
   proxyUsername?: string;
@@ -343,6 +347,8 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     vision: body.vision ?? serverConfig.vision,
     maxIterations: body.maxIterations ?? serverConfig.max_iterations,
     maxValidationAttempts: body.maxValidationAttempts ?? serverConfig.max_validation_attempts,
+    trustedHostnames: body.trustedHostnames ?? serverConfig.trusted_hostnames,
+    unsafeMode: body.unsafeMode ?? serverConfig.unsafe_mode,
     guardrails: body.guardrails,
     searchProvider: body.searchProvider ?? serverConfig.search_provider,
     searchApiKey: serverConfig.parallel_api_key,


### PR DESCRIPTION
## Description

`pilo-server`'s `/pilo/run` request type (`PiloTaskRequest`) didn't expose the action-firewall controls added in #478 (TAB-976). They were only settable via CLI flags, env vars, or core config — i.e. server-global, not per request.

This wires `trustedHostnames` and `unsafeMode` from the request body into the `WebAgent` config in `runTask`, following the existing `body.X ?? serverConfig.Y` override pattern used by every other field. `WebAgentOptions` already accepts both (`webAgent.ts`), so this is purely the server-side plumbing.

Field names are camelCase to match the rest of `PiloTaskRequest` (`maxIterations`, `pwCdpEndpoints`, …) and the tabstack-api client that calls this endpoint.

## PR Type

- New Feature

## Related issues

Related to TAB-976 (action firewall) and TAB-980 (tabstack-api `/automate` exposure). Downstream consumer: Mozilla-Ocho/tabs-api#375.

## Checklist

- [x] I understand the code I am submitting
- [x] I have tested this code locally
- [x] New and existing tests pass locally (`pnpm test`) — `pnpm --filter pilo-server test`: 97/97 passed across 7 files
- [x] I have added tests that prove my fix/feature works (`taskRunner.test.ts`: asserts both fields reach the `WebAgent` constructor)
- [x] Documentation was updated where necessary (`packages/server/README.md`)
- [ ] I have read and followed the contribution guidelines

## AI Usage

- [x] This is fully AI-generated

Claude (Opus) with Claude Code.
