### PR TITLE
fix(server): decouple /ready from concurrency capacity (TAB-993)

### DIFF
--- a/packages/server/.env.example
+++ b/packages/server/.env.example
@@ -21,8 +21,10 @@ OPENAI_API_KEY=your_openai_api_key_here
 PORT=3000
 
 # Maximum number of concurrent tasks per server instance (default: 3)
-# Increase for servers with more resources. When at capacity the server
-# returns CONCURRENCY_LIMIT and stops accepting new tasks via /ready.
+# Increase for servers with more resources. When at capacity the server rejects
+# new task requests with CONCURRENCY_LIMIT (per-request backpressure). The
+# /ready probe stays 200 regardless so the load balancer keeps the pod in
+# rotation; readiness reflects process health, not free task slots.
 # MAX_CONCURRENT_TASKS=3
 
 # How long (ms) to wait for in-flight tasks to finish after SIGTERM before

--- a/packages/server/src/health.ts
+++ b/packages/server/src/health.ts
@@ -1,0 +1,24 @@
+import type { Hono } from "hono";
+
+/**
+ * Register the liveness (`/health`) and readiness (`/ready`) probes.
+ *
+ * Readiness reports whether the process is alive and able to serve requests —
+ * NOT whether it currently has a free task slot. Coupling readiness to the
+ * concurrency limit caused the load balancer to evict every pod from the
+ * Service under burst load (each pod 503s the instant it hits the cap), turning
+ * a busy backend into an unreachable one. Over-capacity is instead shed
+ * per-request via CONCURRENCY_LIMIT in the task routes, so a busy pod stays in
+ * rotation and returns clean retryable errors. (TAB-993)
+ */
+export function registerHealthRoutes(app: Hono): void {
+  // Liveness: is the process alive?
+  app.get("/health", (c) => {
+    return c.json({ status: "ok", timestamp: new Date().toISOString() });
+  });
+
+  // Readiness: should this pod receive traffic? Yes whenever the process is up.
+  app.get("/ready", (c) => {
+    return c.json({ status: "ok" });
+  });
+}

--- a/packages/server/src/index.test.ts
+++ b/packages/server/src/index.test.ts
@@ -44,21 +44,26 @@ describe("Server Application", () => {
     expect(data.description).toBe("Web server for Pilo AI-powered web automation");
   });
 
-  describe("GET /ready", () => {
+  describe("health/readiness probes", () => {
     beforeEach(() => {
       vi.resetModules();
     });
 
-    afterEach(() => {
+    afterEach(async () => {
       delete process.env.MAX_CONCURRENT_TASKS;
+      const { _resetActiveTasksForTesting } = await import("./concurrencyGuard.js");
+      _resetActiveTasksForTesting();
     });
 
-    it("should return 200 when below capacity", async () => {
-      const { isAtCapacity } = await import("./concurrencyGuard.js");
+    it("readiness returns 200 even when at concurrency capacity", async () => {
+      // MAX_CONCURRENT_TASKS=0 makes the pod report 'at capacity' for every
+      // task. Readiness must still report ready so the load balancer keeps
+      // routing here; over-capacity requests are shed per-request
+      // (CONCURRENCY_LIMIT), not by evicting the pod from the Service. (TAB-993)
+      process.env.MAX_CONCURRENT_TASKS = "0";
+      const { registerHealthRoutes } = await import("./health.js");
       const app = new Hono();
-      app.get("/ready", (c) =>
-        isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),
-      );
+      registerHealthRoutes(app);
 
       const res = await app.request("/ready");
       expect(res.status).toBe(200);
@@ -66,18 +71,15 @@ describe("Server Application", () => {
       expect(data.status).toBe("ok");
     });
 
-    it("should return 503 when at capacity", async () => {
-      process.env.MAX_CONCURRENT_TASKS = "0";
-      const { isAtCapacity } = await import("./concurrencyGuard.js");
+    it("liveness /health returns 200", async () => {
+      const { registerHealthRoutes } = await import("./health.js");
       const app = new Hono();
-      app.get("/ready", (c) =>
-        isAtCapacity() ? c.json({ status: "at capacity" }, 503) : c.json({ status: "ok" }),
-      );
+      registerHealthRoutes(app);
 
-      const res = await app.request("/ready");
-      expect(res.status).toBe(503);
+      const res = await app.request("/health");
+      expect(res.status).toBe(200);
       const data = await res.json();
-      expect(data.status).toBe("at capacity");
+      expect(data.status).toBe("ok");
     });
   });
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -10,7 +10,8 @@ import { createNodeWebSocket } from "@hono/node-ws";
 import { cors } from "hono/cors";
 import { sentry } from "@hono/sentry";
 import piloRoutes from "./routes/pilo.js";
-import { isAtCapacity, setDraining, getActiveTasks } from "./concurrencyGuard.js";
+import { setDraining, getActiveTasks } from "./concurrencyGuard.js";
+import { registerHealthRoutes } from "./health.js";
 import { createPiloWsRoute, type ActiveWS } from "./routes/piloWs.js";
 
 const app = new Hono();
@@ -43,19 +44,8 @@ app.use(
   }),
 );
 
-// Liveness: is the process alive?
-app.get("/health", (c) => {
-  return c.json({ status: "ok", timestamp: new Date().toISOString() });
-});
-
-// Readiness: should this pod receive traffic?
-// Returns 503 when at concurrency limit so the load balancer stops routing here.
-app.get("/ready", (c) => {
-  if (isAtCapacity()) {
-    return c.json({ status: "at capacity" }, 503);
-  }
-  return c.json({ status: "ok" });
-});
+// Liveness (/health) and readiness (/ready) probes.
+registerHealthRoutes(app);
 
 // Basic info endpoint
 app.get("/", (c) => {


### PR DESCRIPTION
## Summary

Fixes the staging-saturation cascade from the 2026-06-03 eval run ([TAB-993](https://linear.app/mozilla-np/issue/TAB-993)).

`/ready` returned 503 the instant a pod hit `MAX_CONCURRENT_TASKS` (default 3). With 2 replicas, ~6 concurrent tasks pulled every pod out of the k8s Service, so `tabs-api` → pilo calls failed (`tabstack_staging_error`) and partial responses produced blank pages (`browser_render_failure`).

Readiness now reflects **process health**, not free task slots — it returns 200 while the process is up. Over-capacity is still shed per-request via `CONCURRENCY_LIMIT`, so a busy pod stays in rotation and returns clean retryable errors instead of being evicted.

## Changes
- Extract `/health` + `/ready` into a side-effect-free `health.ts` (the real handler is now unit-testable; `index.ts` boots the server at import).
- `/ready` no longer consults `isAtCapacity()`.
- Test asserts `/ready` stays 200 at capacity (regression guard; inverts the old coupled assertion).
- Update `.env.example` doc to match.

## Testing
- `pnpm --filter pilo-server run test` → 99/99 pass
- `pnpm --filter pilo-server run typecheck` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)