### PR TITLE
Create a dependabot group for @radix-ui/* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,6 @@ updates:
           - vitest
           - wxt
           - "@wxt-dev/*"
+      radixui:
+        patterns:
+          - "@radix-ui/*"


### PR DESCRIPTION
These packages tend to upgrade all at once, so might as well bundle them together.