### PR TITLE
chore: stop Dependabot proposing TypeScript major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,20 @@ updates:
       default-days: 14
     open-pull-requests-limit: 10
     versioning-strategy: increase
+    ignore:
+      # TypeScript 7 is the Go port of the compiler and ships no public
+      # programmatic API (Microsoft has said a new one arrives in 7.1). Every
+      # tool that drives TypeScript through that API breaks on it — for us,
+      # tsup's declaration emit via rollup-plugin-dts, which takes down all of
+      # `pnpm run build` and therefore releases. rollup-plugin-dts still caps
+      # its peer range at `^6.0` and tsup is already at its latest.
+      #
+      # A major bump here is not actionable until that upstream chain moves, so
+      # don't keep proposing one. Minor and patch updates still come through.
+      # Remove this once TS 7.1 lands and rollup-plugin-dts supports it.
+      # See #628 for the upgrade plan; #617 is the bump that broke the build.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       react:
         patterns:


### PR DESCRIPTION
## Why

TypeScript 7 is the Go port of the compiler and ships **no public programmatic API** — Microsoft has said a replacement arrives in 7.1. Any tool that drives TypeScript through that API breaks on it. For this repo that's tsup's declaration emit via `rollup-plugin-dts`, which takes down all of `pnpm run build`, and therefore releases.

There is no upstream path today:

- `rollup-plugin-dts@6.4.1` (latest) caps its peer range at `typescript: ^4.5 || ^5.0 || ^6.0`
- `tsup` is already at its latest 8.5.1

#617 proposed the bump anyway and merged green, breaking the release build until #627 pinned back to `^6.0.3`.

Since a major bump isn't actionable until that upstream chain moves, stop proposing one.

## Change

```yaml
    ignore:
      - dependency-name: "typescript"
        update-types: ["version-update:semver-major"]
```

## What this does and doesn't affect

`typescript` stays in the `devdependencies` group. [Dependabot applies `ignore` rules *before* grouping](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference), so:

- ✅ TypeScript **minor and patch** updates still arrive, grouped as before
- ✅ Every other dependency is untouched
- 🚫 Only TypeScript **major** bumps are suppressed

## Relationship to #614

#614 added the `Release build` job, so a bump like this now fails loudly instead of merging green. That's the safety net; this removes the recurring churn on top of it. The two are complementary — this PR is not a substitute for the guard.

## Reverting

Remove the `ignore` block once TS 7.1 lands and `rollup-plugin-dts` supports it. The comment in the file says so, and #628 tracks the full upgrade plan.

## Verification

YAML parses; `ignore` sits at the correct level as a sibling of `groups`; all four groups and their patterns are unchanged; `typescript` is still listed under `devdependencies`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)