### PR TITLE
fix(core): require abort() when a required filter/criterion can't be applied (TAB-995)

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -378,6 +378,7 @@ Analyze the current page state and determine your next action based on previous 
 4. Data grounding: every value in your answer must appear in a page snapshot, a tool result, or the task input. Do NOT use general knowledge to fill gaps. If a value was not found during this session, say so explicitly rather than inventing it.
 5. Blockers vs. obstacles: if you hit an unrecoverable block (paywall, login wall, access denied, payment declined) that prevented completing a core requirement, call abort() with the reason. Temporary obstacles you handled (dismissed popups, retried errors) don't change the outcome.
 6. If anything is unverified, incomplete, or uncertain — call abort() with the reason rather than done() with an overclaiming answer.
+7. Required steps are not optional: if a required filter, criterion, or input cannot be applied — the control is missing or unavailable, or the provided value looks malformed — you MUST call abort() with the reason. Do NOT call done() with partial or unfiltered results, and do NOT silently drop the requirement.
 
 **When using done():**
 Provide your final answer:

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -190,6 +190,15 @@ describe("prompts", () => {
       expect(actionLoopSystemPrompt).toContain("Best Practices:");
     });
 
+    it("requires abort() when a required filter/criterion cannot be applied", () => {
+      // Sub-pattern A from TAB-995: when a required filter/criterion/input cannot
+      // be applied, the agent must abort() rather than done() with partial or
+      // unfiltered results.
+      expect(actionLoopSystemPrompt).toContain(
+        "Do NOT call done() with partial or unfiltered results",
+      );
+    });
+
     it("should contain required instructions", () => {
       // Verify youArePrompt content is included
       expect(actionLoopSystemPrompt).toContain(


### PR DESCRIPTION
## Summary

Quick-win for [TAB-995](https://linear.app/mozilla-np/issue/TAB-995) (sub-pattern A from the 2026-06-03 eval).

In `webvoyagerx--Amazon--31`, a required price filter could not be applied (the value arrived malformed). The agent declared it invalid and returned an **unfiltered** list via `done()`, reporting success — the judge rejected it because the required filter was never applied.

The completion checklist already covered access blockers (item 5) and general uncertainty (item 6), but not the case where a *required filter/criterion/input cannot be applied*. This adds an explicit rule so the agent aborts instead of returning partial results.

## Change
- `prompts.ts` "Before calling done():" — new item 7: a required filter/criterion/input that can't be applied (missing/unavailable control, or malformed value) MUST `abort()` with the reason; never `done()` with partial/unfiltered results.
- Test asserts the action-loop system prompt contains the rule.

## Testing
- `pnpm --filter pilo-core run test` → 852/852 pass
- `pnpm --filter pilo-core run typecheck` → clean
- prettier clean

## Scope
Prompt-level mitigation (probabilistic). The durable **enforcing** fix — planner-emitted structured `requiredConstraints` fed to the validator + removing the unconditional force-accept (`webAgent.ts:1441`) — is the larger contract-changing work tracked in TAB-995. The malformed `$00 to $00` input itself is an external eval-harness bug (TAB-996), not Pilo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)