### PR TITLE
ci: guard the release build on PRs

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -175,6 +175,14 @@ jobs:
       - name: Build published package
         run: pnpm run build
 
+      # A successful build does not mean a working binary. The bundled CLI can
+      # assemble cleanly and still die on startup — e.g. a transitive CommonJS
+      # dependency calling bare `require("stream")`, which esbuild inlines behind
+      # a shim that throws "Dynamic require of ... is not supported". Actually
+      # running the entry point is the only thing that catches that class of bug.
+      - name: Verify the built CLI starts
+        run: node dist/cli/src/cli.js --version
+
       - name: Verify the tarball is complete
         run: |
           set -euo pipefail

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -19,6 +19,7 @@ jobs:
       server: ${{ steps.filter.outputs.server }}
       extension: ${{ steps.filter.outputs.extension }}
       workflows: ${{ steps.filter.outputs.workflows }}
+      build: ${{ steps.filter.outputs.build }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -46,6 +47,15 @@ jobs:
               - 'package.json'
             workflows:
               - '.github/workflows/**'
+            # Everything the root tsup assembly consumes. Broad on purpose: this
+            # gates the only job that exercises the command `release.yml` runs.
+            build:
+              - 'tsup.config.ts'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              - 'packages/core/**'
+              - 'packages/cli/**'
+              - 'packages/extension/**'
 
   # Reports which secret-backed credentials are available to this run.
   # The `secrets` context cannot be read in a job-level `if:`, so downstream
@@ -117,6 +127,81 @@ jobs:
 
       - name: Check formatting
         run: pnpm format:check
+
+  # Exercises the exact command `release.yml` runs between "Run tests" and
+  # "npm pack". No other job runs the root `pnpm run build`, so without this a
+  # broken release assembly surfaces only at tag time — which is how the
+  # TypeScript 6 `baseUrl` deprecation (TS5101) came to block releases while
+  # every PR stayed green.
+  build:
+    name: Release build
+    runs-on: ubuntu-latest
+    needs: [detect-changes, setup]
+    if: needs.detect-changes.outputs.build == 'true' || needs.detect-changes.outputs.workflows == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          # Deliberately "24" rather than the "22" the test jobs use: this job
+          # guards the release path, so it should run the version release.yml runs.
+          node-version: "24"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # No cached core build is restored here on purpose: `prebuild` rebuilds
+      # core and the extension itself, and this job should assemble from scratch
+      # exactly the way a release does.
+      - name: Build published package
+        run: pnpm run build
+
+      - name: Verify the tarball is complete
+        run: |
+          set -euo pipefail
+          npm pack --ignore-scripts --dry-run --json > "$RUNNER_TEMP/pack.json"
+          files=$(jq -r '.[0].files[].path' "$RUNNER_TEMP/pack.json")
+
+          fail=0
+          for required in dist/cli/src/cli.js dist/core/src/index.js dist/core/src/index.d.ts; do
+            if ! grep -qxF "$required" <<<"$files"; then
+              echo "::error::published tarball is missing $required"
+              fail=1
+            fi
+          done
+
+          # Guards the failure mode that shipped 0.19.4 as a 3-file tarball with
+          # no dist/ at all: a pack that succeeds while the build output is
+          # absent or only partly assembled.
+          for prefix in dist/core/src/ dist/extension/chrome/ dist/extension/firefox/; do
+            count=$(grep -c "^$prefix" <<<"$files" || true)
+            if [ "$count" -lt 10 ]; then
+              echo "::error::published tarball has only $count files under $prefix"
+              fail=1
+            fi
+          done
+
+          echo "Tarball contains $(grep -c . <<<"$files") files."
+          exit "$fail"
 
   core:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

Nothing in CI ran the root `pnpm run build` — the command `release.yml` runs between "Run tests" and "npm pack". A broken release assembly therefore surfaced only at tag time. That is how the TypeScript 6 `baseUrl` deprecation (TS5101) came to block releases while every PR stayed green, and how 0.19.4 shipped as a 3-file tarball with no `dist/` at all.

## Change

Adds a `Release build` job to `build-test.yml` that:

1. Runs `pnpm run build` on Node 24 — deliberately matching `release.yml` rather than the 22 the test jobs use — from scratch, with no cached core build restored, exactly as a release assembles.
2. Runs the built binary (`node dist/cli/src/cli.js --version`).
3. Verifies the packed tarball actually contains the expected output: required entry points present, and a floor on file counts under `dist/core/src/`, `dist/extension/chrome/`, and `dist/extension/firefox/`.

The job is gated on `detect-changes` so it only runs when build inputs or workflows change.

## Note on scope

This PR originally also carried the `tsup` `dts.compilerOptions.ignoreDeprecations` fix for TS5101. #615 landed the identical change, so that commit was dropped in the rebase — this is now purely the CI guard.

## Why the startup check is a separate step

A successful build does not imply a working binary, and the distinction is not hypothetical. Reverting the `banner` workaround from #615 locally:

| | `pnpm run build` | `node dist/cli/src/cli.js --version` |
| --- | --- | --- |
| without `banner` | exit 0 | exit 1 — `Dynamic require of "stream" is not supported` (via `mute-stream`) |
| with `banner` | exit 0 | exit 0 |

The build and the tarball check both pass in the broken case. Without step 2, this job would have shipped #615's bug.

## Verification

- The workflow file in the first commit is byte-identical to the version whose `Release build` job already passed on this PR before the rebase.
- Tarball check run locally against a real build: 262 files total, 201 under `dist/core/src/`, 27 each under the two extension dirs, all required paths present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)