### PR TITLE
fix(deps): force undici >=7.28.0 via pnpm override (TAB-1090)

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   "pnpm": {
     "overrides": {
       "zod": "4.3.6",
-      "shell-quote": ">=1.8.4"
+      "shell-quote": ">=1.8.4",
+      "undici": ">=7.28.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   zod: 4.3.6
   shell-quote: '>=1.8.4'
+  undici: '>=7.28.0'
 
 importers:
 
@@ -4453,10 +4454,6 @@ packages:
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -7613,7 +7610,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.25.0
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -8689,8 +8686,6 @@ snapshots:
   undici-types@7.27.0: {}
 
   undici-types@8.3.0: {}
-
-  undici@7.25.0: {}
 
   undici@7.28.0: {}
 


### PR DESCRIPTION
## Summary
- Closes Dependabot alert #155: high-severity DoS in `undici`'s WebSocket client (CVE-2026-12151 / GHSA-vxpw-j846-p89q, CVSS 7.5). `maxPayloadSize` caps cumulative fragment bytes but not fragment count — a malicious WS server can stream unbounded tiny continuation frames and exhaust client memory.
- `jsdom@29.1.1` (test-only devDependency of `packages/core`) resolved `undici@7.25.0`, even though jsdom's own declared range (`^7.25.0`) already permits the patched `7.28.0`. A second resolution via `cheerio` was already on `7.28.0` — pnpm just wasn't converging the two.
- Same fix pattern as TAB-1089/#592: `pnpm.overrides` forcing `undici` to `>=7.28.0` repo-wide, no package.json range changes needed.

## Test plan
- [x] `pnpm install` — lockfile now resolves a single `undici@7.28.0`; `7.25.0` fully removed.
- [x] `pnpm -r run typecheck` — all packages pass.
- [x] `pnpm -r run test` — 1,505 tests pass across core/cli/server/extension (core's suite runs in the `jsdom` environment, so this exercises the bumped undici directly).
- [x] `npx prettier --check package.json pnpm-lock.yaml` — clean.

Linear: TAB-1090