### PR TITLE
test(core): fix flaky image-sanitization logger assertion

### DIFF
--- a/packages/core/test/loggers.test.ts
+++ b/packages/core/test/loggers.test.ts
@@ -975,8 +975,10 @@ describe("JSONConsoleLogger", () => {
       expect(imageBlock.type).toBe("image");
       expect(imageBlock.data).toBe("<omitted>");
       expect(imageBlock.size).toBe(fakeJpeg.byteLength);
-      // Raw byte array must not appear in the output
-      expect(output).not.toContain("255"); // 0xff byte value
+      // Raw byte array must not appear in the output. Match the serialized
+      // byte sequence rather than a bare "255" — the latter collides with
+      // the millisecond timestamp in the output and makes this test flaky.
+      expect(output).not.toContain("255,216,255"); // raw fakeJpeg bytes
     });
 
     it("should preserve raw image data when sanitizeGenerationImages is false", () => {


### PR DESCRIPTION
## Problem

The `core` CI job intermittently fails on:

`packages/core/test/loggers.test.ts > JSONConsoleLogger > JSON output > should sanitize image Buffer data in AI_GENERATION messages`

```
AssertionError: expected '{"event":"ai:generation","data":{"tim…' not to contain '255'
```

This has surfaced on unrelated PRs (e.g. dependabot bumps) where it has nothing to do with the change — most recently #568.

## Root cause

The test verifies that a fake JPEG buffer (whose first byte is `0xff` = 255) gets sanitized out of the logged output. To do so it asserted that the **entire serialized JSON output** did not contain the bare string `"255"`:

```js
timestamp: Date.now(),          // 13-digit ms value, serialized into the output
...
expect(output).not.toContain("255"); // 0xff byte value
```

But the output also includes the `Date.now()` timestamp. Whenever that millisecond value happens to contain the substring `255`, the assertion fails — regardless of whether sanitization worked. That's a ~0.5–1% chance per run, so it flakes randomly across CI.

Verified locally: forcing `Date.now()` to return `1782552000000` (contains `255`) reproduces the failure; the current real timestamp passes.

## Fix

Assert against the serialized **raw byte sequence** (`255,216,255`) instead of a bare `255`. This matches the actual leak format (an unsanitized buffer serializes as a comma-separated byte array) and cannot collide with the timestamp, since a numeric timestamp has no commas. The check still fails loudly if sanitization regresses.

## Testing

`pnpm --filter pilo-core run test` — all 900 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)