### PR TITLE
fix(cli): move firewall remediation rendering into ChalkConsoleLogger

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -14,13 +14,7 @@ import {
   MetricsCollector,
   SecretsRedactor,
 } from "pilo-core";
-import type {
-  Logger,
-  UserDataCallback,
-  UserDataRequest,
-  UserDataResponse,
-  FirewallBlockedNonInteractiveEventData,
-} from "pilo-core";
+import type { Logger, UserDataCallback, UserDataRequest, UserDataResponse } from "pilo-core";
 import { validateBrowser, getValidBrowsers, parseJsonData, parseResourcesList } from "../utils.js";
 import * as fs from "fs";
 import * as path from "path";
@@ -312,10 +306,6 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       });
     }
 
-    eventEmitter.onEvent(WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE, (data: unknown) => {
-      printFirewallRemediation(data as FirewallBlockedNonInteractiveEventData);
-    });
-
     // Create WebAgent
     const webAgent = new WebAgent(browser, {
       debug: debugMode,
@@ -350,42 +340,5 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
   } catch (error) {
     console.error(chalk.red.bold("\n❌ Error:"), chalk.whiteBright(error));
     process.exit(1);
-  }
-}
-
-export function printFirewallRemediation(data: FirewallBlockedNonInteractiveEventData): void {
-  const lines: string[] = [];
-  lines.push("");
-  lines.push(chalk.yellow.bold("Pilo: an action was blocked by the prompt-injection firewall."));
-  lines.push(chalk.yellow(`Reason: ${data.reason}`));
-
-  const involvedHosts = Array.from(
-    new Set(
-      [data.pageHostname, ...data.formActionHostnames].filter((h): h is string => Boolean(h)),
-    ),
-  );
-  if (involvedHosts.length > 0) {
-    lines.push(chalk.yellow(`Hostnames involved: ${involvedHosts.join(", ")}`));
-  }
-
-  lines.push(chalk.yellow("To allow this action, you can:"));
-  for (const r of data.remediations) {
-    if (r.kind === "add-trusted-hostnames") {
-      const cmd =
-        r.hostnames.length > 0
-          ? `pilo config set trusted_hostnames ${r.hostnames.join(",")}`
-          : "pilo config set trusted_hostnames <host>";
-      lines.push(`  - ${r.description}`);
-      lines.push(`    Run: ${chalk.cyan(cmd)}`);
-    } else if (r.kind === "enable-interactive-mode") {
-      lines.push(`  - ${r.description}`);
-    } else if (r.kind === "enable-unsafe-mode") {
-      lines.push(`  - ${r.description}`);
-      lines.push(`    Run: ${chalk.cyan("pilo config set unsafe_mode true")}`);
-    }
-  }
-
-  for (const line of lines) {
-    console.warn(line);
   }
 }

--- a/packages/cli/test/commands/run.test.ts
+++ b/packages/cli/test/commands/run.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Command } from "commander";
-import { createRunCommand, printFirewallRemediation } from "../../src/commands/run.js";
-import type { FirewallBlockedNonInteractiveEventData } from "pilo-core";
+import { createRunCommand } from "../../src/commands/run.js";
 import { getConfigDefaults } from "pilo-core";
 
 // Get defaults from schema (used for mocking config.getConfig)
@@ -587,88 +586,5 @@ describe("CLI Run Command", () => {
       // Just check that the process exited with error code
       expect(mockExit).toHaveBeenCalledWith(1);
     });
-  });
-});
-
-describe("printFirewallRemediation", () => {
-  let warnSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-  });
-
-  afterEach(() => {
-    warnSpy.mockRestore();
-  });
-
-  it("prints all three remediation options with the blocked hostname", () => {
-    const data: FirewallBlockedNonInteractiveEventData = {
-      timestamp: Date.now(),
-      iterationId: "",
-      reason: "Security policy blocked submitting a form containing unauthorized agent-filled data",
-      kind: "form-submission",
-      pageHostname: "untrusted.com",
-      formActionHostnames: ["untrusted.com"],
-      remediations: [
-        {
-          kind: "add-trusted-hostnames",
-          hostnames: ["untrusted.com"],
-          description: "Add untrusted.com to trusted_hostnames to allow this action on this site.",
-        },
-        {
-          kind: "enable-interactive-mode",
-          description:
-            "Run in interactive mode by providing a UserDataCallback so the agent can ask the user to approve sensitive fields per-action via request_user_data.",
-        },
-        {
-          kind: "enable-unsafe-mode",
-          description: "Set unsafe_mode=true to disable the action firewall entirely. WARNING: ...",
-        },
-      ],
-    };
-
-    printFirewallRemediation(data);
-    const output = warnSpy.mock.calls
-      .map((c: unknown[]) => c.join(" "))
-      .join("\n")
-      .replace(/\x1b\[[0-9;]*m/g, "");
-    expect(output).toContain("untrusted.com");
-    expect(output).toContain("trusted_hostnames untrusted.com");
-    expect(output).toContain("interactive mode");
-    expect(output).toContain("unsafe_mode true");
-  });
-
-  it("falls back to a generic command when no hostnames are listed", () => {
-    const data: FirewallBlockedNonInteractiveEventData = {
-      timestamp: Date.now(),
-      iterationId: "",
-      reason: "Security policy blocked filling a submittable form field without user approval",
-      kind: "freeform-fill",
-      pageHostname: null,
-      formActionHostnames: [],
-      remediations: [
-        {
-          kind: "add-trusted-hostnames",
-          hostnames: [],
-          description:
-            "Add the page hostname to trusted_hostnames to allow this action on this site.",
-        },
-        {
-          kind: "enable-interactive-mode",
-          description: "Run in interactive mode...",
-        },
-        {
-          kind: "enable-unsafe-mode",
-          description: "Set unsafe_mode=true...",
-        },
-      ],
-    };
-
-    printFirewallRemediation(data);
-    const output = warnSpy.mock.calls
-      .map((c: unknown[]) => c.join(" "))
-      .join("\n")
-      .replace(/\x1b\[[0-9;]*m/g, "");
-    expect(output).toContain("trusted_hostnames <host>");
   });
 });

