### PR TITLE
feat(core): add plain-text firewall remediation handler to ConsoleLogger

### DIFF
--- a/packages/core/src/loggers/console.ts
+++ b/packages/core/src/loggers/console.ts
@@ -18,6 +18,7 @@ import type {
   ScreenshotCapturedEventData,
   ValidationErrorEventData,
   AIGenerationErrorEventData,
+  FirewallBlockedNonInteractiveEventData,
 } from "../events.js";
 import { Logger } from "./types.js";
 
@@ -63,6 +64,9 @@ export class ConsoleLogger implements Logger {
 
     // AI events
     emitter.onEvent(WebAgentEventType.AI_GENERATION_ERROR, this.handleAIGenerationError);
+
+    // Firewall events
+    emitter.onEvent(WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE, this.handleFirewallBlocked);
   }
 
   dispose(): void {
@@ -102,6 +106,12 @@ export class ConsoleLogger implements Logger {
 
       // AI events
       this.emitter.offEvent(WebAgentEventType.AI_GENERATION_ERROR, this.handleAIGenerationError);
+
+      // Firewall events
+      this.emitter.offEvent(
+        WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        this.handleFirewallBlocked,
+      );
 
       // Reset emitter reference
       this.emitter = null;
@@ -247,5 +257,42 @@ export class ConsoleLogger implements Logger {
 
   private handleAIGenerationError = (data: AIGenerationErrorEventData): void => {
     console.error("❌ AI generation error:", data.error);
+  };
+
+  private handleFirewallBlocked = (data: FirewallBlockedNonInteractiveEventData): void => {
+    const lines: string[] = [];
+    lines.push("");
+    lines.push("Pilo: an action was blocked by the prompt-injection firewall.");
+    lines.push(`Reason: ${data.reason}`);
+
+    const involvedHosts = Array.from(
+      new Set(
+        [data.pageHostname, ...data.formActionHostnames].filter((h): h is string => Boolean(h)),
+      ),
+    );
+    if (involvedHosts.length > 0) {
+      lines.push(`Hostnames involved: ${involvedHosts.join(", ")}`);
+    }
+
+    lines.push("To allow this action, you can:");
+    for (const r of data.remediations) {
+      if (r.kind === "add-trusted-hostnames") {
+        const cmd =
+          r.hostnames.length > 0
+            ? `pilo config set trusted_hostnames ${r.hostnames.join(",")}`
+            : "pilo config set trusted_hostnames <host>";
+        lines.push(`  - ${r.description}`);
+        lines.push(`    Run: ${cmd}`);
+      } else if (r.kind === "enable-interactive-mode") {
+        lines.push(`  - ${r.description}`);
+      } else if (r.kind === "enable-unsafe-mode") {
+        lines.push(`  - ${r.description}`);
+        lines.push(`    Run: pilo config set unsafe_mode true`);
+      }
+    }
+
+    for (const line of lines) {
+      console.warn(line);
+    }
   };
 }

--- a/packages/core/test/loggers.test.ts
+++ b/packages/core/test/loggers.test.ts
@@ -667,6 +667,98 @@ describe("ConsoleLogger", () => {
       expect(allOutput).toContain("API rate limit exceeded");
     });
   });
+
+  describe("Firewall events", () => {
+    // console.warn is not part of the shared mockConsole, so spy on it locally.
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    const warnOutput = () => warnSpy.mock.calls.map((c: unknown[]) => c.join(" ")).join("\n");
+
+    it("prints plain-text remediation options with the blocked hostname", () => {
+      const data: FirewallBlockedNonInteractiveEventData = {
+        timestamp: Date.now(),
+        iterationId: "",
+        reason:
+          "Security policy blocked submitting a form containing unauthorized agent-filled data",
+        kind: "form-submission",
+        pageHostname: "untrusted.com",
+        formActionHostnames: ["untrusted.com"],
+        remediations: [
+          {
+            kind: "add-trusted-hostnames",
+            hostnames: ["untrusted.com"],
+            description:
+              "Add untrusted.com to trusted_hostnames to allow this action on this site.",
+          },
+          {
+            kind: "enable-interactive-mode",
+            description:
+              "Run in interactive mode by providing a UserDataCallback so the agent can ask the user to approve sensitive fields per-action via request_user_data.",
+          },
+          {
+            kind: "enable-unsafe-mode",
+            description:
+              "Set unsafe_mode=true to disable the action firewall entirely. WARNING: ...",
+          },
+        ],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        data,
+      });
+
+      const output = warnOutput();
+      expect(output).toContain("untrusted.com");
+      expect(output).toContain("trusted_hostnames untrusted.com");
+      expect(output).toContain("interactive mode");
+      expect(output).toContain("unsafe_mode true");
+      // Output must be plain text, with no ANSI escape codes.
+      expect(output).not.toMatch(/\x1b\[[0-9;]*m/);
+    });
+
+    it("falls back to a generic command when no hostnames are listed", () => {
+      const data: FirewallBlockedNonInteractiveEventData = {
+        timestamp: Date.now(),
+        iterationId: "",
+        reason: "Security policy blocked filling a submittable form field without user approval",
+        kind: "freeform-fill",
+        pageHostname: null,
+        formActionHostnames: [],
+        remediations: [
+          {
+            kind: "add-trusted-hostnames",
+            hostnames: [],
+            description:
+              "Add the page hostname to trusted_hostnames to allow this action on this site.",
+          },
+          {
+            kind: "enable-interactive-mode",
+            description: "Run in interactive mode...",
+          },
+          {
+            kind: "enable-unsafe-mode",
+            description: "Set unsafe_mode=true...",
+          },
+        ],
+      };
+
+      emitter.emitEvent({
+        type: WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        data,
+      });
+
+      expect(warnOutput()).toContain("trusted_hostnames <host>");
+    });
+  });
 });
 
 describe("JSONConsoleLogger", () => {


### PR DESCRIPTION
## Background

Follow-up to #506. After that change, `ChalkConsoleLogger` (and the generic `JSONConsoleLogger`) handle `FIREWALL_BLOCKED_NON_INTERACTIVE`, but the plain `ConsoleLogger` did not. Firewall-blocked actions routed through `ConsoleLogger` would be silently dropped — the user would get no remediation guidance.

`ConsoleLogger` isn't on the CLI `run` path today (which uses chalk or json), so this wasn't reachable in practice, but the gap is worth closing for completeness and any future consumer of the browser-safe logger.

## Change

Add a `handleFirewallBlocked` handler to `ConsoleLogger` that mirrors the `ChalkConsoleLogger` output in **plain text** (no `chalk`), keeping the logger browser-safe. Subscribed in `initialize()` and torn down in `dispose()` like every other handler.

## Tests

Added two tests under the `ConsoleLogger` suite in `packages/core/test/loggers.test.ts`, exercising the handler through the event emitter:
- prints remediation options with the blocked hostname, and asserts the output contains **no ANSI escape codes** (the key distinction from the chalk logger);
- falls back to a generic command when no hostnames are listed.

## Verification

- `pnpm --filter pilo-core run test` — 859 passing (incl. the 2 new tests)
- `pnpm --filter pilo-core run typecheck` — clean
- `pnpm --filter pilo-core run check:schemas` — clean (no event-type drift; this change only subscribes to an existing event)
- `pnpm run format:check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)