### PR TITLE
fix(core): bound the domcontentloaded wait in ensureOptimizedPageLoad

### DIFF
--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -590,8 +590,13 @@ export class PlaywrightBrowser implements AriaBrowser {
     if (!this.page) throw new Error("Browser not started");
 
     try {
-      // 1. Wait for DOM to be ready - this is critical for interactivity
-      await this.page.waitForLoadState("domcontentloaded");
+      // 1. Wait for DOM to be ready - this is critical for interactivity.
+      // Bounded by actionTimeoutMs: a page (or SPA soft-nav) that never reaches
+      // domcontentloaded must not hang the agent. On timeout we continue, since the
+      // page may still be interactive and the load wait + settle below still run.
+      await this.page.waitForLoadState("domcontentloaded", {
+        timeout: this.actionTimeoutMs,
+      });
     } catch (error) {
       // Still continue since we might be able to interact with what's loaded
     }

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -1340,4 +1340,20 @@ describe("PlaywrightBrowser", () => {
       expect(error).not.toBeInstanceOf(BrowserDisconnectedError);
     });
   });
+
+  describe("ensureOptimizedPageLoad", () => {
+    it("bounds the domcontentloaded wait with actionTimeoutMs so it can't hang indefinitely", async () => {
+      const browser = new PlaywrightBrowser({ browser: "chromium", actionTimeoutMs: 1234 });
+      const waitForLoadState = vi.fn().mockResolvedValue(undefined);
+      (browser as any).page = {
+        waitForLoadState,
+        waitForTimeout: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await (browser as any).ensureOptimizedPageLoad();
+
+      // The domcontentloaded wait must carry a timeout (previously unbounded).
+      expect(waitForLoadState).toHaveBeenCalledWith("domcontentloaded", { timeout: 1234 });
+    });
+  });
 });


### PR DESCRIPTION
Closes #514.

## Problem

`PlaywrightBrowser.ensureOptimizedPageLoad()` waited for `domcontentloaded` with **no timeout**:

```ts
await this.page.waitForLoadState("domcontentloaded");   // unbounded
```

The `load` wait immediately below is bounded by `actionTimeoutMs`, and the settle is a fixed 1s — only this first wait was unbounded. A navigation that commits to a page (or SPA soft-navigation) that never fires `DOMContentLoaded` as Playwright tracks it could hang the await indefinitely. Same class of freeze as #511, on the path that runs after **every** navigation (click-nav, `goto`, back/forward).

## Fix

Pass `{ timeout: this.actionTimeoutMs }` to the `domcontentloaded` wait, matching the `load` wait. It's already inside a `try/catch` that continues on failure, so a timeout simply proceeds to the bounded `load` wait and the settle delay — **no behavior change on healthy pages**, just removes the unbounded-hang risk. Reuses `actionTimeoutMs` rather than adding a new knob (both waits answer "how long to wait for the page to be ready").

## Testing

- New `ensureOptimizedPageLoad` test asserting `waitForLoadState("domcontentloaded", { timeout: actionTimeoutMs })` is called (guards against the timeout being dropped again). Red before the fix, green after.
- Full core suite: **862 pass** (861 baseline + 1). Typecheck + `prettier --check` clean.

No live run: this is a latent path (needs a page that never fires `DOMContentLoaded`), not reliably reproducible on demand; the unit test is the meaningful guard and the change mirrors the already-bounded `load` wait.

## Context

Follow-up to #511. Sibling reliability issues: #515 (stream timeout), #516 (agent-loop watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)