### PR TITLE
feat: report a performed action with no confirmation as done(), not abort

### DIFF
--- a/packages/core/src/prompts.ts
+++ b/packages/core/src/prompts.ts
@@ -379,11 +379,13 @@ Analyze the current page state and determine your next action based on previous 
    - Did all specified filters/criteria apply (price range, date, location, format)?
    - Does your answer match the requested format?
 3. Verify actions actually completed by checking the most recent page state:
-   - If you submitted a form, did the next page confirm success?
+   - If you submitted a form, look for a success message or a validation error:
+     - A validation error means it did NOT submit — fix and retry.
+     - Neither a confirmation nor an error is a normal outcome on many sites: treat the submission as completed and report it with done(), stating explicitly that no confirmation was shown.
    - If you extracted data, did you actually find it in the page snapshot or extract() output?
 4. Data grounding: every value in your answer must appear in a page snapshot, a tool result, or the task input. Do NOT use general knowledge to fill gaps. If a value was not found during this session, say so explicitly rather than inventing it.
 5. Blockers vs. obstacles: if you hit an unrecoverable block (paywall, login wall, access denied, payment declined) that prevented completing a core requirement, call abort() with the reason. Temporary obstacles you handled (dismissed popups, retried errors) don't change the outcome.
-6. If anything is unverified, incomplete, or uncertain — call abort() with the reason rather than done() with an overclaiming answer.
+6. If the information or data the task asks you to return is unverified, or a core step was blocked outright, call abort() with the reason rather than done() with an overclaiming answer. But an action you actually performed — e.g. a form submit that returned no error and showed no validation error — is NOT "unverified" merely because the site displayed no explicit success message; report that with done() and the caveat, don't abort.
 
 **When using done():**
 Provide your final answer:

--- a/packages/core/test/prompts.test.ts
+++ b/packages/core/test/prompts.test.ts
@@ -287,6 +287,15 @@ describe("prompts", () => {
       expect(prompt).toContain("GUARDRAIL COMPLIANCE");
     });
 
+    it("guides done() for an action that completed without error but showed no confirmation", () => {
+      const prompt = buildActionLoopSystemPrompt(false, false);
+
+      // A submitted form with neither confirmation nor error should be reported
+      // with done() (caveated), not aborted as "unverified".
+      expect(prompt).toContain("no confirmation was shown");
+      expect(prompt).toContain('is NOT "unverified"');
+    });
+
     it("should support both guardrails and webSearch", () => {
       const prompt = buildActionLoopSystemPrompt(true, true);
 


### PR DESCRIPTION
## Summary
Refines the `done()`/`abort()` guidance in the action-loop prompt. Today, a form submit that returns **no error** but shows **no explicit confirmation** is treated as "unverified," pushing the agent to `abort()`. That's miscalibrated for action tasks: the honest outcome is "submitted; no confirmation shown, but no error either." This change lets the agent report such cases with `done()` (caveated), while **keeping** `abort()` for unverified *data* and blocked core steps.

Two scoped edits to the "Before calling done()" block in `prompts.ts`:
- Form-submit check now distinguishes a validation error (did NOT submit → fix/retry) from "neither confirmation nor error" (normal on many sites → `done()` stating no confirmation was shown).
- The abort-on-uncertain rule is narrowed to *information/data* you must return, or a blocked core step — explicitly **not** an action you performed that produced no error.

## Why separate from #534
This is a global agent-behavior change (affects every task), distinct from the upload-files feature. Reviewers should weigh it on its own.

## Validation
- [x] **Target (action tasks):** browser-use ember-form upload task, firewall on — **5 of 6** runs now pass via honest, caveated `done()` (previously aborted reliably). Reasoning shows the agent stating it submitted with no confirmation but no error.
- [x] **Guardrail intact (data honesty):** "report a datum that isn't on the page" probe — **3 of 3** correctly `abort()`, zero fabrication.
- [x] Unit test asserts the new guidance is present; `pnpm --filter pilo-core` tests green.

## Note for reviewers
Rigorous research-task regression measurement belongs in a main-vs-branch comparison eval (the local probes here are a sound sanity check, not a full sweep). Worth running before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)