### PR TITLE
fix(core): CDP connect retry with backoff; single-endpoint reconnect (TAB-997)

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -241,6 +241,10 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
           (options.pwCdpEndpoints as string[] | undefined) ??
           cfg.pw_cdp_endpoints ??
           (cfg.pw_cdp_endpoint ? [cfg.pw_cdp_endpoint] : undefined),
+        cdpConnectRetry: {
+          maxAttempts: options.cdpConnectMaxAttempts ?? cfg.cdp_connect_max_attempts,
+          backoffBaseMs: options.cdpConnectBackoffBaseMs ?? cfg.cdp_connect_backoff_base_ms,
+        },
         actionTimeoutMs: options.actionTimeoutMs ?? cfg.action_timeout_ms,
         navigationRetry: {
           baseTimeoutMs: options.navigationTimeoutMs ?? cfg.navigation_timeout_ms,

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -244,6 +244,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
         cdpConnectRetry: {
           maxAttempts: options.cdpConnectMaxAttempts ?? cfg.cdp_connect_max_attempts,
           backoffBaseMs: options.cdpConnectBackoffBaseMs ?? cfg.cdp_connect_backoff_base_ms,
+          backoffMaxMs: options.cdpConnectBackoffMaxMs ?? cfg.cdp_connect_backoff_max_ms,
         },
         actionTimeoutMs: options.actionTimeoutMs ?? cfg.action_timeout_ms,
         navigationRetry: {

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -66,6 +66,8 @@ export interface PlaywrightBrowserOptions {
   pwCdpEndpoint?: string;
   /** Ordered list of CDP endpoint URLs to try in sequence (chromium only, takes precedence over pwCdpEndpoint) */
   pwCdpEndpoints?: string[];
+  /** Retry/backoff configuration for CDP connection attempts (chromium only) */
+  cdpConnectRetry?: Partial<CdpConnectRetryConfig>;
   /** Called when a CDP endpoint fails and the next one is being tried */
   onCdpEndpointCycle?: (attempt: number, error: Error) => void;
   /** Called when a CDP endpoint is successfully connected to */
@@ -100,6 +102,39 @@ export interface ExtendedPlaywrightBrowserOptions extends PlaywrightBrowserOptio
  */
 /** Timeout per CDP endpoint connection attempt in milliseconds */
 const CDP_CONNECTION_TIMEOUT_MS = 5_000;
+
+/**
+ * Retry/backoff settings for CDP connection attempts. Each endpoint is retried up to
+ * `maxAttempts` times on transient connection errors before failing over to the next
+ * endpoint (a retry is a "failover-to-self"). Backoff is exponential with jitter,
+ * capped at `backoffMaxMs`.
+ */
+export interface CdpConnectRetryConfig {
+  /** Max connection attempts per endpoint (>= 1) */
+  maxAttempts: number;
+  /** Base delay for exponential backoff, in milliseconds */
+  backoffBaseMs: number;
+  /** Cap on backoff delay, in milliseconds */
+  backoffMaxMs: number;
+}
+
+/** Default attempts per CDP endpoint before failing over to the next endpoint */
+const CDP_CONNECT_MAX_ATTEMPTS = 3;
+/** Default base delay (ms) for exponential backoff between CDP connect retries */
+const CDP_CONNECT_BACKOFF_BASE_MS = 1_000;
+/** Cap (ms) on the exponential backoff delay between CDP connect retries */
+const CDP_CONNECT_BACKOFF_MAX_MS = 10_000;
+
+/** Resolve a partial retry config against defaults, ignoring undefined overrides. */
+function resolveCdpConnectRetryConfig(
+  partial?: Partial<CdpConnectRetryConfig>,
+): CdpConnectRetryConfig {
+  return {
+    maxAttempts: Math.max(1, partial?.maxAttempts ?? CDP_CONNECT_MAX_ATTEMPTS),
+    backoffBaseMs: partial?.backoffBaseMs ?? CDP_CONNECT_BACKOFF_BASE_MS,
+    backoffMaxMs: partial?.backoffMaxMs ?? CDP_CONNECT_BACKOFF_MAX_MS,
+  };
+}
 
 /**
  * Timeout for evaluating the aria-tree script in a single frame, in milliseconds.
@@ -144,6 +179,7 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   // CDP endpoint failover state
   private readonly cdpEndpoints: string[];
+  private readonly cdpConnectRetry: CdpConnectRetryConfig;
   private nextStartIndex: number = 0;
 
   /** Called when a CDP endpoint fails and the next one is being tried. Can be set after construction. */
@@ -172,6 +208,9 @@ export class PlaywrightBrowser implements AriaBrowser {
       : options.pwCdpEndpoint
         ? [options.pwCdpEndpoint]
         : [];
+
+    // Resolve CDP connect retry/backoff config (defaults safely applied)
+    this.cdpConnectRetry = resolveCdpConnectRetryConfig(options.cdpConnectRetry);
 
     // Initialize callbacks from options (can also be set directly after construction)
     this.onCdpEndpointCycle = options.onCdpEndpointCycle;
@@ -481,34 +520,81 @@ export class PlaywrightBrowser implements AriaBrowser {
   }
 
   /**
-   * Try each CDP endpoint in sequence starting from nextStartIndex.
-   * Advances nextStartIndex on success. Throws a hard error if all are exhausted.
+   * Connect over CDP with retry and failover.
+   *
+   * Visits every configured endpoint once per call, starting at `nextStartIndex` and
+   * wrapping with modulo. Wrapping (rather than slicing from `nextStartIndex` to the end)
+   * is what gives each `start()` a fresh attempt budget: a single-endpoint reconnect after
+   * a prior success — where `nextStartIndex` has advanced to 1 — still attempts that
+   * endpoint instead of running an empty loop and instantly failing.
+   *
+   * Each endpoint is retried up to `cdpConnectRetry.maxAttempts` times on transient
+   * connection errors (a retry is a failover-to-self), with exponential backoff + jitter
+   * between attempts. Non-connection errors (e.g. auth) throw immediately. When an
+   * endpoint's attempts are exhausted, control fails over to the next endpoint. If every
+   * endpoint is exhausted, a hard error is thrown.
+   *
+   * On success, `nextStartIndex` advances past the connected endpoint so a later restart
+   * prefers the next distinct endpoint (multi-endpoint failover semantics preserved).
    */
   private async connectOverCDPWithFailover(
     connectOptions: ConnectOptions,
   ): Promise<PlaywrightOriginalBrowser> {
-    for (let i = this.nextStartIndex; i < this.cdpEndpoints.length; i++) {
-      const endpoint = this.cdpEndpoints[i];
-      try {
-        const browser = await chromium.connectOverCDP(endpoint, {
-          ...connectOptions,
-          timeout: CDP_CONNECTION_TIMEOUT_MS,
-        });
-        this.nextStartIndex = i + 1;
-        this.onCdpEndpointConnected?.(i + 1, this.cdpEndpoints.length);
-        return browser;
-      } catch (err) {
-        if (!(err instanceof Error) || !this.isCdpConnectionError(err)) {
-          throw err;
-        }
-        const attemptNumber = i + 1;
-        const remaining = this.cdpEndpoints.length - i - 1;
-        if (remaining > 0) {
-          this.onCdpEndpointCycle?.(attemptNumber, err);
+    const total = this.cdpEndpoints.length;
+    const { maxAttempts } = this.cdpConnectRetry;
+
+    for (let visited = 0; visited < total; visited++) {
+      const index = (this.nextStartIndex + visited) % total;
+      const endpoint = this.cdpEndpoints[index];
+      const isLastEndpoint = visited === total - 1;
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+        try {
+          const browser = await chromium.connectOverCDP(endpoint, {
+            ...connectOptions,
+            timeout: CDP_CONNECTION_TIMEOUT_MS,
+          });
+          this.nextStartIndex = index + 1;
+          this.onCdpEndpointConnected?.(index + 1, total);
+          return browser;
+        } catch (err) {
+          // Non-connection errors (auth, malformed URL, ...) are not transient — fail fast.
+          if (!(err instanceof Error) || !this.isCdpConnectionError(err)) {
+            throw err;
+          }
+
+          const moreAttemptsOnThisEndpoint = attempt < maxAttempts;
+          if (moreAttemptsOnThisEndpoint) {
+            // Same-endpoint retry: back off, then try this endpoint again.
+            await this.delay(this.backoffDelayMs(attempt));
+            continue;
+          }
+
+          // Endpoint exhausted. Fail over to the next endpoint if one remains.
+          if (!isLastEndpoint) {
+            this.onCdpEndpointCycle?.(index + 1, err);
+          }
         }
       }
     }
-    throw new Error(`All ${this.cdpEndpoints.length} CDP endpoint(s) failed. Giving up.`);
+
+    throw new Error(`All ${total} CDP endpoint(s) failed. Giving up.`);
+  }
+
+  /**
+   * Exponential backoff delay for the Nth retry, capped and jittered.
+   * `attempt` is 1-based (1 → base, 2 → 2×base, ...). Full jitter in [0, computed].
+   */
+  private backoffDelayMs(attempt: number): number {
+    const { backoffBaseMs, backoffMaxMs } = this.cdpConnectRetry;
+    const exponential = backoffBaseMs * 2 ** (attempt - 1);
+    const capped = Math.min(exponential, backoffMaxMs);
+    return Math.floor(Math.random() * capped);
+  }
+
+  /** Promise-based delay (testable under fake timers). */
+  private delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   /**

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -118,21 +118,15 @@ export interface CdpConnectRetryConfig {
   backoffMaxMs: number;
 }
 
-/** Default attempts per CDP endpoint before failing over to the next endpoint */
-const CDP_CONNECT_MAX_ATTEMPTS = 3;
-/** Default base delay (ms) for exponential backoff between CDP connect retries */
-const CDP_CONNECT_BACKOFF_BASE_MS = 1_000;
-/** Cap (ms) on the exponential backoff delay between CDP connect retries */
-const CDP_CONNECT_BACKOFF_MAX_MS = 10_000;
-
-/** Resolve a partial retry config against defaults, ignoring undefined overrides. */
+/** Resolve a partial retry config against schema defaults, ignoring undefined overrides. */
 function resolveCdpConnectRetryConfig(
   partial?: Partial<CdpConnectRetryConfig>,
 ): CdpConnectRetryConfig {
+  const defaults = getConfigDefaults();
   return {
-    maxAttempts: Math.max(1, partial?.maxAttempts ?? CDP_CONNECT_MAX_ATTEMPTS),
-    backoffBaseMs: partial?.backoffBaseMs ?? CDP_CONNECT_BACKOFF_BASE_MS,
-    backoffMaxMs: partial?.backoffMaxMs ?? CDP_CONNECT_BACKOFF_MAX_MS,
+    maxAttempts: Math.max(1, partial?.maxAttempts ?? defaults.cdp_connect_max_attempts),
+    backoffBaseMs: partial?.backoffBaseMs ?? defaults.cdp_connect_backoff_base_ms,
+    backoffMaxMs: partial?.backoffMaxMs ?? defaults.cdp_connect_backoff_max_ms,
   };
 }
 

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -517,9 +517,10 @@ export class PlaywrightBrowser implements AriaBrowser {
    * Connect over CDP with per-endpoint retry (exponential backoff + jitter) and failover
    * across endpoints. The index wraps modulo from `nextStartIndex` so each call gets a
    * fresh budget — a single-endpoint reconnect (nextStartIndex already past 0) still
-   * retries that endpoint instead of looping zero times. Non-connection errors throw
-   * immediately; on success nextStartIndex advances so a later restart prefers the next
-   * endpoint.
+   * retries that endpoint instead of looping zero times. Every connect failure is retried
+   * (bounded): Playwright flattens connect errors to message-only `Error`s with no
+   * structured codes, and connecting is idempotent, so classifying is unsound — we retry
+   * all. On success nextStartIndex advances so a later restart prefers the next endpoint.
    */
   private async connectOverCDPWithFailover(
     connectOptions: ConnectOptions,
@@ -542,15 +543,13 @@ export class PlaywrightBrowser implements AriaBrowser {
           this.onCdpEndpointConnected?.(index + 1, total);
           return browser;
         } catch (err) {
-          if (!(err instanceof Error) || !this.isCdpConnectionError(err)) {
-            throw err; // non-connection error (auth, bad URL) — not transient
-          }
           if (attempt < maxAttempts) {
             await this.delay(this.backoffDelayMs(attempt));
             continue;
           }
           if (!isLastEndpoint) {
-            this.onCdpEndpointCycle?.(index + 1, err);
+            const error = err instanceof Error ? err : new Error(String(err));
+            this.onCdpEndpointCycle?.(index + 1, error);
           }
         }
       }
@@ -569,22 +568,6 @@ export class PlaywrightBrowser implements AriaBrowser {
 
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
-  }
-
-  /**
-   * Returns true for connection-level errors that should trigger CDP endpoint cycling:
-   * timeouts and network-level failures. Auth errors, malformed URLs, etc. return false.
-   */
-  private isCdpConnectionError(error: Error): boolean {
-    if (error instanceof playwrightErrors.TimeoutError) return true;
-    const message = error.message;
-    return (
-      message.includes("ECONNREFUSED") ||
-      message.includes("ECONNRESET") ||
-      message.includes("ETIMEDOUT") ||
-      message.includes("net::ERR_") ||
-      message.includes("NS_ERROR_")
-    );
   }
 
   /**

--- a/packages/core/src/browser/playwrightBrowser.ts
+++ b/packages/core/src/browser/playwrightBrowser.ts
@@ -520,22 +520,12 @@ export class PlaywrightBrowser implements AriaBrowser {
   }
 
   /**
-   * Connect over CDP with retry and failover.
-   *
-   * Visits every configured endpoint once per call, starting at `nextStartIndex` and
-   * wrapping with modulo. Wrapping (rather than slicing from `nextStartIndex` to the end)
-   * is what gives each `start()` a fresh attempt budget: a single-endpoint reconnect after
-   * a prior success — where `nextStartIndex` has advanced to 1 — still attempts that
-   * endpoint instead of running an empty loop and instantly failing.
-   *
-   * Each endpoint is retried up to `cdpConnectRetry.maxAttempts` times on transient
-   * connection errors (a retry is a failover-to-self), with exponential backoff + jitter
-   * between attempts. Non-connection errors (e.g. auth) throw immediately. When an
-   * endpoint's attempts are exhausted, control fails over to the next endpoint. If every
-   * endpoint is exhausted, a hard error is thrown.
-   *
-   * On success, `nextStartIndex` advances past the connected endpoint so a later restart
-   * prefers the next distinct endpoint (multi-endpoint failover semantics preserved).
+   * Connect over CDP with per-endpoint retry (exponential backoff + jitter) and failover
+   * across endpoints. The index wraps modulo from `nextStartIndex` so each call gets a
+   * fresh budget — a single-endpoint reconnect (nextStartIndex already past 0) still
+   * retries that endpoint instead of looping zero times. Non-connection errors throw
+   * immediately; on success nextStartIndex advances so a later restart prefers the next
+   * endpoint.
    */
   private async connectOverCDPWithFailover(
     connectOptions: ConnectOptions,
@@ -558,19 +548,13 @@ export class PlaywrightBrowser implements AriaBrowser {
           this.onCdpEndpointConnected?.(index + 1, total);
           return browser;
         } catch (err) {
-          // Non-connection errors (auth, malformed URL, ...) are not transient — fail fast.
           if (!(err instanceof Error) || !this.isCdpConnectionError(err)) {
-            throw err;
+            throw err; // non-connection error (auth, bad URL) — not transient
           }
-
-          const moreAttemptsOnThisEndpoint = attempt < maxAttempts;
-          if (moreAttemptsOnThisEndpoint) {
-            // Same-endpoint retry: back off, then try this endpoint again.
+          if (attempt < maxAttempts) {
             await this.delay(this.backoffDelayMs(attempt));
             continue;
           }
-
-          // Endpoint exhausted. Fail over to the next endpoint if one remains.
           if (!isLastEndpoint) {
             this.onCdpEndpointCycle?.(index + 1, err);
           }
@@ -581,10 +565,7 @@ export class PlaywrightBrowser implements AriaBrowser {
     throw new Error(`All ${total} CDP endpoint(s) failed. Giving up.`);
   }
 
-  /**
-   * Exponential backoff delay for the Nth retry, capped and jittered.
-   * `attempt` is 1-based (1 → base, 2 → 2×base, ...). Full jitter in [0, computed].
-   */
+  /** Exponential backoff with full jitter for the 1-based attempt, capped at backoffMaxMs. */
   private backoffDelayMs(attempt: number): number {
     const { backoffBaseMs, backoffMaxMs } = this.cdpConnectRetry;
     const exponential = backoffBaseMs * 2 ** (attempt - 1);
@@ -592,7 +573,6 @@ export class PlaywrightBrowser implements AriaBrowser {
     return Math.floor(Math.random() * capped);
   }
 
-  /** Promise-based delay (testable under fake timers). */
   private delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -116,6 +116,8 @@ export interface PiloConfig {
   pw_endpoint?: string;
   pw_cdp_endpoint?: string;
   pw_cdp_endpoints?: string[];
+  cdp_connect_max_attempts?: number;
+  cdp_connect_backoff_base_ms?: number;
   bypass_csp?: boolean;
 
   // Navigation Configuration (timeouts in milliseconds)
@@ -191,6 +193,8 @@ export interface PiloConfigResolved {
   pw_endpoint?: string;
   pw_cdp_endpoint?: string;
   pw_cdp_endpoints?: string[];
+  cdp_connect_max_attempts: number;
+  cdp_connect_backoff_base_ms: number;
   bypass_csp: boolean;
 
   // Navigation Configuration (timeouts in milliseconds)
@@ -589,6 +593,26 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
       "Comma-separated list of CDP endpoint URLs to try in order (chromium only, takes precedence over --pw-cdp-endpoint)",
     category: "playwright",
   },
+  cdp_connect_max_attempts: {
+    default: 3,
+    type: "number",
+    cli: "--cdp-connect-max-attempts",
+    placeholder: "n",
+    env: ["PILO_CDP_CONNECT_MAX_ATTEMPTS"],
+    description:
+      "Max connection attempts per CDP endpoint before failing over to the next (chromium only). Retries transient connection errors with exponential backoff.",
+    category: "playwright",
+  },
+  cdp_connect_backoff_base_ms: {
+    default: 1000,
+    type: "number",
+    cli: "--cdp-connect-backoff-base-ms",
+    placeholder: "ms",
+    env: ["PILO_CDP_CONNECT_BACKOFF_BASE_MS"],
+    description:
+      "Base delay in milliseconds for exponential backoff between CDP connect retries (doubles each attempt, capped at 10s, with jitter)",
+    category: "playwright",
+  },
   bypass_csp: {
     default: false,
     type: "boolean",
@@ -736,6 +760,8 @@ function buildDefaults(): PiloConfigResolved {
     "max_consecutive_errors",
     "max_total_errors",
     "initial_navigation_retries",
+    "cdp_connect_max_attempts",
+    "cdp_connect_backoff_base_ms",
     "bypass_csp",
     "navigation_timeout_ms",
     "navigation_max_timeout_ms",

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -118,6 +118,7 @@ export interface PiloConfig {
   pw_cdp_endpoints?: string[];
   cdp_connect_max_attempts?: number;
   cdp_connect_backoff_base_ms?: number;
+  cdp_connect_backoff_max_ms?: number;
   bypass_csp?: boolean;
 
   // Navigation Configuration (timeouts in milliseconds)
@@ -195,6 +196,7 @@ export interface PiloConfigResolved {
   pw_cdp_endpoints?: string[];
   cdp_connect_max_attempts: number;
   cdp_connect_backoff_base_ms: number;
+  cdp_connect_backoff_max_ms: number;
   bypass_csp: boolean;
 
   // Navigation Configuration (timeouts in milliseconds)
@@ -610,7 +612,17 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     placeholder: "ms",
     env: ["PILO_CDP_CONNECT_BACKOFF_BASE_MS"],
     description:
-      "Base delay in milliseconds for exponential backoff between CDP connect retries (doubles each attempt, capped at 10s, with jitter)",
+      "Base delay in milliseconds for exponential backoff between CDP connect retries (doubles each attempt, capped at cdp_connect_backoff_max_ms, with jitter)",
+    category: "playwright",
+  },
+  cdp_connect_backoff_max_ms: {
+    default: 10000,
+    type: "number",
+    cli: "--cdp-connect-backoff-max-ms",
+    placeholder: "ms",
+    env: ["PILO_CDP_CONNECT_BACKOFF_MAX_MS"],
+    description:
+      "Maximum delay in milliseconds for exponential backoff between CDP connect retries (chromium only)",
     category: "playwright",
   },
   bypass_csp: {
@@ -762,6 +774,7 @@ function buildDefaults(): PiloConfigResolved {
     "initial_navigation_retries",
     "cdp_connect_max_attempts",
     "cdp_connect_backoff_base_ms",
+    "cdp_connect_backoff_max_ms",
     "bypass_csp",
     "navigation_timeout_ms",
     "navigation_max_timeout_ms",

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -187,6 +187,7 @@ describe("ConfigManager", () => {
         "pw_cdp_endpoints",
         "cdp_connect_max_attempts",
         "cdp_connect_backoff_base_ms",
+        "cdp_connect_backoff_max_ms",
         "bypass_csp",
         "navigation_timeout_ms",
         "navigation_max_timeout_ms",

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -185,6 +185,8 @@ describe("ConfigManager", () => {
         "pw_endpoint",
         "pw_cdp_endpoint",
         "pw_cdp_endpoints",
+        "cdp_connect_max_attempts",
+        "cdp_connect_backoff_base_ms",
         "bypass_csp",
         "navigation_timeout_ms",
         "navigation_max_timeout_ms",

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -1085,6 +1085,9 @@ describe("PlaywrightBrowser", () => {
       const browser = new PlaywrightBrowser({
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
+        // One attempt per endpoint: a single failure on host-a exhausts its
+        // budget and forces failover to host-b (the behavior under test here).
+        cdpConnectRetry: { maxAttempts: 1 },
       });
       await browser.start();
 
@@ -1102,6 +1105,7 @@ describe("PlaywrightBrowser", () => {
       const browser = new PlaywrightBrowser({
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
+        cdpConnectRetry: { maxAttempts: 1 },
       });
       await browser.start();
 
@@ -1115,6 +1119,9 @@ describe("PlaywrightBrowser", () => {
       const browser = new PlaywrightBrowser({
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222", "ws://host-c:9222"],
+        // One attempt per endpoint isolates the failover (cross-endpoint) count
+        // from the same-endpoint retry behavior exercised in the retry suite.
+        cdpConnectRetry: { maxAttempts: 1 },
       });
 
       await expect(browser.start()).rejects.toThrow("All 3 CDP endpoint(s) failed");
@@ -1170,6 +1177,9 @@ describe("PlaywrightBrowser", () => {
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
         onCdpEndpointCycle: cycleCallback,
+        // One attempt per endpoint so the single host-a failure cycles to host-b
+        // rather than being absorbed by a same-endpoint retry.
+        cdpConnectRetry: { maxAttempts: 1 },
       });
       await browser.start();
 
@@ -1196,6 +1206,176 @@ describe("PlaywrightBrowser", () => {
       // (We just verify the internal state; actual launch isn't tested here)
       const browser = new PlaywrightBrowser({ browser: "chromium" });
       expect((browser as any).cdpEndpoints).toEqual([]);
+    });
+  });
+
+  describe("CDP connect retry with backoff", () => {
+    let mockChromium: { connectOverCDP: ReturnType<typeof vi.fn> };
+
+    beforeEach(async () => {
+      const playwright = await import("playwright");
+      mockChromium = playwright.chromium as any;
+      vi.clearAllMocks();
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.clearAllMocks();
+    });
+
+    function makeMockBrowser() {
+      const mockPage = { setDefaultTimeout: vi.fn(), close: vi.fn() };
+      const mockContext = { newPage: vi.fn().mockResolvedValue(mockPage), close: vi.fn() };
+      const mockBrowser = { newContext: vi.fn().mockResolvedValue(mockContext), close: vi.fn() };
+      return { mockBrowser, mockContext, mockPage };
+    }
+
+    it("retries the same endpoint on a transient connection error, then succeeds", async () => {
+      const { mockBrowser } = makeMockBrowser();
+      // Two transient failures on the single endpoint, then success on attempt 3.
+      mockChromium.connectOverCDP
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(mockBrowser);
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222"],
+        cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 1000 },
+      });
+
+      const startPromise = browser.start();
+      // Drain pending microtasks + scheduled backoff timers until the retries resolve.
+      await vi.runAllTimersAsync();
+      await startPromise;
+
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
+      // Every retry hit the SAME endpoint.
+      for (const call of mockChromium.connectOverCDP.mock.calls) {
+        expect(call[0]).toBe("ws://host-a:9222");
+      }
+      expect(browser.pwCdpEndpoint).toBe("ws://host-a:9222");
+    });
+
+    it("waits with a backoff delay between same-endpoint retries", async () => {
+      const { mockBrowser } = makeMockBrowser();
+      mockChromium.connectOverCDP
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(mockBrowser);
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222"],
+        cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 1000 },
+      });
+
+      const startPromise = browser.start();
+
+      // Let the first (failing) attempt settle, but do NOT advance timers yet.
+      await Promise.resolve();
+      await Promise.resolve();
+      // Backoff is pending: the second attempt must not have fired yet.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(1);
+
+      await vi.runAllTimersAsync();
+      await startPromise;
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(2);
+    });
+
+    it("gives up after max attempts with the all-failed error", async () => {
+      mockChromium.connectOverCDP.mockRejectedValue(new Error("ECONNREFUSED"));
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222"],
+        cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 1000 },
+      });
+
+      const startPromise = browser.start();
+      // Attach the rejection handler before draining timers to avoid an
+      // unhandled rejection during the fake-timer flush.
+      const assertion = expect(startPromise).rejects.toThrow("All 1 CDP endpoint(s) failed");
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      // Single endpoint × 3 attempts.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
+    });
+
+    it("does not retry a non-connection error — throws immediately", async () => {
+      mockChromium.connectOverCDP.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222"],
+        cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 1000 },
+      });
+
+      const startPromise = browser.start();
+      const assertion = expect(startPromise).rejects.toThrow("HTTP 401 Unauthorized");
+      await vi.runAllTimersAsync();
+      await assertion;
+
+      // No retry on a non-connection (auth) error.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(1);
+    });
+
+    it("single-endpoint reconnect: a second start() connects again instead of instantly failing", async () => {
+      const { mockBrowser } = makeMockBrowser();
+      mockChromium.connectOverCDP.mockResolvedValue(mockBrowser);
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222"],
+        cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 1000 },
+      });
+
+      const first = browser.start();
+      await vi.runAllTimersAsync();
+      await first;
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(1);
+
+      // Simulate a mid-task disconnect + reconnect.
+      await browser.shutdown();
+      const second = browser.start();
+      await vi.runAllTimersAsync();
+      await second;
+
+      // Reconnect must actually attempt the endpoint again — the pre-fix bug
+      // ran `for (i = 1; i < 1; ...)` and threw "All 1 CDP endpoint(s) failed".
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(2);
+      expect(mockChromium.connectOverCDP).toHaveBeenLastCalledWith(
+        "ws://host-a:9222",
+        expect.any(Object),
+      );
+      expect(browser.pwCdpEndpoint).toBe("ws://host-a:9222");
+    });
+
+    it("multi-endpoint failover still advances to the next endpoint after exhausting retries", async () => {
+      const { mockBrowser } = makeMockBrowser();
+      // host-a fails both attempts; host-b succeeds on its first attempt.
+      mockChromium.connectOverCDP
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(mockBrowser);
+
+      const browser = new PlaywrightBrowser({
+        browser: "chromium",
+        pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
+        cdpConnectRetry: { maxAttempts: 2, backoffBaseMs: 1000 },
+      });
+
+      const startPromise = browser.start();
+      await vi.runAllTimersAsync();
+      await startPromise;
+
+      // 2 attempts on host-a, then 1 on host-b.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
+      expect(mockChromium.connectOverCDP.mock.calls[0][0]).toBe("ws://host-a:9222");
+      expect(mockChromium.connectOverCDP.mock.calls[1][0]).toBe("ws://host-a:9222");
+      expect(mockChromium.connectOverCDP.mock.calls[2][0]).toBe("ws://host-b:9222");
+      expect(browser.pwCdpEndpoint).toBe("ws://host-b:9222");
     });
   });
 

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -1377,6 +1377,39 @@ describe("PlaywrightBrowser", () => {
       expect(mockChromium.connectOverCDP.mock.calls[2][0]).toBe("ws://host-b:9222");
       expect(browser.pwCdpEndpoint).toBe("ws://host-b:9222");
     });
+
+    it("caps the backoff delay at the configured backoffMaxMs", async () => {
+      const { mockBrowser } = makeMockBrowser();
+      // Fail twice so two backoff delays are scheduled, then succeed.
+      mockChromium.connectOverCDP
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockRejectedValueOnce(new Error("ECONNREFUSED"))
+        .mockResolvedValueOnce(mockBrowser);
+
+      // Near-max jitter so the delay ~= the (capped) exponential, isolating the cap.
+      const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.999999);
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      try {
+        const browser = new PlaywrightBrowser({
+          browser: "chromium",
+          pwCdpEndpoints: ["ws://host-a:9222"],
+          // Un-capped exponential would be 5000 then 10000; both must clamp to 1000.
+          cdpConnectRetry: { maxAttempts: 3, backoffBaseMs: 5000, backoffMaxMs: 1000 },
+        });
+
+        const startPromise = browser.start();
+        await vi.runAllTimersAsync();
+        await startPromise;
+
+        // Two retries scheduled; every backoff delay is clamped to backoffMaxMs (1000).
+        // floor(0.999999 * 1000) = 999, never the un-capped 5000/10000.
+        const delays = setTimeoutSpy.mock.calls.map((c) => c[1]);
+        expect(delays).toEqual([999, 999]);
+      } finally {
+        setTimeoutSpy.mockRestore();
+        randomSpy.mockRestore();
+      }
+    });
   });
 
   describe("browser disconnect detection", () => {

--- a/packages/core/test/playwrightBrowser.test.ts
+++ b/packages/core/test/playwrightBrowser.test.ts
@@ -1128,17 +1128,22 @@ describe("PlaywrightBrowser", () => {
       expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
     });
 
-    it("does not cycle on auth/hard errors", async () => {
+    it("retries every endpoint on any connect failure, then fails over", async () => {
+      // Any connect error (here an auth-shaped message) is retried per endpoint
+      // and cycles — no classifier gates failover. Playwright flattens connect
+      // errors to message-only, so retry-all is the only sound policy.
       mockChromium.connectOverCDP.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
 
       const browser = new PlaywrightBrowser({
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
+        // One attempt per endpoint isolates the failover count from same-endpoint retry.
+        cdpConnectRetry: { maxAttempts: 1 },
       });
 
-      await expect(browser.start()).rejects.toThrow("HTTP 401 Unauthorized");
-      // Only tried the first endpoint — didn't cycle
-      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(1);
+      await expect(browser.start()).rejects.toThrow("All 2 CDP endpoint(s) failed");
+      // Cycled through both endpoints.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(2);
     });
 
     it("advances nextStartIndex after successful connection for mid-task restart", async () => {
@@ -1187,7 +1192,7 @@ describe("PlaywrightBrowser", () => {
       expect(cycleCallback).toHaveBeenCalledWith(1, expect.any(Error));
     });
 
-    it("does not call onCdpEndpointCycle on hard errors", async () => {
+    it("calls onCdpEndpointCycle on any connect failure when cycling", async () => {
       const cycleCallback = vi.fn();
       mockChromium.connectOverCDP.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
 
@@ -1195,10 +1200,14 @@ describe("PlaywrightBrowser", () => {
         browser: "chromium",
         pwCdpEndpoints: ["ws://host-a:9222", "ws://host-b:9222"],
         onCdpEndpointCycle: cycleCallback,
+        // One attempt per endpoint so the first failure cycles rather than retrying in place.
+        cdpConnectRetry: { maxAttempts: 1 },
       });
 
       await expect(browser.start()).rejects.toThrow();
-      expect(cycleCallback).not.toHaveBeenCalled();
+      // Cycled off the first (non-last) endpoint.
+      expect(cycleCallback).toHaveBeenCalledOnce();
+      expect(cycleCallback).toHaveBeenCalledWith(1, expect.any(Error));
     });
 
     it("falls through to local launch when cdpEndpoints is empty", () => {
@@ -1303,7 +1312,10 @@ describe("PlaywrightBrowser", () => {
       expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
     });
 
-    it("does not retry a non-connection error — throws immediately", async () => {
+    it("retries any connect failure up to maxAttempts, then throws", async () => {
+      // Connect failures are not classified — an auth-shaped message is retried
+      // the same as a transient one (Playwright flattens connect errors to
+      // message-only; connecting is idempotent, so retry-all is sound).
       mockChromium.connectOverCDP.mockRejectedValue(new Error("HTTP 401 Unauthorized"));
 
       const browser = new PlaywrightBrowser({
@@ -1313,12 +1325,12 @@ describe("PlaywrightBrowser", () => {
       });
 
       const startPromise = browser.start();
-      const assertion = expect(startPromise).rejects.toThrow("HTTP 401 Unauthorized");
+      const assertion = expect(startPromise).rejects.toThrow("All 1 CDP endpoint(s) failed");
       await vi.runAllTimersAsync();
       await assertion;
 
-      // No retry on a non-connection (auth) error.
-      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(1);
+      // Retried up to maxAttempts on the single endpoint before giving up.
+      expect(mockChromium.connectOverCDP).toHaveBeenCalledTimes(3);
     });
 
     it("single-endpoint reconnect: a second start() connects again instead of instantly failing", async () => {

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -54,6 +54,7 @@ export interface PiloTaskRequest {
   pwCdpEndpoints?: string[];
   cdpConnectMaxAttempts?: number;
   cdpConnectBackoffBaseMs?: number;
+  cdpConnectBackoffMaxMs?: number;
   bypassCSP?: boolean;
 
   // WebAgent behavior overrides
@@ -334,6 +335,7 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
     cdpConnectRetry: {
       maxAttempts: body.cdpConnectMaxAttempts ?? serverConfig.cdp_connect_max_attempts,
       backoffBaseMs: body.cdpConnectBackoffBaseMs ?? serverConfig.cdp_connect_backoff_base_ms,
+      backoffMaxMs: body.cdpConnectBackoffMaxMs ?? serverConfig.cdp_connect_backoff_max_ms,
     },
     bypassCSP: body.bypassCSP ?? serverConfig.bypass_csp,
     proxyServer: body.proxy ?? serverConfig.proxy,

--- a/packages/server/src/taskRunner.ts
+++ b/packages/server/src/taskRunner.ts
@@ -52,6 +52,8 @@ export interface PiloTaskRequest {
   pwEndpoint?: string;
   pwCdpEndpoint?: string;
   pwCdpEndpoints?: string[];
+  cdpConnectMaxAttempts?: number;
+  cdpConnectBackoffBaseMs?: number;
   bypassCSP?: boolean;
 
   // WebAgent behavior overrides
@@ -329,6 +331,10 @@ export async function runTask(options: TaskRunnerOptions): Promise<TaskExecution
       body.pwCdpEndpoints ??
       serverConfig.pw_cdp_endpoints ??
       (serverConfig.pw_cdp_endpoint ? [serverConfig.pw_cdp_endpoint] : undefined),
+    cdpConnectRetry: {
+      maxAttempts: body.cdpConnectMaxAttempts ?? serverConfig.cdp_connect_max_attempts,
+      backoffBaseMs: body.cdpConnectBackoffBaseMs ?? serverConfig.cdp_connect_backoff_base_ms,
+    },
     bypassCSP: body.bypassCSP ?? serverConfig.bypass_csp,
     proxyServer: body.proxy ?? serverConfig.proxy,
     proxyUsername: body.proxyUsername ?? serverConfig.proxy_username,


### PR DESCRIPTION
## Summary

Fixes [TAB-997](https://linear.app/mozilla-np/issue/TAB-997). The CDP connection path had **no retry**, and mid-task **reconnect was broken for a single endpoint** — so a transient connect blip or a disconnect mid-task failed the task outright. The eval and local `.env` both use a single CDP endpoint, so both gaps bit.

## What changed (`packages/core/src/browser/playwrightBrowser.ts`)

- **Per-endpoint retry with exponential backoff + jitter** on CDP connect (a retry is "failover-to-self"). **All** connect failures are retried (bounded) — there is no error classifier.
- **Single-endpoint reconnect fixed.** The endpoint index now wraps modulo from `nextStartIndex`, so every `start()` gets a fresh attempt budget. Previously `nextStartIndex` only advanced and never reset, so a reconnect on one endpoint ran `for (i=1; i<1)` → instant "All 1 CDP endpoint(s) failed." Multi-endpoint failover semantics preserved.
- Per-attempt connect **timeout left at 5s** — the fix is retry, not a longer timeout (probe showed healthy connects are sub-second; failures are transient).

## Configurable on both CLI and server

| Setting | Config key | Env | Default |
|---|---|---|---|
| Attempts per endpoint | `cdp_connect_max_attempts` | `PILO_CDP_CONNECT_MAX_ATTEMPTS` | 3 |
| Backoff base | `cdp_connect_backoff_base_ms` | `PILO_CDP_CONNECT_BACKOFF_BASE_MS` | 1000 |
| Backoff cap | `cdp_connect_backoff_max_ms` | `PILO_CDP_CONNECT_BACKOFF_MAX_MS` | 10000 |

All three are exposed as CLI flags (`--cdp-connect-*`) and accepted in the server `/pilo/run` request body. Worst-case attempts are bounded: `(initial_navigation_retries + 1) × max_attempts × endpoints`.

## Tests
retry-then-succeed, give-up-after-max, retry-any-failure-then-throw, cycle-on-any-failure, single-endpoint reconnect, multi-endpoint failover, and the configurable cap clamps the delay.

## Note for reviewers
The connect path now retries **all** connect failures (bounded, with backoff) rather than gating on a message-substring classifier. This is deliberate: Playwright flattens connect failures to message-only `Error`s (no `.code`/`.statusCode`), so any allowlist is both fragile and prone to silently dropping provider errors (e.g. a Bright Data `no_peers`). Because connecting is idempotent, retry-all-bounded is the sound policy. The old `isCdpConnectionError` classifier has been removed (it had zero remaining callers).

## Verification
pilo-core / pilo-cli / pilo-server typecheck clean; tests pass (core 868, cli 226, server 99); prettier + gitleaks clean.
