### PR TITLE
feat: add upload_file action

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -13,8 +13,15 @@ import {
   WebAgentEventEmitter,
   MetricsCollector,
   SecretsRedactor,
+  PLAYWRIGHT_BROWSERS,
 } from "pilo-core";
-import type { Logger, UserDataCallback, UserDataRequest, UserDataResponse } from "pilo-core";
+import type {
+  FileUploadConfig,
+  Logger,
+  UserDataCallback,
+  UserDataRequest,
+  UserDataResponse,
+} from "pilo-core";
 import { validateBrowser, getValidBrowsers, parseJsonData, parseResourcesList } from "../utils.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -186,6 +193,14 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       process.exit(1);
     }
 
+    const uploadAllowedPaths =
+      (options.uploadAllowedPaths as string[] | undefined) ?? cfg.upload_allowed_paths;
+    const allowFileUpload: false | FileUploadConfig =
+      PLAYWRIGHT_BROWSERS.includes(browserOption as (typeof PLAYWRIGHT_BROWSERS)[number]) &&
+      uploadAllowedPaths?.length > 0
+        ? { allowedPaths: uploadAllowedPaths }
+        : false;
+
     // Create logger
     const loggerType = options.logger ?? cfg.logger;
     const metricsIncremental = options.metricsIncremental ?? cfg.metrics_incremental;
@@ -242,6 +257,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
           cfg.pw_cdp_endpoints ??
           (cfg.pw_cdp_endpoint ? [cfg.pw_cdp_endpoint] : undefined),
         actionTimeoutMs: options.actionTimeoutMs ?? cfg.action_timeout_ms,