--- a/packages/core/src/loggers/chalkConsole.ts
+++ b/packages/core/src/loggers/chalkConsole.ts
@@ -23,6 +23,7 @@ import type {
   ValidationErrorEventData,
   AIGenerationErrorEventData,
   TaskMetricsEventData,
+  FirewallBlockedNonInteractiveEventData,
 } from "../events.js";
 import { Logger } from "./types.js";
 
@@ -89,6 +90,9 @@ export class ChalkConsoleLogger implements Logger {
     emitter.onEvent(WebAgentEventType.CDP_ENDPOINT_CONNECTED, this.handleCdpEndpointConnected);
     emitter.onEvent(WebAgentEventType.CDP_ENDPOINT_CYCLE, this.handleCdpEndpointCycle);
     emitter.onEvent(WebAgentEventType.BROWSER_RECONNECTED, this.handleBrowserReconnected);
+
+    // Firewall events
+    emitter.onEvent(WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE, this.handleFirewallBlocked);
   }
 
   dispose(): void {
@@ -143,6 +147,12 @@ export class ChalkConsoleLogger implements Logger {
       );
       this.emitter.offEvent(WebAgentEventType.CDP_ENDPOINT_CYCLE, this.handleCdpEndpointCycle);
       this.emitter.offEvent(WebAgentEventType.BROWSER_RECONNECTED, this.handleBrowserReconnected);
+
+      // Firewall events
+      this.emitter.offEvent(
+        WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        this.handleFirewallBlocked,
+      );
 
       // Reset emitter reference
       this.emitter = null;
@@ -388,5 +398,42 @@ export class ChalkConsoleLogger implements Logger {
         `📊 Steps: ${chalk.whiteBright(data.stepCount)} | AI Gens: ${chalk.whiteBright(data.aiGenerationCount)}${errorIndicator} | Tokens: ${chalk.whiteBright(totalTokens.toLocaleString())}`,
       ),
     );
+  };
+
+  private handleFirewallBlocked = (data: FirewallBlockedNonInteractiveEventData): void => {
+    const lines: string[] = [];
+    lines.push("");
+    lines.push(chalk.yellow.bold("Pilo: an action was blocked by the prompt-injection firewall."));
+    lines.push(chalk.yellow(`Reason: ${data.reason}`));
+
+    const involvedHosts = Array.from(
+      new Set(
+        [data.pageHostname, ...data.formActionHostnames].filter((h): h is string => Boolean(h)),
+      ),
+    );
+    if (involvedHosts.length > 0) {
+      lines.push(chalk.yellow(`Hostnames involved: ${involvedHosts.join(", ")}`));
+    }
+
+    lines.push(chalk.yellow("To allow this action, you can:"));
+    for (const r of data.remediations) {
+      if (r.kind === "add-trusted-hostnames") {
+        const cmd =
+          r.hostnames.length > 0
+            ? `pilo config set trusted_hostnames ${r.hostnames.join(",")}`
+            : "pilo config set trusted_hostnames <host>";
+        lines.push(`  - ${r.description}`);
+        lines.push(`    Run: ${chalk.cyan(cmd)}`);
+      } else if (r.kind === "enable-interactive-mode") {
+        lines.push(`  - ${r.description}`);
+      } else if (r.kind === "enable-unsafe-mode") {
+        lines.push(`  - ${r.description}`);
+        lines.push(`    Run: ${chalk.cyan("pilo config set unsafe_mode true")}`);
+      }
+    }
+
+    for (const line of lines) {
+      console.warn(line);
+    }
   };
 }

--- a/packages/core/test/loggers.test.ts
+++ b/packages/core/test/loggers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ConsoleLogger } from "../src/loggers/console.js";
 import { JSONConsoleLogger } from "../src/loggers/json.js";
