### PR TITLE
feat(webAgent): diagnose why a generation returned no tool call

### DIFF
--- a/packages/core/schemas/webagent-event.json
+++ b/packages/core/schemas/webagent-event.json
@@ -4897,6 +4897,38 @@
       ],
       "type": "object"
     },
+    "NoToolCallDebugEventData": {
+      "additionalProperties": false,
+      "description": "Event data for a generation that returned no tool call at all.\n\nThe agent recovers by feeding the error back to the model, but the turn is spent — so a high rate of these silently drains the iteration budget. The two causes need opposite fixes and are only distinguishable by `finishReason`: \"stop\" means the model answered in prose instead of calling a tool, while \"length\" means it was truncated before the call completed.",
+      "properties": {
+        "finishReason": {
+          "description": "Why the provider stopped generating (e.g. \"stop\", \"length\", \"content-filter\").",
+          "type": "string"
+        },
+        "iterationId": {
+          "type": "string"
+        },
+        "textLength": {
+          "description": "Length of the prose the model returned instead of a tool call.",
+          "type": "number"
+        },
+        "textPreview": {
+          "description": "Leading characters of that prose, for diagnosis. Truncated.",
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "finishReason",
+        "iterationId",
+        "textLength",
+        "textPreview",
+        "timestamp"
+      ],
+      "type": "object"
+    },
     "PageNavigationEventData": {
       "additionalProperties": false,
       "description": "Event data when navigating to a page",
@@ -5988,6 +6020,23 @@
             },
             "type": {
               "const": "system:debug_tool_drop",
+              "type": "string"
+            }
+          },
+          "required": [
+            "type",
+            "data"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "data": {
+              "$ref": "#/definitions/NoToolCallDebugEventData"
+            },
+            "type": {
+              "const": "system:debug_no_tool_call",
               "type": "string"
             }
           },

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -45,6 +45,7 @@ export enum WebAgentEventType {
   SYSTEM_DEBUG_COMPRESSION = "system:debug_compression",
   SYSTEM_DEBUG_MESSAGE = "system:debug_message",
   SYSTEM_DEBUG_TOOL_DROP = "system:debug_tool_drop",
+  SYSTEM_DEBUG_NO_TOOL_CALL = "system:debug_no_tool_call",
 
   // CDP endpoint failover
   CDP_ENDPOINT_CONNECTED = "cdp:endpoint_connected",
@@ -321,6 +322,24 @@ export interface ToolDropDebugEventData extends WebAgentEventData {
 }
 
 /**
+ * Event data for a generation that returned no tool call at all.
+ *
+ * The agent recovers by feeding the error back to the model, but the turn is
+ * spent — so a high rate of these silently drains the iteration budget. The
+ * two causes need opposite fixes and are only distinguishable by
+ * `finishReason`: "stop" means the model answered in prose instead of calling
+ * a tool, while "length" means it was truncated before the call completed.
+ */
+export interface NoToolCallDebugEventData extends WebAgentEventData {
+  /** Why the provider stopped generating (e.g. "stop", "length", "content-filter"). */
+  finishReason: string;
+  /** Length of the prose the model returned instead of a tool call. */
+  textLength: number;
+  /** Leading characters of that prose, for diagnosis. Truncated. */
+  textPreview: string;
+}
+
+/**
  * Event data for waiting notifications
  */
 export interface WaitingEventData extends WebAgentEventData {
@@ -442,6 +461,7 @@ export type WebAgentEvent =
   | { type: WebAgentEventType.SYSTEM_DEBUG_COMPRESSION; data: CompressionDebugEventData }
   | { type: WebAgentEventType.SYSTEM_DEBUG_MESSAGE; data: MessagesDebugEventData }
   | { type: WebAgentEventType.SYSTEM_DEBUG_TOOL_DROP; data: ToolDropDebugEventData }
+  | { type: WebAgentEventType.SYSTEM_DEBUG_NO_TOOL_CALL; data: NoToolCallDebugEventData }
   | { type: WebAgentEventType.CDP_ENDPOINT_CONNECTED; data: CdpEndpointConnectedEventData }
   | { type: WebAgentEventType.CDP_ENDPOINT_CYCLE; data: CdpEndpointCycleEventData }
   | { type: WebAgentEventType.BROWSER_RECONNECTED; data: BrowserReconnectedEventData }

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -1206,7 +1206,7 @@ export class WebAgent {
           }
 
           // Await only the properties we actually need
-          const [toolResults, response, finishReason, usage, warnings, providerMetadata, text] =
+          const [toolResults, response, finishReason, usage, warnings, providerMetadata] =
             await Promise.all([
               streamResult.toolResults,
               streamResult.response,
@@ -1214,8 +1214,11 @@ export class WebAgent {
               streamResult.usage,
               streamResult.warnings,
               streamResult.providerMetadata,
-              streamResult.text,
             ]);
+
+          // Only materialize the model's prose on the failure path. When a tool
+          // was called the text is unused, and it can be large.
+          const text = toolResults.length === 0 ? await streamResult.text : "";
 
           const result: ProcessedAIResponse = {
             toolResults,

--- a/packages/core/src/webAgent.ts
+++ b/packages/core/src/webAgent.ts
@@ -249,12 +249,22 @@ type StepOutcome =
   | { flow: "return"; value: { success: boolean; finalAnswer: string; error?: TaskError } }
   | { flow: "next"; needsPageSnapshot: boolean };
 
+/** How much of a no-tool-call prose response to keep for diagnosis. */
+const NO_TOOL_CALL_TEXT_PREVIEW_CHARS = 500;
+
 type StreamTextResultGeneric = StreamTextResult<any, any, never>;
 // HACK: cobble together a type from StreamTextResult with promises resolved
 type ProcessedAIResponse = AwaitedProperties<
   Pick<
     StreamTextResultGeneric,
-    "toolResults" | "response" | "finishReason" | "usage" | "warnings" | "providerMetadata"
+    | "toolResults"
+    | "response"
+    | "finishReason"
+    | "usage"
+    | "warnings"
+    | "providerMetadata"
+    // Only read when no tool was called, to report what the model said instead.
+    | "text"
   >
 >;
 
@@ -1196,7 +1206,7 @@ export class WebAgent {
           }
 
           // Await only the properties we actually need
-          const [toolResults, response, finishReason, usage, warnings, providerMetadata] =
+          const [toolResults, response, finishReason, usage, warnings, providerMetadata, text] =
             await Promise.all([
               streamResult.toolResults,
               streamResult.response,
@@ -1204,6 +1214,7 @@ export class WebAgent {
               streamResult.usage,
               streamResult.warnings,
               streamResult.providerMetadata,
+              streamResult.text,
             ]);
 
           const result: ProcessedAIResponse = {
@@ -1213,6 +1224,7 @@ export class WebAgent {
             usage,
             warnings,
             providerMetadata,
+            text,
           };
 
           aiSpan.setAttribute("pilo.ai.finish_reason", String(finishReason));
@@ -1261,7 +1273,22 @@ export class WebAgent {
 
     // Process tool results
     if (!aiResponse?.toolResults?.length) {
-      console.error("[WebAgent] No tools called in action generation");
+      // The model answered without calling a tool. Recoverable — the error below
+      // is fed back and the next turn usually succeeds — but the turn is spent,
+      // so record why it happened. "stop" means prose instead of a tool call;
+      // "length" means the response was truncated mid-call.
+      const finishReason = String(aiResponse?.finishReason ?? "unknown");
+      const text = aiResponse?.text ?? "";
+      console.error(
+        `[WebAgent] No tools called in action generation ` +
+          `(finishReason=${finishReason}, textLength=${text.length})`,
+      );
+      this.emit(WebAgentEventType.SYSTEM_DEBUG_NO_TOOL_CALL, {
+        iterationId: this.currentIterationId,
+        finishReason,
+        textLength: text.length,
+        textPreview: text.slice(0, NO_TOOL_CALL_TEXT_PREVIEW_CHARS),
+      });
       throw new ToolExecutionError(
         "You must use exactly one tool. Please use one of the available tools.",
         {

--- a/packages/core/test/events.test.ts
+++ b/packages/core/test/events.test.ts
@@ -137,6 +137,7 @@ describe("WebAgentEventEmitter", () => {
         "system:debug_compression",
         "system:debug_message",
         "system:debug_tool_drop",
+        "system:debug_no_tool_call",
         "cdp:endpoint_connected",
         "cdp:endpoint_cycle",
         "browser:reconnected",

--- a/packages/core/test/webAgent.test.ts
+++ b/packages/core/test/webAgent.test.ts
@@ -2079,6 +2079,73 @@ describe("WebAgent", () => {
       expect(
         mockLogger.events.find((e) => e.type === WebAgentEventType.AI_GENERATION_ERROR),
       ).toBeUndefined();
+
+      // A diagnostic event must record WHY no tool was called. Without it the
+      // only trace is the corrective message above, which says nothing about
+      // whether the model wrote prose or was truncated mid-call.
+      const noToolCall = mockLogger.events.find(
+        (e) => e.type === WebAgentEventType.SYSTEM_DEBUG_NO_TOOL_CALL,
+      );
+      expect(noToolCall).toBeDefined();
+      expect(noToolCall?.data.finishReason).toBe("stop");
+      expect(noToolCall?.data.textLength).toBe("No tools used".length);
+      expect(noToolCall?.data.textPreview).toBe("No tools used");
+    });
+
+    it("should report finishReason=length when a tool call was truncated", async () => {
+      // Mock planning
+      mockGenerateTextWithRetry.mockResolvedValueOnce({
+        text: "Planning",
+        toolResults: [
+          {
+            type: "tool-result",
+            toolCallId: "plan_1",
+            toolName: "create_plan",
+            input: {},
+            output: {
+              successCriteria: "Test task",
+              plan: "1. Complete task",
+            },
+          },
+        ],
+      } as any);
+
+      // Truncated generation: no tool call, and finishReason says why.
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          text: "I will now click the",
+          toolResults: [],
+          finishReason: "length",
+          response: { messages: [] },
+        }) as any,
+      );
+
+      // Recovery turn: a real tool call so the run can terminate.
+      mockStreamText.mockReturnValueOnce(
+        createMockStreamResponse({
+          toolResults: [
+            {
+              type: "tool-result",
+              toolCallId: "done_1",
+              toolName: "done",
+              input: { result: "Complete" },
+              output: { action: "done", result: "Complete", isTerminal: true },
+            },
+          ],
+          response: { messages: [] },
+        }) as any,
+      );
+
+      mockGenerateTextWithRetry.mockResolvedValueOnce(mockValidationResponse("complete"));
+
+      await webAgent.execute("Test", { startingUrl: "https://example.com" });
+
+      const noToolCall = mockLogger.events.find(
+        (e) => e.type === WebAgentEventType.SYSTEM_DEBUG_NO_TOOL_CALL,
+      );
+      expect(noToolCall).toBeDefined();
+      expect(noToolCall?.data.finishReason).toBe("length");
+      expect(noToolCall?.data.textPreview).toBe("I will now click the");
     });
 
     it("should handle tool result without output property", async () => {


### PR DESCRIPTION
## Problem

When the model returns zero tool calls, `webAgent.ts` throws a `ToolExecutionError` that gets fed back to the model. The agent recovers — the next turn usually succeeds — but **the turn is spent**.

Auditing 82 archived eval tasks from the scheduled WebVoyagerX runs (`pilo-cli` + `tabstack-stage`, every 5th run since 2026-06-13):

- **46 of 82 tasks** hit this at least once — 116 occurrences total
- **36% of all iterations** on affected tasks were consumed by these no-op turns (mean 2.5 malformed against a mean stepCount of 7.0)
- It is *not* a death spiral: max consecutive streak is 2, and malformed calls interleave with successful actions (`AAMAMAMA`). The agent recovers each time and then runs out of budget.
- On running out, it aborts citing **"browser connection lost"** — a phrase that appears in **zero** error events across all 82 tasks. It's confabulated, and it caused these failures to be misfiled as infrastructure problems for weeks.
- Distribution is lopsided: **46/52 `pilo-cli` tasks vs 0/30 `tabstack-stage`**.

The two underlying causes need opposite fixes and are only distinguishable by `finishReason` — `"stop"` means the model wrote prose instead of calling a tool, `"length"` means it was truncated mid-call. Neither was recorded: `finishReason` was awaited but unused on this path, and `streamResult.text` was never read at all.

## Change

Diagnostics only — no behaviour change to the recovery path.

- Add `"text"` to `ProcessedAIResponse` and the `Promise.all`
- Emit `SYSTEM_DEBUG_NO_TOOL_CALL` with `finishReason`, `textLength`, and a 500-char prose preview before throwing, mirroring how the existing `SYSTEM_DEBUG_TOOL_DROP` handles the >1-tool-call case
- Include `finishReason` + `textLength` in the existing `console.error`

## On the unchanged message

I deliberately left `"You must use exactly one tool. Please use one of the available tools."` alone, even though the trigger is *zero* tool calls, not more than one.

It reads oddly as a label, but it is fed back to the model as the instruction to retry — where telling a model that returned no call to use exactly one is accurate advice. It is also the exact string downstream eval tooling classifies on. Changing agent-facing text and the classifier contract in a diagnostics PR seemed like the wrong trade. The diagnosis belongs in the event.

## Why diagnostics before a retry

A retry on empty `toolResults` is the obvious fix, but it's premature: if this is truncation (`finishReason: "length"`), retrying the same oversized request likely reproduces it, and the real fix is budget. A day of scheduled runs with this event will say which case dominates.

## Testing

- Extended `should handle missing tool results` to assert the new event, `finishReason: "stop"`, `textLength`, and preview
- New test for the truncation case (`finishReason: "length"`) with a recovery turn
- Registered the new type in the exhaustive `events.test.ts` enum list
- Regenerated `schemas/webagent-event.json` (`check:schemas` gate)
- `pnpm run check` green: 950 core / 229 cli / 103 server / 273 extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)