### PR TITLE
ci: skip smoke eval when GCP credentials are unavailable

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -47,6 +47,24 @@ jobs:
             workflows:
               - '.github/workflows/**'
 
+  # Reports which secret-backed credentials are available to this run.
+  # The `secrets` context cannot be read in a job-level `if:`, so downstream
+  # jobs that need a secret gate on these outputs instead. Secrets are not
+  # passed to workflows triggered from forks or Dependabot, so the
+  # corresponding output is 'false' on those runs and the dependent job is
+  # cleanly skipped rather than hard-failing. Add one line per secret as more
+  # jobs come to need credentials.
+  check-secrets:
+    name: Check secret availability
+    runs-on: ubuntu-latest
+    outputs:
+      gcp_smoke_eval: ${{ steps.check.outputs.gcp_smoke_eval }}
+    steps:
+      - name: Check which secrets are available
+        id: check
+        run: |
+          echo "gcp_smoke_eval=${{ secrets.GCP_SMOKE_EVAL_SA_KEY != '' }}" >> "$GITHUB_OUTPUT"
+
   setup:
     runs-on: ubuntu-latest
     needs: [detect-changes]
@@ -360,8 +378,15 @@ jobs:
   smoke-eval:
     name: Smoke eval (Pilo agent on example.com)
     runs-on: ubuntu-latest
-    needs: [detect-changes, setup]
-    if: needs.detect-changes.outputs.cli == 'true' || needs.detect-changes.outputs.core == 'true' || needs.detect-changes.outputs.workflows == 'true'
+    needs: [detect-changes, setup, check-secrets]
+    # Skip (rather than fail) when the GCP credentials are unavailable — e.g.
+    # on fork or Dependabot PRs, where secrets are not provided. Note `&&`
+    # binds tighter than `||`, so the change-detection clause is parenthesized.
+    if: >
+      needs.check-secrets.outputs.gcp_smoke_eval == 'true' &&
+      (needs.detect-changes.outputs.cli == 'true' ||
+      needs.detect-changes.outputs.core == 'true' ||
+      needs.detect-changes.outputs.workflows == 'true')
     # id-token: write is required if/when this job is switched to Workload
     # Identity Federation (see the auth step below).
     permissions:


### PR DESCRIPTION
## Problem

The **Smoke eval** job hard-fails at the `google-github-actions/auth@v2` step on Dependabot and fork PRs (e.g. #495). GitHub does not pass repo secrets to workflows triggered from those sources, so `secrets.GCP_SMOKE_EVAL_SA_KEY` is empty and the auth action errors out:

> the GitHub Action workflow must specify exactly one of "workload_identity_provider" or "credentials_json"! ... By default, secrets are not passed to workflows triggered from forks, including Dependabot.

The check goes red even though these PRs have no way to access the credentials — pure noise, and it will hit external contributors once Pilo is open-sourced.

## Fix

Add a lightweight **`check-secrets`** job that reports which secret-backed credentials are available as job outputs. The `secrets` context can't be read in a job-level `if:`, so this surfaces it indirectly. The smoke-eval job then gates on it:

```yaml
needs: [detect-changes, setup, check-secrets]
if: >
  needs.check-secrets.outputs.gcp_smoke_eval == 'true' &&
  (needs.detect-changes.outputs.cli == 'true' || ... || workflows == 'true')
```

When the credential is absent, the whole smoke-eval job is **skipped** (grey) rather than failing (red) — honest about the fact that it didn't run, and it burns zero build minutes.

The `check-secrets` job is intentionally generic: as more jobs come to need secrets, add one output line (`<name>: ${{ secrets.FOO != '' }}`) and gate on `needs.check-secrets.outputs.<name>`.

## Notes

- This PR touches `.github/workflows/**`, so the smoke-eval job runs here — and because it's a same-repo branch (not a fork/Dependabot), the credential *is* available, so the eval actually executes. That confirms the gate doesn't break the normal happy path.
- To clear the red check on #495 specifically: once this lands on `main`, comment `@dependabot rebase` on that PR so it picks up the updated workflow and the eval skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)