+import { ChalkConsoleLogger } from "../src/loggers/chalkConsole.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../src/events.js";
 import type {
   TaskStartEventData,
@@ -21,6 +22,7 @@ import type {
   ProcessingEventData,
   ScreenshotCapturedEventData,
   ScreenshotCapturedImageEventData,
+  FirewallBlockedNonInteractiveEventData,
 } from "../src/events.js";
 
 // Mock console methods
@@ -1074,6 +1076,108 @@ describe("JSONConsoleLogger", () => {
       const output = mockConsole.log.mock.calls[0][0];
       const parsed = JSON.parse(output);
       expect(parsed.event).toBe(WebAgentEventType.BROWSER_SCREENSHOT_CAPTURED);
+    });
+  });
+});
+
+describe("ChalkConsoleLogger", () => {
+  let logger: ChalkConsoleLogger;
+  let emitter: WebAgentEventEmitter;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logger = new ChalkConsoleLogger();
+    emitter = new WebAgentEventEmitter();
+    logger.initialize(emitter);
+  });
+
+  afterEach(() => {
+    logger.dispose();
+    warnSpy.mockRestore();
+  });
+
+  // Strip ANSI color codes so assertions can match plain text.
+  const plainOutput = () =>
+    warnSpy.mock.calls
+      .map((c: unknown[]) => c.join(" "))
+      .join("\n")
+      .replace(/\x1b\[[0-9;]*m/g, "");
+
+  describe("firewall remediation", () => {
+    it("prints all three remediation options with the blocked hostname", () => {
+      const data: FirewallBlockedNonInteractiveEventData = {
+        timestamp: Date.now(),
+        iterationId: "",
+        reason:
+          "Security policy blocked submitting a form containing unauthorized agent-filled data",
+        kind: "form-submission",
+        pageHostname: "untrusted.com",
+        formActionHostnames: ["untrusted.com"],
+        remediations: [
+          {
+            kind: "add-trusted-hostnames",
+            hostnames: ["untrusted.com"],
+            description:
+              "Add untrusted.com to trusted_hostnames to allow this action on this site.",
+          },
+          {
+            kind: "enable-interactive-mode",
+            description:
+              "Run in interactive mode by providing a UserDataCallback so the agent can ask the user to approve sensitive fields per-action via request_user_data.",
+          },
+          {
+            kind: "enable-unsafe-mode",
+            description:
+              "Set unsafe_mode=true to disable the action firewall entirely. WARNING: ...",
+          },
+        ],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        data,
+      });
+
+      const output = plainOutput();
+      expect(output).toContain("untrusted.com");
+      expect(output).toContain("trusted_hostnames untrusted.com");
+      expect(output).toContain("interactive mode");
+      expect(output).toContain("unsafe_mode true");
+    });
+
+    it("falls back to a generic command when no hostnames are listed", () => {
+      const data: FirewallBlockedNonInteractiveEventData = {
+        timestamp: Date.now(),
+        iterationId: "",
+        reason: "Security policy blocked filling a submittable form field without user approval",
+        kind: "freeform-fill",
+        pageHostname: null,
+        formActionHostnames: [],
+        remediations: [
+          {
+            kind: "add-trusted-hostnames",
+            hostnames: [],
+            description:
+              "Add the page hostname to trusted_hostnames to allow this action on this site.",
+          },
+          {
+            kind: "enable-interactive-mode",
+            description: "Run in interactive mode...",
+          },
+          {
+            kind: "enable-unsafe-mode",
+            description: "Set unsafe_mode=true...",
+          },
+        ],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        data,
+      });
+
+      expect(plainOutput()).toContain("trusted_hostnames <host>");
     });
   });
 });


### PR DESCRIPTION
## Problem

The `FIREWALL_BLOCKED_NON_INTERACTIVE` handler registered in the `run` command (`packages/cli/src/commands/run.ts`) called `printFirewallRemediation`, which wrote chalk-colored `console.warn` lines **unconditionally** — regardless of which logger was selected. Under `--logger json` (or `PILO_LOGGER=json`), this injected colored human-readable text into the middle of the otherwise machine-readable JSONL stream, corrupting it.

The JSON logger already subscribes to every event type and emits `FIREWALL_BLOCKED_NON_INTERACTIVE` as a structured JSON line, so the extra rendering was redundant there and actively harmful to the output format.

## Fix

Move the rendering into `ChalkConsoleLogger` as a `handleFirewallBlocked` handler, subscribed in `initialize()` and torn down in `dispose()` like every other handler in that logger. Now:

- **Chalk logger** (default for interactive use): renders the colored remediation guidance, as before.
- **JSON logger**: emits a single clean JSON line for the event, with no chalk pollution.

Removes the `run`-command event subscription and the now-unused exported `printFirewallRemediation` function (and its now-unused type import).

## Tests

The two remediation-rendering tests move from `packages/cli/test/commands/run.test.ts` to `packages/core/test/loggers.test.ts`, now exercising the behavior through the event emitter against a real `ChalkConsoleLogger` (`initialize` → `emitEvent` → assert on `console.warn`) rather than calling the function directly. Assertions are unchanged (ANSI codes stripped before matching).

## Verification

- `pnpm --filter pilo-core run test` — 853 passing (includes the 2 relocated firewall tests)
- `pnpm --filter pilo-cli run test` — 226 passing
- `pnpm --filter pilo-core run typecheck` / `pnpm --filter pilo-cli run typecheck` — clean
- `pnpm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)