### PR TITLE
feat(bidi): optional acceptInsecureCerts for BiDi sessions

### DIFF
--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -226,8 +226,7 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       }
       browser = new BiDiBrowser({
         bidiUrl,
-        acceptInsecureCerts:
-          options.bidiAcceptInsecureCerts ?? cfg.bidi_accept_insecure_certs ?? false,
+        acceptInsecureCerts: options.bidiAcceptInsecureCerts ?? cfg.bidi_accept_insecure_certs,
         actionTimeoutMs: options.actionTimeoutMs ?? cfg.action_timeout_ms,
       });
     } else if (browserOption === "foxcloud") {

--- a/packages/cli/src/commands/run.ts
+++ b/packages/cli/src/commands/run.ts
@@ -226,6 +226,8 @@ async function executeRunCommand(task: string, options: any): Promise<void> {
       }
       browser = new BiDiBrowser({
         bidiUrl,
+        acceptInsecureCerts:
+          options.bidiAcceptInsecureCerts ?? cfg.bidi_accept_insecure_certs ?? false,
         actionTimeoutMs: options.actionTimeoutMs ?? cfg.action_timeout_ms,
       });
     } else if (browserOption === "foxcloud") {

--- a/packages/core/src/browser/bidiBrowser.ts
+++ b/packages/core/src/browser/bidiBrowser.ts
@@ -21,6 +21,12 @@ export interface BiDiBrowserOptions {
   bidiUrl?: string;
   /** Timeout for browser actions in milliseconds (default: 30000) */
   actionTimeoutMs?: number;
+  /**
+   * Accept TLS certificates that fail verification (default: false). Required
+   * for sandboxes whose sites are served by a private CA the browser image
+   * does not trust. Disables certificate validation for the whole session.
+   */
+  acceptInsecureCerts?: boolean;
 }
 
 /**
@@ -56,10 +62,12 @@ export class BiDiBrowser implements AriaBrowser {
   private readonly actionTimeoutMs: number;
   private bidiUrl: string | undefined;
   protected turndown: TurndownService;
+  private readonly acceptInsecureCerts: boolean;
 
   constructor(options: BiDiBrowserOptions = {}) {
     this.bidiUrl = options.bidiUrl;
     this.actionTimeoutMs = options.actionTimeoutMs ?? 30_000;
+    this.acceptInsecureCerts = options.acceptInsecureCerts ?? false;
     this.turndown = new TurndownService({
       headingStyle: "atx",
       codeBlockStyle: "fenced",
@@ -83,7 +91,9 @@ export class BiDiBrowser implements AriaBrowser {
     }
 
     await this.connection.connect();
-    await this.connection.sendCommand("session.new", { capabilities: {} });
+    await this.connection.sendCommand("session.new", {
+      capabilities: this.acceptInsecureCerts ? { alwaysMatch: { acceptInsecureCerts: true } } : {},
+    });
 
     const treeResult = (await this.connection.sendCommand("browsingContext.getTree", {})) as {
       contexts: Array<{ context: string; url: string; children: unknown[] }>;

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -89,6 +89,7 @@ export interface PiloConfig {
   // Browser Configuration
   browser?: Browser;
   bidi_url?: string;
+  bidi_accept_insecure_certs?: boolean;
   foxcloud_url?: string;
   foxcloud_proxy_url?: string;
   channel?: string;
@@ -169,6 +170,7 @@ export interface PiloConfigResolved {
   // Browser Configuration
   browser: Browser;
   bidi_url?: string;
+  bidi_accept_insecure_certs?: boolean;
   foxcloud_url?: string;
   foxcloud_proxy_url?: string;
   channel?: string;
@@ -374,6 +376,15 @@ export const FIELDS: Record<ConfigKey, FieldDef> = {
     placeholder: "url",
     env: ["PILO_BIDI_URL"],
     description: "WebSocket URL for BiDi browser (use with --browser bidi)",
+    category: "browser",
+  },
+  bidi_accept_insecure_certs: {
+    default: false,
+    type: "boolean",
+    cli: "--bidi-accept-insecure-certs",
+    env: ["PILO_BIDI_ACCEPT_INSECURE_CERTS"],
+    description:
+      "Accept TLS certificates that fail verification in BiDi mode (use with --browser bidi). Needed for sandboxes served by a private CA. WARNING: disables certificate validation for the whole session; do not use against the public web.",
     category: "browser",
   },
   foxcloud_url: {

--- a/packages/core/src/config/defaults.ts
+++ b/packages/core/src/config/defaults.ts
@@ -170,7 +170,7 @@ export interface PiloConfigResolved {
   // Browser Configuration
   browser: Browser;
   bidi_url?: string;
-  bidi_accept_insecure_certs?: boolean;
+  bidi_accept_insecure_certs: boolean;
   foxcloud_url?: string;
   foxcloud_proxy_url?: string;
   channel?: string;

--- a/packages/core/test/bidiBrowser.test.ts
+++ b/packages/core/test/bidiBrowser.test.ts
@@ -64,6 +64,28 @@ describe("BiDiBrowser", () => {
       expect((browser as any).currentContext).toBe("ctx-1");
     });
 
+    it("requests acceptInsecureCerts when configured", async () => {
+      const browser = new BiDiBrowser({
+        bidiUrl: "ws://localhost:9222",
+        acceptInsecureCerts: true,
+      });
+      const conn = getMockConnection(browser);
+      conn.sendCommand.mockImplementation((method: string) => {
+        if (method === "session.new") return Promise.resolve({});
+        if (method === "browsingContext.getTree")
+          return Promise.resolve({
+            contexts: [{ context: "ctx-1", url: "about:blank", children: [] }],
+          });
+        return Promise.resolve(undefined);
+      });
+
+      await browser.start();
+
+      expect(conn.sendCommand).toHaveBeenCalledWith("session.new", {
+        capabilities: { alwaysMatch: { acceptInsecureCerts: true } },
+      });
+    });
+
     it("accepts bidiUrl override in start()", async () => {
       const browser = new BiDiBrowser();
       const conn = getMockConnection(browser);

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -158,6 +158,7 @@ describe("ConfigManager", () => {
         "llm_provider_timeout_ms",
         "browser",
         "bidi_url",
+        "bidi_accept_insecure_certs",
         "foxcloud_url",
         "foxcloud_proxy_url",
         "channel",


### PR DESCRIPTION
## Description

Adds an opt-in `--bidi-accept-insecure-certs` for `--browser bidi`, which makes
`session.new` request the W3C `acceptInsecureCerts` capability. Off by default,
so nothing changes unless you ask for it.

Also available as `PILO_BIDI_ACCEPT_INSECURE_CERTS` and
`pilo config set bidi_accept_insecure_certs true`, following the existing
`CONFIG_SCHEMA` pattern.

## Motivation

`--browser bidi` currently sends `session.new` with `capabilities: {}`, so there
is no way for a caller to accept a certificate the browser does not trust. That
makes the BiDi path unusable against sandboxes served by a private CA.

Concretely: driving a local [the_zoo](https://github.com/bgrins/the_zoo) sandbox
through a remote Firefox, every `https://*.zoo` navigation fails with
`NS_ERROR_GENERATE_FAILURE(NS_ERROR_MODULE_SECURITY, SEC_ERROR_UNKNOWN_ISSUER)`.
Plain-HTTP sites in the sandbox work; anything HTTPS, including sites that
redirect to it, does not. The Playwright path has `ignoreHTTPSErrors`
equivalents available; BiDi had no equivalent at all.

## Implementation

- `BiDiBrowserOptions.acceptInsecureCerts?: boolean` (default `false`)
- when set, `start()` sends `session.new` with
  `{ capabilities: { alwaysMatch: { acceptInsecureCerts: true } } }`, otherwise
  the existing `{ capabilities: {} }`
- schema entry drives the CLI flag, env var, and config key
- `run.ts` passes the resolved value through to `BiDiBrowser`

The description warns that it disables certificate validation for the whole
session, in the same spirit as the existing `unsafe_mode` copy. It is deliberately
a caller decision rather than something inferred from the target URL.

## Testing

- new unit test asserting the capability is sent when configured; verified it
  fails against the previous implementation (`session.new` with `{}`)
- `pnpm run check` passes: 962 core / 229 cli / 103 server / 273 extension
- `pnpm run format:check` clean
- verified end to end against a real remote Firefox driving a private-CA
  sandbox: the same URL fails with `SEC_ERROR_UNKNOWN_ISSUER` without the flag
  and loads correctly with it

## Notes for reviewers

Two things I would flag rather than assume:

1. The flag name follows the `--bidi-*` prefix of `--bidi-url`. If you would
   rather this generalise across browser modes (a single `--accept-insecure-certs`
   honoured by both the Playwright and BiDi paths), I am happy to rework it.
2. `acceptInsecureCerts` is per-session and cannot be scoped to a hostname, so
   enabling it means no certificate error is reachable for that run. That is the
   right trade for a sandbox, and the wrong one against the public web — hence
   opt-in and the warning in the flag description.