### PR TITLE
ci: sync pilo-cli:latest to main via pilo-evals-judge dispatch

### DIFF
--- a/.github/workflows/trigger_main_build.yml
+++ b/.github/workflows/trigger_main_build.yml
@@ -1,0 +1,59 @@
+name: Trigger Pilo Main Build
+
+# On every push to main (and manual dispatch), tell pilo-evals-judge to build
+# pilo-cli:<sha> and move pilo-cli:latest to it, so scheduled evals always run
+# the current main build. Thin trigger — all build logic lives in
+# pilo-evals-judge's handle_pilo_main_build.yml. Mirrors trigger_eval.yml.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-main-build:
+    name: Dispatch pilo_main_build to pilo-evals-judge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve commit timestamp
+        id: meta
+        run: |
+          # head_commit is present on push events but absent on workflow_dispatch;
+          # fall back to the current UTC time so the payload is always populated.
+          TS="${{ github.event.head_commit.timestamp }}"
+          if [ -z "$TS" ]; then TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"; fi
+          echo "commit_timestamp=$TS" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger repository_dispatch
+        run: |
+          cat > payload.json <<EOF
+          {
+            "event_type": "pilo_main_build",
+            "client_payload": {
+              "git_sha": "${{ github.sha }}",
+              "git_ref": "${{ github.ref }}",
+              "repo": "${{ github.repository }}",
+              "commit_timestamp": "${{ steps.meta.outputs.commit_timestamp }}",
+              "run_id": "${{ github.run_id }}"
+            }
+          }
+          EOF
+
+          HTTP_STATUS=$(curl -s -o response.json -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.PILO_EVALS_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/Mozilla-Ocho/pilo-evals-judge/dispatches \
+            --data @payload.json)
+
+          echo "GitHub API HTTP status: $HTTP_STATUS"
+          if [[ "$HTTP_STATUS" -lt 200 || "$HTTP_STATUS" -ge 300 ]]; then
+            echo "❌ Failed to send repository_dispatch event (HTTP $HTTP_STATUS)"
+            [ -s response.json ] && cat response.json
+            exit 1
+          fi
+          echo "✓ Dispatched pilo_main_build for ${{ github.sha }}"


### PR DESCRIPTION
## Why

The eval pipeline runs `pilo-cli:latest`, but nothing currently moves that tag on `main` — `trigger_eval.yml` only dispatches on `evals/**` branches, and the eval repo's build path tags by SHA, never `:latest`. As a result `pilo-cli:latest` has been frozen at a Feb-2026 build, so the scheduled "pilo-cli" eval line has been measuring stale code rather than current `main`.

## What this does

Adds `.github/workflows/trigger_main_build.yml`: a thin trigger that, on every push to `main` (plus `workflow_dispatch`), fires a `pilo_main_build` `repository_dispatch` to `Mozilla-Ocho/pilo-evals-judge`. All build logic lives there — this just signals the SHA. Mirrors the existing `trigger_eval.yml` (same `PILO_EVALS_DISPATCH_TOKEN` secret, endpoint, and API version).

## Companion PR

Consumer side: **Mozilla-Ocho/pilo-evals-judge#87** (`handle_pilo_main_build.yml` builds `pilo-cli:<sha>` and moves `:latest`). That PR should merge first; once this one merges, `:latest` begins tracking `main` on every push.

## Test plan

- [x] YAML parse + convention cross-check against `trigger_eval.yml` (secret, endpoint, `X-GitHub-Api-Version`)
- [ ] After both PRs merge: trigger via `workflow_dispatch`, confirm the eval repo's **Handle Pilo Main Build** run fires and `pilo-cli:latest` advances to current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)