+        allowFileUpload,
         navigationRetry: {
           baseTimeoutMs: options.navigationTimeoutMs ?? cfg.navigation_timeout_ms,
           maxTimeoutMs: options.navigationMaxTimeoutMs ?? cfg.navigation_max_timeout_ms,
@@ -323,6 +339,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       tabstackApiUrl: options.tabstackApiUrl ?? cfg.tabstack_api_url,
       trustedHostnames: options.trustedHostnames ?? cfg.trusted_hostnames,
       unsafeMode: options.unsafe ?? cfg.unsafe_mode,
+      allowFileUpload,
       providerConfig,
       logger,
       eventEmitter,

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -23,6 +23,12 @@ vi.mock("pilo-core", async (importOriginal) => {
     PlaywrightBrowser: vi.fn().mockImplementation(function () {
       return {};
     }),
+    BiDiBrowser: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+    FoxcloudBrowser: vi.fn().mockImplementation(function () {
+      return {};
+    }),
     config: {
       get: vi.fn((key: string) => actual.DEFAULTS[key as keyof typeof actual.DEFAULTS]),
       getConfig: vi.fn(() => ({ ...actual.DEFAULTS })),
@@ -360,6 +366,54 @@ describe("CLI Run Command", () => {
       });
     });
 
+    it("should pass upload allowlist for Playwright browsers", async () => {
+      const uploadAllowedPaths = ["/tmp/pilo-uploads"];
+      mockConfig.getConfig.mockReturnValueOnce({
+        ...schemaDefaults,
+        browser: "firefox",
+        upload_allowed_paths: uploadAllowedPaths,
+      });
+
+      await command.parseAsync(["test task"], { from: "user" });
+
+      expect(mockPlaywrightBrowser).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowFileUpload: { allowedPaths: uploadAllowedPaths },
+        }),
+      );
+      expect(mockWebAgent.mock.calls[0][1]).toMatchObject({
+        allowFileUpload: { allowedPaths: uploadAllowedPaths },
+      });
+    });
+
+    it("should disable file uploads for BiDi even when upload paths are configured", async () => {
+      mockConfig.getConfig.mockReturnValueOnce({
+        ...schemaDefaults,
+        browser: "bidi",
+        bidi_url: "ws://localhost:1234",
+        upload_allowed_paths: ["/tmp/pilo-uploads"],
+      });
+
+      await command.parseAsync(["test task"], { from: "user" });
+
+      expect(mockPlaywrightBrowser).not.toHaveBeenCalled();
+      expect(mockWebAgent.mock.calls[0][1]).toMatchObject({ allowFileUpload: false });
+    });
+
+    it("should disable file uploads for Foxcloud even when upload paths are configured", async () => {
+      mockConfig.getConfig.mockReturnValueOnce({
+        ...schemaDefaults,
+        browser: "foxcloud",
+        foxcloud_url: "ws://localhost:5678",
+        upload_allowed_paths: ["/tmp/pilo-uploads"],
+      });
+
+      await command.parseAsync(["test task"], { from: "user" });
+
+      expect(mockPlaywrightBrowser).not.toHaveBeenCalled();
+      expect(mockWebAgent.mock.calls[0][1]).toMatchObject({ allowFileUpload: false });
+    });
+
     it("should set up generation logging when debug flag is enabled", async () => {
       const mockFs = vi.mocked(fs);
       const mockEventEmitter = vi.mocked(WebAgentEventEmitter);
@@ -373,9 +427,12 @@ describe("CLI Run Command", () => {
       await command.parseAsync(args, { from: "user" });
 
       // Should create debug/generations directory
-      expect(mockFs.mkdirSync).toHaveBeenCalledWith(expect.stringContaining("debug/generations"), {
-        recursive: true,
-      });
+      expect(mockFs.mkdirSync).toHaveBeenCalledWith(
+        expect.stringMatching(/debug[\\/]+generations/),
+        {
+          recursive: true,
+        },
+      );
 
       // Should create event emitter and set up listener
       expect(mockEventEmitter).toHaveBeenCalled();
@@ -402,7 +459,7 @@ describe("CLI Run Command", () => {
 
       // Should write generation data to file
       expect(mockFs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringMatching(/debug\/generations\/.*\.json$/),
+        expect.stringMatching(/debug[\\/]+generations[\\/]+.*\.json$/),
         JSON.stringify(mockData, null, 2),
       );
     });

--- a/packages/core/src/browser/ariaBrowser.ts
+++ b/packages/core/src/browser/ariaBrowser.ts
@@ -10,6 +10,7 @@ export enum PageAction {
   Click = "click",
   Hover = "hover",
   Fill = "fill",
+  UploadFile = "upload_file",
   Focus = "focus",
   Check = "check",
   Uncheck = "uncheck",
@@ -34,6 +35,10 @@ export enum PageAction {
  */
 export type ScrollDirection = "up" | "down" | "top" | "bottom";
 export const SCROLL_DIRECTIONS: ScrollDirection[] = ["up", "down", "top", "bottom"];
+
+export interface FileUploadConfig {
+  allowedPaths: readonly string[];
+}
 
 /**
  * Page load states to wait for

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -1200,7 +1200,7 @@ export class PlaywrightBrowser implements AriaBrowser {
 
               case PageAction.UploadFile: {
                 if (!value) {
-                  throw new BrowserActionException("upload_file", "upload_path_not_file");
+                  throw new BrowserActionException("upload_file", "upload_path_required");
                 }
                 const uploadPath = await this.resolveAllowedUploadPath(value);
                 const fileInput = await this.resolveFileInputLocator(locator!);

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -11,8 +11,11 @@ import {
   Locator,
   errors as playwrightErrors,
 } from "playwright";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import {
   AriaBrowser,
+  FileUploadConfig,
   FieldMetadata,
   FormSubmissionTrigger,
   FormSubmissionContext,
@@ -84,6 +87,8 @@ export interface PlaywrightBrowserOptions {
    * Primarily a testability seam; rarely needs overriding in production.
    */
   ariaFrameEvaluateTimeoutMs?: number;
+  /** Explicit local filesystem allowlist for file uploads. Empty/false disables uploads. */
+  allowFileUpload?: false | FileUploadConfig;
 }
 
 export interface ExtendedPlaywrightBrowserOptions extends PlaywrightBrowserOptions {
@@ -550,6 +555,52 @@ export class PlaywrightBrowser implements AriaBrowser {
       message.includes("NS_ERROR_") || // Firefox: NS_ERROR_NET_RESET, etc.
       message.includes("NS_BINDING_") // Firefox: NS_BINDING_ABORTED, etc.
     );
+  }
+
+  private async resolveAllowedUploadPath(inputPath: string): Promise<string> {
+    const uploadConfig = this.options.allowFileUpload;
+    if (!uploadConfig || uploadConfig.allowedPaths.length === 0) {
+      throw new BrowserActionException("upload_file", "upload_disabled");
+    }
+
+    const resolvedPath = path.resolve(inputPath);
+    let stat;
+    try {
+      stat = await fs.stat(resolvedPath);
+    } catch {
+      throw new BrowserActionException("upload_file", "upload_path_not_file");
+    }
+
+    if (!stat.isFile()) {
+      throw new BrowserActionException("upload_file", "upload_path_not_file");
+    }
+
+    const realPath = await fs.realpath(resolvedPath);
+    for (const allowedRoot of uploadConfig.allowedPaths) {
+      try {
+        const realRoot = await fs.realpath(path.resolve(allowedRoot));
+        const relative = path.relative(realRoot, realPath);
+        if (relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative))) {
+          return realPath;
+        }
+      } catch {
+        // Ignore missing or unreadable allowlist roots. They simply cannot match.
+      }
+    }
+
+    throw new BrowserActionException("upload_file", "upload_path_not_allowed");
+  }
+
+  private async resolveFileInputLocator(locator: Locator): Promise<Locator> {
+    const isDirectFileInput = await locator.evaluate((element) => {
+      return element instanceof HTMLInputElement && element.type.toLowerCase() === "file";
+    });
+    if (isDirectFileInput) return locator;
+
+    const nestedFileInput = locator.locator('input[type="file"]').first();
+    if ((await nestedFileInput.count()) > 0) return nestedFileInput;
+
+    throw new BrowserActionException("upload_file", "upload_target_not_file_input");
   }
 
   /**
@@ -1147,6 +1198,16 @@ export class PlaywrightBrowser implements AriaBrowser {
                 await locator!.fill(value, { timeout: this.actionTimeoutMs });
                 break;
 
+              case PageAction.UploadFile: {
+                if (!value) {
+                  throw new BrowserActionException("upload_file", "upload_path_not_file");
+                }
+                const uploadPath = await this.resolveAllowedUploadPath(value);
+                const fileInput = await this.resolveFileInputLocator(locator!);
+                await fileInput.setInputFiles(uploadPath, { timeout: this.actionTimeoutMs });
+                break;
+              }
+
               case PageAction.Focus:
                 await locator!.focus({ timeout: this.actionTimeoutMs });
                 break;
@@ -1331,6 +1392,7 @@ export class PlaywrightBrowser implements AriaBrowser {
       PageAction.Click,
       PageAction.Hover,
       PageAction.Fill,
+      PageAction.UploadFile,
       PageAction.Focus,
       PageAction.Check,
       PageAction.Uncheck,

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -128,6 +128,7 @@ export interface PiloConfig {
   action_timeout_ms?: number;
   trusted_hostnames?: string[];
   unsafe_mode?: boolean;
+  upload_allowed_paths?: string[];
 
   // Search Configuration
   search_provider?: SearchProviderName;
@@ -203,6 +204,7 @@ export interface PiloConfigResolved {
   action_timeout_ms: number;
   trusted_hostnames: string[];
   unsafe_mode: boolean;
+  upload_allowed_paths: string[];
 
   // Search Configuration
   search_provider: SearchProviderName;
@@ -665,6 +667,16 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
       "Disables the action firewall entirely. WARNING: prompt injection from page content can then cause the agent to submit your data, including credentials, personal info, and conversation context, to attacker-controlled forms. Only enable for trusted, controlled environments.",
     category: "action",
   },
+  upload_allowed_paths: {
+    default: [],
+    type: "string[]",
+    cli: "--upload-allowed-paths",
+    placeholder: "path1,path2,...",
+    env: ["PILO_UPLOAD_ALLOWED_PATHS"],
+    description:
+      "Comma-separated local filesystem roots where upload_file may read files. Empty means file upload is disabled.",
+    category: "action",
+  },
 
   // Search Configuration
   search_provider: {
@@ -744,6 +756,7 @@ function buildDefaults(): PiloConfigResolved {
     "action_timeout_ms",
     "trusted_hostnames",
     "unsafe_mode",
+    "upload_allowed_paths",
     "search_provider",
   ];
 

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -7,6 +7,7 @@
 export { WebAgent } from "./webAgent.js";
 export type {
   AriaBrowser,
+  FileUploadConfig,
   FieldMetadata,
   FormSubmissionContext,
   FormSubmissionTrigger,

--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -23,6 +23,11 @@ export const TOOL_STRINGS = {
     fill: {
       description: "Fill text into an input field",
     },
+    uploadFile: {
+      description: "Upload an allowlisted local file to a file input element or its container",
+      ref: "Element reference for the file input or a container containing one",
+      path: "Local file path inside configured upload_allowed_paths",
+    },
     select: {
       description: "Select an option from a dropdown",
       value: "Option to select",
@@ -173,6 +178,7 @@ function buildToolExamples(
   const lines = [
     `- click({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.click.description}`,
     `- fill({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "text"}) - ${TOOL_STRINGS.webActions.fill.description}`,
+    `- upload_file({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "path": "/path/to/file"}) - ${TOOL_STRINGS.webActions.uploadFile.description}`,
     `- select({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}", "value": "option"}) - ${TOOL_STRINGS.webActions.select.description}`,
     `- hover({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.hover.description}`,
     `- check({"ref": "${TOOL_STRINGS.webActions.common.elementRefExample}"}) - ${TOOL_STRINGS.webActions.check.description}`,

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -7,7 +7,12 @@
 
 import { tool } from "ai";
 import { z } from "zod";
-import { AriaBrowser, PageAction, SCROLL_DIRECTIONS } from "../browser/ariaBrowser.js";
+import {
+  AriaBrowser,
+  FileUploadConfig,
+  PageAction,
+  SCROLL_DIRECTIONS,
+} from "../browser/ariaBrowser.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
 import { buildExtractionPrompt, TOOL_STRINGS } from "../prompts.js";
 import type { ProviderConfig } from "../provider.js";
@@ -38,6 +43,7 @@ interface WebActionContext {
   operationalRefs: Set<string>;
   firewall: FirewallConfig;
   interactive: boolean;
+  allowFileUpload?: false | FileUploadConfig;
   /** Timeout for LLM provider calls in milliseconds (used by extract). */
   llmProviderTimeoutMs?: number;
 }
@@ -356,6 +362,22 @@ export function createWebActionTools(context: WebActionContext) {
           }
           throw error;
         }
+      },
+    }),
+
+    upload_file: tool({
+      description: TOOL_STRINGS.webActions.uploadFile.description,
+      inputSchema: z.object({
+        ref: z.string().describe(TOOL_STRINGS.webActions.uploadFile.ref),
+        path: z.string().describe(TOOL_STRINGS.webActions.uploadFile.path),
+      }),
+      execute: async ({ ref, path }) => {
+        const uploadConfig = context.allowFileUpload;
+        if (!uploadConfig || uploadConfig.allowedPaths.length === 0) {
+          return failedActionResult(PageAction.UploadFile, "upload_disabled", context, ref, path);
+        }
+
+        return await performActionWithValidation(PageAction.UploadFile, context, ref, path);
       },
     }),
 

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -9,7 +9,7 @@
 
 import { streamText, ModelMessage, StreamTextResult } from "ai";
 import type { ProviderConfig } from "./provider.js";
