### PR TITLE
fix(core): load dev .env from INIT_CWD and fix config-list env view

### DIFF
--- a/packages/core/src/config/manager.ts
+++ b/packages/core/src/config/manager.ts
@@ -61,11 +61,7 @@ export class ConfigManager {
     }
 
     // Dev mode: load local .env file and include env vars.
-    try {
-      process.loadEnvFile(".env");
-    } catch {
-      // Ignore if .env doesn't exist
-    }
+    this.loadDotEnv();
 
     const envConfig = parseEnvConfig();
 
@@ -77,6 +73,29 @@ export class ConfigManager {
     };
 
     return merged as PiloConfigResolved;
+  }
+
+  /**
+   * Load a local `.env` file into process.env (dev mode only).
+   *
+   * The path is resolved against INIT_CWD when set — this is the directory the
+   * user invoked the command from. It matters because `pnpm pilo` runs the CLI
+   * with the working directory set to the package dir, not the repo root where
+   * the user's .env lives. INIT_CWD is unset for the published binary, so it
+   * falls back to process.cwd().
+   */
+  private loadDotEnv(): void {
+    const baseDir = process.env.INIT_CWD ?? process.cwd();
+    try {
+      process.loadEnvFile(join(baseDir, ".env"));
+    } catch (err) {
+      // A missing .env is expected and fine to ignore. Any other failure (e.g.
+      // a malformed file that fails to parse) is worth surfacing rather than
+      // silently dropping the user's entire env config.
+      if ((err as NodeJS.ErrnoException)?.code !== "ENOENT") {
+        console.warn(`Config warning: failed to load .env: ${(err as Error).message}`);
+      }
+    }
   }
 
   /**
@@ -190,8 +209,11 @@ export class ConfigManager {
     merged: PiloConfigResolved;
   } {
     const global = this.getGlobalConfig();
-    const env = parseEnvConfig();
+    // getConfig() loads the local .env (dev mode), so it must run before
+    // parseEnvConfig() — otherwise the env view is read before .env is loaded
+    // and always comes back empty.
     const merged = this.getConfig();
+    const env = parseEnvConfig();
     return { global, env, merged };
   }
 }

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -356,3 +356,105 @@ describe("ConfigManager - production flag behavior (dev mode default)", () => {
     vi.resetModules();
   });
 });
+
+// ---------------------------------------------------------------------------
+// ConfigManager - .env loading (dev mode)
+// ---------------------------------------------------------------------------
+// In dev mode, getConfig() loads a local .env via process.loadEnvFile().
+// These tests pin down three behaviors:
+//   1. listSources() must load .env BEFORE reading env vars, so the
+//      "Environment Variables" view is not perpetually empty.
+//   2. The .env path is resolved against INIT_CWD (the dir the user ran the
+//      command from) when set, falling back to process.cwd(). This is needed
+//      because `pnpm pilo` runs the CLI with cwd set to the package dir.
+//   3. A missing .env (ENOENT) is ignored silently, but other errors (e.g. a
+//      malformed .env that fails to parse) are surfaced rather than swallowed.
+
+describe("ConfigManager - .env loading (dev mode)", () => {
+  it("listSources().env reflects values arriving from the .env file", async () => {
+    vi.resetModules();
+    const originalProvider = process.env.PILO_PROVIDER;
+    delete process.env.PILO_PROVIDER;
+
+    // Simulate loadEnvFile reading a .env that sets PILO_PROVIDER. The bug was
+    // that parseEnvConfig() ran before this side effect, leaving env empty.
+    const spy = vi.spyOn(process, "loadEnvFile").mockImplementation(() => {
+      process.env.PILO_PROVIDER = "openrouter";
+    });
+
+    try {
+      const { config: mgr } = await import("../src/config/manager.js");
+      const sources = mgr.listSources();
+      expect(sources.env.provider).toBe("openrouter");
+    } finally {
+      spy.mockRestore();
+      if (originalProvider === undefined) {
+        delete process.env.PILO_PROVIDER;
+      } else {
+        process.env.PILO_PROVIDER = originalProvider;
+      }
+      vi.resetModules();
+    }
+  });
+
+  it("resolves the .env path against INIT_CWD when set", async () => {
+    vi.resetModules();
+    const originalInitCwd = process.env.INIT_CWD;
+    process.env.INIT_CWD = "/fake/repo/root";
+
+    const spy = vi.spyOn(process, "loadEnvFile").mockImplementation(() => {});
+
+    try {
+      const { config: mgr } = await import("../src/config/manager.js");
+      mgr.getConfig();
+      expect(spy).toHaveBeenCalledWith("/fake/repo/root/.env");
+    } finally {
+      spy.mockRestore();
+      if (originalInitCwd === undefined) {
+        delete process.env.INIT_CWD;
+      } else {
+        process.env.INIT_CWD = originalInitCwd;
+      }
+      vi.resetModules();
+    }
+  });
+
+  it("silently ignores a missing .env (ENOENT)", async () => {
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const loadSpy = vi.spyOn(process, "loadEnvFile").mockImplementation(() => {
+      const err = new Error("no such file") as NodeJS.ErrnoException;
+      err.code = "ENOENT";
+      throw err;
+    });
+
+    try {
+      const { config: mgr } = await import("../src/config/manager.js");
+      mgr.getConfig();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      loadSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+
+  it("warns when .env exists but fails to parse", async () => {
+    vi.resetModules();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const loadSpy = vi.spyOn(process, "loadEnvFile").mockImplementation(() => {
+      throw new Error("malformed line in .env");
+    });
+
+    try {
+      const { config: mgr } = await import("../src/config/manager.js");
+      mgr.getConfig();
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0][0]).toContain("malformed line in .env");
+    } finally {
+      loadSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.resetModules();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

Running `pnpm pilo config list` from the repo root did not pick up environment variables from the project's `.env` file. Investigation surfaced **two independent bugs**, with a third issue that hid them both:

1. **CWD-relative `.env` path.** `ConfigManager.getConfig()` called `process.loadEnvFile(".env")`, resolved against `process.cwd()`. But `pnpm pilo` expands to `pnpm --filter pilo-cli run pilo`, and pnpm runs package scripts with the working directory set to `packages/cli/` — not the repo root where the user's `.env` lives. The resulting `ENOENT` was silently swallowed, so the `.env` never loaded.
2. **Ordering bug in `listSources()`.** `parseEnvConfig()` ran *before* `getConfig()` loaded the `.env`, so `config list`'s "Environment Variables" section was always empty regardless of CWD.
3. **Over-broad `catch`.** The `catch {}` around `loadEnvFile` ignored *every* error (its comment claimed it only ignored a missing file). A malformed `.env` that failed to parse would silently drop the user's entire env config with no warning.

Scope: dev path only. The published `pilo` binary runs in the user's real CWD and skips `.env` loading in production mode, so it is unaffected.

## Fix

- Extract `loadDotEnv()` that resolves the `.env` path against `process.env.INIT_CWD ?? process.cwd()`. `INIT_CWD` is the directory the user invoked the command from (the repo root under `pnpm pilo`); it is unset for the published binary, so behavior there is unchanged.
- Narrow the `catch` to ignore only `ENOENT`; warn on any other failure instead of swallowing it.
- Reorder `listSources()` so `getConfig()` (which loads the `.env`) runs before `parseEnvConfig()`.

## Tests

Added 4 tests in `packages/core/test/config.test.ts` (written failing first):
- `listSources().env` reflects values arriving from the `.env` file.
- The `.env` path resolves against `INIT_CWD` when set.
- A missing `.env` (`ENOENT`) is ignored silently.
- A `.env` that exists but fails to parse emits a warning.

## Verification

- `pnpm --filter pilo-core run test` — 855 passing
- `pnpm --filter pilo-cli run test` — 228 passing
- `pnpm --filter pilo-core run typecheck` — clean
- `pnpm run format:check` — clean
- End-to-end: `pnpm pilo config list` from the repo root now shows the `.env` values in both the Environment Variables and Merged sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)