-import { AriaBrowser, PageAction } from "./browser/ariaBrowser.js";
+import { AriaBrowser, FileUploadConfig, PageAction } from "./browser/ariaBrowser.js";
 import {
   BrowserReconnectedEventData,
   CdpEndpointConnectedEventData,
@@ -125,6 +125,14 @@ export interface WebAgentOptions {
    * trusted, controlled environments.
    */
   unsafeMode?: boolean;
+  /**
+   * Enables `upload_file` only for explicitly allowlisted local paths.
+   *
+   * @warning Uploaded files are read from the local filesystem. Keep this
+   * disabled unless the caller controls the target page and the allowed path
+   * roots.
+   */
+  allowFileUpload?: false | FileUploadConfig;
   /** Timeout for LLM provider calls in milliseconds (default: from config) */
   llmProviderTimeoutMs?: number;
 }
@@ -266,6 +274,7 @@ export class WebAgent {
   private readonly onUserDataRequired: UserDataCallback | undefined;
   private readonly taskId: string | undefined;
   private readonly firewall: FirewallConfig;
+  private readonly allowFileUpload: false | FileUploadConfig;
   private readonly llmProviderTimeoutMs: number;
   // Host of the caller-provided start URL (options.startingUrl), captured at
   // execute() time. Trusted by the firewall — navigating somewhere the caller
@@ -309,6 +318,7 @@ export class WebAgent {
       trustedHostnames: new Set((options.trustedHostnames ?? []).map((h) => normalizeHostname(h))),
       unsafeMode: Boolean(options.unsafeMode),
     });
+    this.allowFileUpload = options.allowFileUpload ?? false;
     this.llmProviderTimeoutMs = options.llmProviderTimeoutMs ?? defaults.llm_provider_timeout_ms;
 
     if (this.searchProvider === "parallel-api" && !this.searchApiKey) {
@@ -480,6 +490,7 @@ export class WebAgent {
       operationalRefs,
       firewall: withTrustedStartHost(this.firewall, this.callerStartHostUrl),
       interactive: Boolean(this.onUserDataRequired),
+      allowFileUpload: this.allowFileUpload,
       llmProviderTimeoutMs: this.llmProviderTimeoutMs,
     });
 

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -128,6 +128,10 @@ export interface WebAgentOptions {
   /**
    * Enables `upload_file` only for explicitly allowlisted local paths.
    *
+   * Only PlaywrightBrowser currently implements PageAction.UploadFile. Callers
+   * using BiDi/Foxcloud should leave this disabled until those backends add
+   * concrete upload support.
+   *
    * @warning Uploaded files are read from the local filesystem. Keep this
    * disabled unless the caller controls the target page and the allowed path
    * roots.

--- a/packages/core/test/ariaBrowser.test.ts
+++ b/packages/core/test/ariaBrowser.test.ts
@@ -8,6 +8,7 @@ describe("AriaBrowser interface", () => {
         "click",
         "hover",
         "fill",
+        "upload_file",
         "focus",
         "check",
         "uncheck",
@@ -36,6 +37,7 @@ describe("AriaBrowser interface", () => {
       expect(PageAction.Click).toBe("click");
       expect(PageAction.Hover).toBe("hover");
       expect(PageAction.Fill).toBe("fill");
+      expect(PageAction.UploadFile).toBe("upload_file");
       expect(PageAction.Focus).toBe("focus");
       expect(PageAction.Check).toBe("check");
       expect(PageAction.Uncheck).toBe("uncheck");
@@ -56,6 +58,7 @@ describe("AriaBrowser interface", () => {
         PageAction.Click,
         PageAction.Hover,
         PageAction.Fill,
+        PageAction.UploadFile,
         PageAction.Focus,
         PageAction.Check,
         PageAction.Uncheck,
@@ -163,6 +166,7 @@ describe("AriaBrowser interface", () => {
     it("should identify actions that require values", () => {
       const valueRequiredActions = [
         PageAction.Fill, // text to fill
+        PageAction.UploadFile, // local file path to upload
         PageAction.Select, // option to select
         PageAction.Wait, // seconds to wait
         PageAction.Goto, // URL to navigate to
@@ -221,6 +225,7 @@ describe("AriaBrowser interface", () => {
       const actionCategories = {
         clicking: [PageAction.Click],
         typing: [PageAction.Fill],
+        uploads: [PageAction.UploadFile],
         selecting: [PageAction.Select],
         checkboxes: [PageAction.Check, PageAction.Uncheck],
         navigation: [PageAction.Goto, PageAction.Back, PageAction.Forward],

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -197,6 +197,7 @@ describe("ConfigManager", () => {
         "parallel_api_key",
         "tabstack_api_key",
         "tabstack_api_url",
+        "upload_allowed_paths",
       ];
 
       // Check that schema has all PiloConfig keys

--- a/packages/core/test/config/commander.test.ts
+++ b/packages/core/test/config/commander.test.ts
@@ -21,6 +21,15 @@ describe("CLI: firewall flags", () => {
     expect(opts.unsafe).toBe(true);
   });
 
+  it("parses --upload-allowed-paths as comma-separated list", () => {
+    const cmd = new Command().exitOverride();
+    addConfigOptions(cmd);
+    cmd.action(() => {});
+    cmd.parse(["node", "test", "--upload-allowed-paths", "/tmp/a,/tmp/b"]);
+    const opts = cmd.opts();
+    expect(opts.uploadAllowedPaths).toEqual(["/tmp/a", "/tmp/b"]);
+  });
+
   it("does not set firewall opts when flags omitted", () => {
     const cmd = new Command().exitOverride();
     addConfigOptions(cmd);
@@ -29,5 +38,6 @@ describe("CLI: firewall flags", () => {
     const opts = cmd.opts();
     expect(opts.trustedHostnames).toBeUndefined();
     expect(opts.unsafe).toBeUndefined();
+    expect(opts.uploadAllowedPaths).toBeUndefined();
   });
 });

--- a/packages/core/test/config/defaults.test.ts
+++ b/packages/core/test/config/defaults.test.ts
@@ -16,6 +16,13 @@ describe("config defaults: firewall fields", () => {
     expect(DEFAULTS.unsafe_mode).toBe(false);
   });
 
+  it("declares upload_allowed_paths as string[] with empty default", () => {
+    expect(FIELDS.upload_allowed_paths).toBeDefined();
+    expect(FIELDS.upload_allowed_paths.type).toBe("string[]");
+    expect(FIELDS.upload_allowed_paths.category).toBe("action");
+    expect(DEFAULTS.upload_allowed_paths).toEqual([]);
+  });
+
   it("trusted_hostnames description warns about data risk", () => {
     expect(FIELDS.trusted_hostnames.description).toMatch(/WARNING/);
     expect(FIELDS.trusted_hostnames.description.toLowerCase()).toContain("trust");
@@ -34,5 +41,10 @@ describe("config defaults: firewall fields", () => {
   it("unsafe_mode has a CLI flag and env var", () => {
     expect(FIELDS.unsafe_mode.cli).toBe("--unsafe");
     expect(FIELDS.unsafe_mode.env).toContain("PILO_UNSAFE_MODE");
+  });
+
+  it("upload_allowed_paths has a CLI flag and env var", () => {
+    expect(FIELDS.upload_allowed_paths.cli).toBe("--upload-allowed-paths");
+    expect(FIELDS.upload_allowed_paths.env).toContain("PILO_UPLOAD_ALLOWED_PATHS");
   });
 });

--- a/packages/core/test/config/env.test.ts
+++ b/packages/core/test/config/env.test.ts
@@ -7,6 +7,7 @@ describe("env: firewall fields", () => {
   beforeEach(() => {
     delete process.env.PILO_TRUSTED_HOSTNAMES;
     delete process.env.PILO_UNSAFE_MODE;
+    delete process.env.PILO_UPLOAD_ALLOWED_PATHS;
   });
 
   afterEach(() => {
@@ -31,9 +32,16 @@ describe("env: firewall fields", () => {
     expect(result.unsafe_mode).toBe(false);
   });
 
+  it("parses PILO_UPLOAD_ALLOWED_PATHS as comma-separated list", () => {
+    process.env.PILO_UPLOAD_ALLOWED_PATHS = "/tmp/a,/tmp/b";
+    const result = parseEnvConfig();
+    expect(result.upload_allowed_paths).toEqual(["/tmp/a", "/tmp/b"]);
+  });
+
   it("returns undefined when env vars are not set", () => {
     const result = parseEnvConfig();
     expect(result.trusted_hostnames).toBeUndefined();
     expect(result.unsafe_mode).toBeUndefined();
+    expect(result.upload_allowed_paths).toBeUndefined();
   });
 });

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -859,6 +859,24 @@ describe("PlaywrightBrowser", () => {
         });
       });
 
+      it("should report upload_path_required when upload_file has no path", async () => {
+        const mockLocator = {
+          count: vi.fn().mockResolvedValue(1),
+          scrollIntoViewIfNeeded: vi.fn(),
+        };
+        const mockPage = {
+          locator: vi.fn().mockReturnValue(mockLocator),
+        };
+        (browser as any).page = mockPage;
+
+        await expect(browser.performAction("file1", PageAction.UploadFile)).rejects.toThrow(
+          BrowserActionException,
+        );
+        await expect(browser.performAction("file1", PageAction.UploadFile)).rejects.toThrow(
+          "upload_path_required",
+        );
+      });
+
       it("should resolve a nested file input when the ref points to a container", async () => {
         const nestedFileInput = {
           count: vi.fn().mockResolvedValue(1),

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -6,6 +6,9 @@ import {
   BrowserActionException,
   BrowserDisconnectedError,
 } from "../src/errors.js";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
 
 // Must be at the top level so Vitest hoists it before any imports resolve.
 // Only replaces connectOverCDP; all other playwright exports remain real.
@@ -743,6 +746,7 @@ describe("PlaywrightBrowser", () => {
           PageAction.Click,
           PageAction.Hover,
           PageAction.Fill,
+          PageAction.UploadFile,
           PageAction.Focus,
           PageAction.Check,
           PageAction.Uncheck,
@@ -831,6 +835,120 @@ describe("PlaywrightBrowser", () => {
         await expect(browser.performAction("ref1", PageAction.Fill)).rejects.toThrow(
           "Value required for fill action",
         );
+      });
+
+      it("should upload a file to a direct file input", async () => {
+        const mockLocator = {
+          count: vi.fn().mockResolvedValue(1),
+          scrollIntoViewIfNeeded: vi.fn(),
+          evaluate: vi.fn().mockResolvedValue(true),
+          setInputFiles: vi.fn().mockResolvedValue(undefined),
+        };
+        const mockPage = {
+          locator: vi.fn().mockReturnValue(mockLocator),
+        };
+        (browser as any).page = mockPage;
+        vi.spyOn(browser as any, "resolveAllowedUploadPath").mockResolvedValue(
+          "C:\\fixtures\\sample.pdf",
+        );
+
+        await browser.performAction("file1", PageAction.UploadFile, "C:\\fixtures\\sample.pdf");
+
+        expect(mockLocator.setInputFiles).toHaveBeenCalledWith("C:\\fixtures\\sample.pdf", {
+          timeout: 30000,
+        });
+      });
+
+      it("should resolve a nested file input when the ref points to a container", async () => {
+        const nestedFileInput = {
+          count: vi.fn().mockResolvedValue(1),
+          setInputFiles: vi.fn().mockResolvedValue(undefined),
+        };
+        const mockLocator = {
+          count: vi.fn().mockResolvedValue(1),
+          scrollIntoViewIfNeeded: vi.fn(),
+          evaluate: vi.fn().mockResolvedValue(false),
+          locator: vi.fn().mockReturnValue({
+            first: vi.fn().mockReturnValue(nestedFileInput),
+          }),
+        };
+        const mockPage = {
+          locator: vi.fn().mockReturnValue(mockLocator),
+        };
+        (browser as any).page = mockPage;
+        vi.spyOn(browser as any, "resolveAllowedUploadPath").mockResolvedValue(
+          "C:\\fixtures\\sample.png",
+        );
+
+        await browser.performAction(
+          "container1",
+          PageAction.UploadFile,
+          "C:\\fixtures\\sample.png",
+        );
+
+        expect(mockLocator.locator).toHaveBeenCalledWith('input[type="file"]');
+        expect(nestedFileInput.setInputFiles).toHaveBeenCalledWith("C:\\fixtures\\sample.png", {
+          timeout: 30000,
+        });
+      });
+
+      it("should throw upload_target_not_file_input when no file input can be resolved", async () => {
+        const nestedFileInput = {
+          count: vi.fn().mockResolvedValue(0),
+        };
+        const mockLocator = {
+          count: vi.fn().mockResolvedValue(1),
+          scrollIntoViewIfNeeded: vi.fn(),
+          evaluate: vi.fn().mockResolvedValue(false),
+          locator: vi.fn().mockReturnValue({
+            first: vi.fn().mockReturnValue(nestedFileInput),
+          }),
+        };
+        const mockPage = {
+          locator: vi.fn().mockReturnValue(mockLocator),
+        };
+        (browser as any).page = mockPage;
+        vi.spyOn(browser as any, "resolveAllowedUploadPath").mockResolvedValue(
+          "C:\\fixtures\\sample.pdf",
+        );
+
+        await expect(
+          browser.performAction("container1", PageAction.UploadFile, "C:\\fixtures\\sample.pdf"),
+        ).rejects.toThrow("upload_target_not_file_input");
+      });
+
+      it("should reject upload paths outside the allowlist", async () => {
+        const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pilo-upload-allowed-"));
+        const otherRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pilo-upload-other-"));
+        try {
+          const filePath = path.join(otherRoot, "sample.txt");
+          await fs.writeFile(filePath, "sample");
+          const uploadBrowser = new PlaywrightBrowser({
+            allowFileUpload: { allowedPaths: [tempRoot] },
+          });
+
+          await expect((uploadBrowser as any).resolveAllowedUploadPath(filePath)).rejects.toThrow(
+            "upload_path_not_allowed",
+          );
+        } finally {
+          await fs.rm(tempRoot, { recursive: true, force: true });
+          await fs.rm(otherRoot, { recursive: true, force: true });
+        }
+      });
+
+      it("should reject directory upload paths as non-files", async () => {
+        const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "pilo-upload-allowed-"));
+        try {
+          const uploadBrowser = new PlaywrightBrowser({
+            allowFileUpload: { allowedPaths: [tempRoot] },
+          });
+
+          await expect((uploadBrowser as any).resolveAllowedUploadPath(tempRoot)).rejects.toThrow(
+            "upload_path_not_file",
+          );
+        } finally {
+          await fs.rm(tempRoot, { recursive: true, force: true });
+        }
       });
 
       it("should throw BrowserActionException for missing value in Select action", async () => {

--- a/packages/core/test/tools/webActionTools.test.ts
+++ b/packages/core/test/tools/webActionTools.test.ts
@@ -171,6 +171,7 @@ describe("Web Action Tools", () => {
       expect(tools).toBeDefined();
       expect(tools.click).toBeDefined();
       expect(tools.fill).toBeDefined();
+      expect(tools.upload_file).toBeDefined();
       expect(tools.select).toBeDefined();
       expect(tools.hover).toBeDefined();
       expect(tools.check).toBeDefined();
@@ -190,6 +191,9 @@ describe("Web Action Tools", () => {
     it("should have correct descriptions", () => {
       expect(tools.click.description).toBe("Click on an element on the page");
       expect(tools.fill.description).toBe("Fill text into an input field");
+      expect(tools.upload_file.description).toBe(
+        "Upload an allowlisted local file to a file input element or its container",
+      );
       expect(tools.select.description).toBe("Select an option from a dropdown");
       expect(tools.hover.description).toBe("Hover over an element");
       expect(tools.check.description).toBe("Check a checkbox");
@@ -452,6 +456,80 @@ describe("Web Action Tools", () => {
 
       const invalid = schema.safeParse({ ref: "input1" }); // missing value
       expect(invalid.success).toBe(false);
+    });
+  });
+
+  describe("Upload File Action", () => {
+    it("should return upload_disabled by default without calling the browser", async () => {
+      const performActionSpy = vi.spyOn(mockBrowser, "performAction");
+
+      const result = await tools.upload_file.execute({
+        ref: "file1",
+        path: "/tmp/fixture/sample.pdf",
+      });
+
+      expect(performActionSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        success: false,
+        action: "upload_file",
+        ref: "file1",
+        value: "/tmp/fixture/sample.pdf",
+        error: "upload_disabled",
+        isRecoverable: true,
+      });
+    });
+
+    it("should execute upload_file when allowed paths are configured", async () => {
+      context.allowFileUpload = { allowedPaths: ["/tmp/fixture"] };
+      tools = createWebActionTools(context);
+      const performActionSpy = vi.spyOn(mockBrowser, "performAction");
+
+      const result = await tools.upload_file.execute({
+        ref: "file1",
+        path: "/tmp/fixture/sample.pdf",
+      });
+
+      expect(performActionSpy).toHaveBeenCalledWith(
+        "file1",
+        PageAction.UploadFile,
+        "/tmp/fixture/sample.pdf",
+      );
+      expect(result).toEqual({
+        success: true,
+        action: "upload_file",
+        ref: "file1",
+        value: "/tmp/fixture/sample.pdf",
+      });
+    });
+
+    it("should validate upload_file input schema", () => {
+      const schema = tools.upload_file.inputSchema;
+
+      expect(schema.safeParse({ ref: "file1", path: "/tmp/sample.pdf" }).success).toBe(true);
+      expect(schema.safeParse({ ref: "file1" }).success).toBe(false);
+      expect(schema.safeParse({ path: "/tmp/sample.pdf" }).success).toBe(false);
+    });
+
+    it("should return structured browser upload errors as recoverable results", async () => {
+      context.allowFileUpload = { allowedPaths: ["/tmp/fixture"] };
+      tools = createWebActionTools(context);
+      vi.spyOn(mockBrowser, "performAction").mockRejectedValueOnce(
+        new BrowserActionException("upload_file", "upload_path_not_allowed"),
+      );
+
+      const result = await tools.upload_file.execute({
+        ref: "file1",
+        path: "/other/sample.pdf",
+      });
+
+      expect(result).toEqual({
+        success: false,
+        action: "upload_file",
+        ref: "file1",
+        value: "/other/sample.pdf",
+        error: "upload_path_not_allowed",
+        isRecoverable: true,
+      });
     });
   });
 

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as path from "node:path";
 
 // Shared mock state for WebAgent so tests can override behavior
 let mockExecute = vi.fn().mockResolvedValue({
@@ -57,6 +58,7 @@ vi.mock("./StreamLogger.js", () => ({
   StreamLogger: class MockStreamLogger {},
 }));
 
+import { config } from "pilo-core";
 import {
   validateTaskRequest,
   createErrorResponse,
@@ -65,6 +67,15 @@ import {
 } from "./taskRunner.js";
 
 describe("taskRunner", () => {
+  const defaultServerConfig = {
+    provider: "openai",
+    openai_api_key: "sk-test123",
+    browser: "firefox",
+    headless: true,
+    llm_provider_timeout_ms: 90000,
+    upload_allowed_paths: [],
+  };
+
   describe("createErrorResponse", () => {
     it("should build the structured error shape from explicit fields", () => {
       const res = createErrorResponse({
@@ -281,6 +292,7 @@ describe("taskRunner", () => {
   describe("runTask", () => {
     beforeEach(() => {
       process.env.OPENAI_API_KEY = "test-key";
+      vi.mocked(config.getConfig).mockReturnValue({ ...defaultServerConfig } as any);
       mockExecute = vi.fn().mockResolvedValue({
         success: true,
         finalAnswer: "Task completed",
@@ -399,6 +411,77 @@ describe("taskRunner", () => {
 
       expect(mockConstructorSpy).toHaveBeenCalledWith(
         expect.objectContaining({ llmProviderTimeoutMs: 45000 }),
+      );
+    });
+
+    it("keeps file uploads disabled when only the request supplies upload paths", async () => {
+      await runTask({
+        body: { task: "test", uploadAllowedPaths: [path.resolve("secrets")] },
+        sendEvent: vi.fn(),
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(mockConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ allowFileUpload: false }),
+      );
+    });
+
+    it("uses the configured server upload allowlist when the request does not narrow it", async () => {
+      const serverRoot = path.resolve("fixtures");
+      vi.mocked(config.getConfig).mockReturnValue({
+        ...defaultServerConfig,
+        upload_allowed_paths: [serverRoot],
+      } as any);
+
+      await runTask({
+        body: { task: "test" },
+        sendEvent: vi.fn(),
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(mockConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowFileUpload: { allowedPaths: [serverRoot] },
+        }),
+      );
+    });
+
+    it("allows request upload paths only when they are inside the server allowlist", async () => {
+      const serverRoot = path.resolve("fixtures");
+      const allowedChild = path.join(serverRoot, "uploads");
+      const outside = path.resolve("outside");
+      vi.mocked(config.getConfig).mockReturnValue({
+        ...defaultServerConfig,
+        upload_allowed_paths: [serverRoot],
+      } as any);
+
+      await runTask({
+        body: { task: "test", uploadAllowedPaths: [allowedChild, outside] },
+        sendEvent: vi.fn(),
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(mockConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowFileUpload: { allowedPaths: [allowedChild] },
+        }),
+      );
+    });
+
+    it("lets an empty request upload allowlist disable uploads for that request", async () => {
+      vi.mocked(config.getConfig).mockReturnValue({
+        ...defaultServerConfig,
+        upload_allowed_paths: [path.resolve("fixtures")],
+      } as any);
+
+      await runTask({
+        body: { task: "test", uploadAllowedPaths: [] },
+        sendEvent: vi.fn(),
+        abortSignal: new AbortController().signal,
+      });
+
+      expect(mockConstructorSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ allowFileUpload: false }),
       );
     });
 

--- a/packages/server/src/taskRunner.test.ts
+++ b/packages/server/src/taskRunner.test.ts
@@ -32,6 +32,7 @@ vi.mock("pilo-core", () => {
         browser: "firefox",
         headless: true,
         llm_provider_timeout_ms: 90000,
+        upload_allowed_paths: [],
       })),
     },
     createAIProvider: vi.fn(() => ({})),

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -13,6 +13,7 @@ import {
   PLAYWRIGHT_BROWSERS,
 } from "pilo-core";
 import type { FileUploadConfig, TaskExecutionResult, UserDataCallback } from "pilo-core";
+import * as path from "node:path";
 import { StreamLogger } from "./StreamLogger.js";
 import { config } from "./config.js";
 
@@ -313,7 +314,10 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
       `Server only supports Playwright browsers (${PLAYWRIGHT_BROWSERS.join(", ")}), got "${browserName}"`,
     );
   }
-  const uploadAllowedPaths = body.uploadAllowedPaths ?? serverConfig.upload_allowed_paths;
+  const uploadAllowedPaths = resolveServerUploadAllowedPaths(
+    serverConfig.upload_allowed_paths,
+    body.uploadAllowedPaths,
+  );
   const allowFileUpload: false | FileUploadConfig =
     uploadAllowedPaths.length > 0 ? { allowedPaths: uploadAllowedPaths } : false;
 
@@ -406,4 +410,29 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
       });
     }
   }
+}
+
+function resolveServerUploadAllowedPaths(
+  serverAllowedPaths: readonly string[],
+  requestAllowedPaths?: readonly string[],
+): string[] {
+  if (serverAllowedPaths.length === 0) {
+    return [];
+  }
+  if (requestAllowedPaths === undefined) {
+    return [...serverAllowedPaths];
+  }
+  if (requestAllowedPaths.length === 0) {
+    return [];
+  }
+
+  const normalizedServerRoots = serverAllowedPaths.map((root) => path.resolve(root));
+  return requestAllowedPaths.flatMap((requestPath) => {
+    const normalizedRequestPath = path.resolve(requestPath);
+    const allowed = normalizedServerRoots.some((serverRoot) => {
+      const relative = path.relative(serverRoot, normalizedRequestPath);
+      return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+    });
+    return allowed ? [normalizedRequestPath] : [];
+  });
 }

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -12,7 +12,7 @@ import {
   SEARCH_PROVIDERS,
   PLAYWRIGHT_BROWSERS,
 } from "pilo-core";
-import type { TaskExecutionResult, UserDataCallback } from "pilo-core";
+import type { FileUploadConfig, TaskExecutionResult, UserDataCallback } from "pilo-core";
 import { StreamLogger } from "./StreamLogger.js";
 import { config } from "./config.js";
 
@@ -62,6 +62,7 @@ export interface PiloTaskRequest {
   // Action firewall overrides
   trustedHostnames?: string[];
   unsafeMode?: boolean;
+  uploadAllowedPaths?: string[];
 
   // Proxy configuration overrides
   proxy?: string;
@@ -312,6 +313,9 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
       `Server only supports Playwright browsers (${PLAYWRIGHT_BROWSERS.join(", ")}), got "${browserName}"`,
     );
   }
+  const uploadAllowedPaths = body.uploadAllowedPaths ?? serverConfig.upload_allowed_paths;
+  const allowFileUpload: false | FileUploadConfig =
+    uploadAllowedPaths.length > 0 ? { allowedPaths: uploadAllowedPaths } : false;
 
   const browserConfig = {
     browser: browserName as (typeof PLAYWRIGHT_BROWSERS)[number],
@@ -334,6 +338,7 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     proxyUsername: body.proxyUsername ?? serverConfig.proxy_username,
     proxyPassword: body.proxyPassword ?? serverConfig.proxy_password,
     actionTimeoutMs: body.actionTimeoutMs ?? serverConfig.action_timeout_ms,
+    allowFileUpload,
     navigationRetry: createNavigationRetryConfig({
       baseTimeoutMs: body.navigationTimeoutMs ?? serverConfig.navigation_timeout_ms,
       maxTimeoutMs: body.navigationMaxTimeoutMs ?? serverConfig.navigation_max_timeout_ms,
@@ -350,6 +355,7 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     maxValidationAttempts: body.maxValidationAttempts ?? serverConfig.max_validation_attempts,
     trustedHostnames: body.trustedHostnames ?? serverConfig.trusted_hostnames,
     unsafeMode: body.unsafeMode ?? serverConfig.unsafe_mode,
+    allowFileUpload,
     llmProviderTimeoutMs: body.llmProviderTimeoutMs ?? serverConfig.llm_provider_timeout_ms,
     guardrails: body.guardrails,
     searchProvider: body.searchProvider ?? serverConfig.search_provider,

--- a/packages/server/test/sensitive-data-leak.test.ts
+++ b/packages/server/test/sensitive-data-leak.test.ts
@@ -40,6 +40,7 @@ vi.mock("pilo-core", () => {
         provider: "openai",
         openai_api_key: "sk-test123",
         browser: "chromium",
+        upload_allowed_paths: [],
       })),
     },
     createAIProvider: vi.fn(() => ({})),


### PR DESCRIPTION
## Summary
- Add a new `upload_file` web action for file input elements and containers that contain a file input.
- Keep uploads disabled by default unless `upload_allowed_paths` is configured.
- Wire the allowlist through config, CLI, env, server requests, PlaywrightBrowser, and WebAgent.
- Validate upload paths with realpath checks and structured recoverable errors.

Closes #462

## Configuration
- CLI: `--upload-allowed-paths path1,path2`
- Env: `PILO_UPLOAD_ALLOWED_PATHS=path1,path2`
- Config: `upload_allowed_paths: [...]`

## Validation
- `pnpm --filter pilo-core exec vitest run test/config.test.ts test/config/defaults.test.ts test/config/commander.test.ts test/config/env.test.ts test/tools/webActionTools.test.ts test/playwrightBrowser.test.ts test/ariaBrowser.test.ts`
- `pnpm --filter pilo-server exec vitest run src/taskRunner.test.ts`
- `pnpm --filter pilo-core run typecheck`
- `pnpm --filter pilo-cli run typecheck`
- `pnpm --filter pilo-server run typecheck`
- `pnpm exec prettier --check ...touched files...`
- `git diff --check`

Note: my local machine is on Node v24.13.1, so pnpm prints the existing engine warning because the repo requests Node `^22.0.0`.